### PR TITLE
Fix/infinite scroll

### DIFF
--- a/apps/www/examples/shield-ts/assets.tsx
+++ b/apps/www/examples/shield-ts/assets.tsx
@@ -114,7 +114,11 @@ export const Assets = () => {
   }, [isLoading, hasMoreData, page]);
 
   useEffect(() => {
-    setData(getData())
+    setIsLoading(true)
+    setTimeout(() => {
+      setData(getData())
+      setIsLoading(false)
+    }, 1000)
   }, [])
 
   return (

--- a/apps/www/examples/shield-ts/assets.tsx
+++ b/apps/www/examples/shield-ts/assets.tsx
@@ -114,11 +114,7 @@ export const Assets = () => {
   }, [isLoading, hasMoreData, page]);
 
   useEffect(() => {
-    setIsLoading(true)
-    setTimeout(() => {
-      setData(getData())
-      setIsLoading(false)
-    }, 1000)
+    loadMoreData()
   }, [])
 
   return (

--- a/packages/raystack/package.json
+++ b/packages/raystack/package.json
@@ -79,9 +79,5 @@
     "@tanstack/react-table": "^8.9.2",
     "@tanstack/table-core": "^8.9.2",
     "react-select": "^5.7.7"
-  },
-  "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0"
   }
 }

--- a/packages/raystack/package.json
+++ b/packages/raystack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raystack/apsara",
-  "version": "0.18.6",
+  "version": "0.19.0",
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "engines": {
@@ -79,5 +79,9 @@
     "@tanstack/react-table": "^8.9.2",
     "@tanstack/table-core": "^8.9.2",
     "react-select": "^5.7.7"
+  },
+  "peerDependencies": {
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   }
 }

--- a/packages/raystack/table/datatable.tsx
+++ b/packages/raystack/table/datatable.tsx
@@ -94,6 +94,37 @@ function DataTableRoot<TData, TValue>({
 
   const [tableState, setTableState] = useState<Partial<TableState>>({});
   const observerRef = useRef<IntersectionObserver | null>(null);
+  const lastRowRef = useRef<HTMLTableRowElement | null>(null);
+
+  useEffect(() => {
+    if (!onLoadMore) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && !isLoading) {
+        onLoadMore();
+      }
+    }, { threshold: 0.1 });
+
+    observerRef.current = observer;
+
+    return () => observer.disconnect();
+  }, [onLoadMore]);
+
+  useEffect(() => {
+    const observer = observerRef.current;
+    const lastRow = lastRowRef.current;
+
+    if (observer && lastRow) {
+      observer.disconnect();
+      observer.observe(lastRow);
+    }
+
+    return () => {
+      if (observer && lastRow) {
+        observer.unobserve(lastRow);
+      }
+    };
+  }, [isLoading]);
 
   const getLoader = (loaderRow: number, columns: ApsaraColumnDef<TData>[]) => (
     [...new Array(loaderRow)].map((_, rowIndex) => (
@@ -161,28 +192,6 @@ function DataTableRoot<TData, TValue>({
     initialState,
     state: tableState,
   });
-
-  const lastRowRef = useCallback(
-    (node: HTMLElement | null) => {
-      if (isLoading) return;
-      if (observerRef.current) observerRef.current.disconnect();
-
-      observerRef.current = new IntersectionObserver((entries) => {
-        if (entries[0].isIntersecting && onLoadMore) {
-          onLoadMore();
-        }
-      });
-
-      if (node) observerRef.current.observe(node);
-    },
-    [data, isLoading, onLoadMore]
-  );
-
-  useEffect(() => {
-    return () => {
-      if (observerRef.current) observerRef.current.disconnect();
-    };
-  }, []);
 
   const tableStyle = {
     ...(table.getRowModel().rows?.length

--- a/packages/raystack/table/datatable.tsx
+++ b/packages/raystack/table/datatable.tsx
@@ -289,11 +289,12 @@ function DataTableRoot<TData, TValue>({
                     </Table.Row>
                   ))
                 ) : (
+                  !isLoading ?
                   <Table.Row>
                     <Table.Cell colSpan={columns.length}>
                       {emptyState || "No results."}
                     </Table.Cell>
-                  </Table.Row>
+                  </Table.Row> : <></>
                 )}
                 {isLoading && getLoader(loaderRow, columns)}
               </Table.Body>

--- a/packages/raystack/table/datatable.tsx
+++ b/packages/raystack/table/datatable.tsx
@@ -175,7 +175,7 @@ function DataTableRoot<TData, TValue>({
 
       if (node) observerRef.current.observe(node);
     },
-    [isLoading, onLoadMore]
+    [data, isLoading, onLoadMore]
   );
 
   useEffect(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
       react-day-picker:
         specifier: ^9.0.4
         version: 9.0.4(react@18.2.0)
+      react-dom:
+        specifier: ^17.0.0 || ^18.0.0
+        version: 18.3.1(react@18.2.0)
       react-loading-skeleton:
         specifier: ^3.4.0
         version: 3.4.0(react@18.2.0)
@@ -8370,7 +8373,7 @@ snapshots:
       '@parcel/source-map': 2.1.1
       '@parcel/types': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
       '@parcel/utils': 2.12.0
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
       abortcontroller-polyfill: 1.7.5
       base-x: 3.0.10
       browserslist: 4.23.2
@@ -8435,7 +8438,7 @@ snapshots:
       '@parcel/types': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
       '@parcel/utils': 2.12.0
       '@parcel/watcher': 2.4.1
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -8597,7 +8600,7 @@ snapshots:
       '@parcel/node-resolver-core': 3.3.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))
       '@parcel/types': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
       '@parcel/utils': 2.12.0
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
       '@swc/core': 1.6.13(@swc/helpers@0.5.12)
       semver: 7.6.2
     transitivePeerDependencies:
@@ -8610,7 +8613,7 @@ snapshots:
       '@parcel/fs': 2.9.2(@parcel/core@2.12.0(@swc/helpers@0.5.12))
       '@parcel/logger': 2.9.2
       '@parcel/node-resolver-core': 3.0.2(@parcel/core@2.12.0(@swc/helpers@0.5.12))
-      '@parcel/types': 2.9.2(@parcel/core@2.9.2)
+      '@parcel/types': 2.9.2(@parcel/core@2.12.0(@swc/helpers@0.5.12))
       '@parcel/utils': 2.9.2
       '@parcel/workers': 2.9.2(@parcel/core@2.12.0(@swc/helpers@0.5.12))
       semver: 5.7.2
@@ -8926,7 +8929,7 @@ snapshots:
       '@parcel/fs': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
       '@parcel/package-manager': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
       '@parcel/source-map': 2.1.1
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
       utility-types: 3.11.0
     transitivePeerDependencies:
       - '@parcel/core'
@@ -9034,7 +9037,7 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.4.1
       '@parcel/watcher-win32-x64': 2.4.1
 
-  '@parcel/workers@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))':
+  '@parcel/workers@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)':
     dependencies:
       '@parcel/core': 2.12.0(@swc/helpers@0.5.12)
       '@parcel/diagnostic': 2.12.0
@@ -9043,6 +9046,8 @@ snapshots:
       '@parcel/types': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
       '@parcel/utils': 2.12.0
       nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@swc/helpers'
 
   '@parcel/workers@2.9.2(@parcel/core@2.12.0(@swc/helpers@0.5.12))':
     dependencies:


### PR DESCRIPTION
Parent PR - [PR-140](https://github.com/raystack/apsara/pull/140)

- Add correct loading ui.
- Implement logic in effect hook as observer ref was not attaching to the last table row correctly bacause of async API call. 

**Why break down the logic into two useEffects?**
- Initialising intersection observer and attaching it to last row are dependent on seperate dependencies (onLoadMore and isLoading). In the previous useCallback approach, the init was triggered multiple times even when isLoading changed.


**First useEffect:**
Initialises the Intersection Observer (observerRef) when the onLoadMore function is passed in props. Threshold is set to 10% i.e. this will be triggered when 10% of the row has intersected.

**Second useEffect:**
Attaches the observer to the last row of the table, triggered whenever isLoading changes.

**Issues found:**
[here](https://github.com/raystack/frontier/pull/740/files#diff-253895be3895b3ec98796a7437de5ecc5414efca71db1a79c2ed35f24b6d6a5bL65) the global loader is conflicting with the infinite scroll. Functionality working fine.

**Testing:**
Manually tested with www/example and Frontier Admin UI
