### PR TITLE
fix: DatePicker outside click causing stale date updates

### DIFF
--- a/packages/raystack/calendar/date-picker.tsx
+++ b/packages/raystack/calendar/date-picker.tsx
@@ -42,6 +42,11 @@ export function DatePicker({
   const textFieldRef = useRef<HTMLInputElement | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
   const isInputFieldFocused = useRef(false);
+	const calendarValRef = useRef(value);
+
+	useEffect(() => {
+		calendarValRef.current = calendarVal;
+	}, [calendarVal]);
 
   function isElementOutside(el: HTMLElement) {
     return !isDropdownOpenRef.current && // Month and Year dropdown from Date picker
@@ -56,14 +61,14 @@ export function DatePicker({
 
   function registerEventListeners() {
     isInputFieldFocused.current = true;
-    document.addEventListener('mouseup', handleMouseDown, true);
+    document.addEventListener('mouseup', handleMouseDown);
   }
 
   function removeEventListeners() {
     isInputFieldFocused.current = false;
     setShowCalendar(false);
 
-    const updatedVal = dayjs(calendarVal).format(dateFormat);
+    const updatedVal = dayjs(calendarValRef.current).format(dateFormat);
 
     if  (textFieldRef.current) textFieldRef.current.value = updatedVal;
     if (inputState === undefined) onSelect(dayjs(updatedVal).toDate());
@@ -74,6 +79,7 @@ export function DatePicker({
   const handleSelect = (day: Date) => {
     onSelect(day);
     setCalendarVal(day);
+		calendarValRef.current = day;
     setInputState(undefined);
     removeEventListeners();
   };


### PR DESCRIPTION
### Changelog

**Issue:** On clicking outside the date-picker, the date-picker was reverting back to the previous date

**Cause:** handleMouseDown is wrapped under useCallback so that document.removeEventListener('mouseup', handleMouseDown) receives the same instance of handleMouseDown as document.addEventListener('mouseup', handleMouseDown). But due to this the calendarVal inside handleMouseDown -> removeEventListener was getting stale value

**Screenshot:**

https://github.com/user-attachments/assets/1a61d745-06be-4b0f-bf0d-c166a62c3454

