### PR TITLE
feat: blur effect on the overlay of dialog component

### DIFF
--- a/apps/www/content/primitives/components/dialog.mdx
+++ b/apps/www/content/primitives/components/dialog.mdx
@@ -9,19 +9,51 @@ radix:
 ## Preview
 
 <Preview>
-  <Dialog>
-    <Dialog.Trigger asChild>
-      <Button variant="ghost" size="small">Dialog button</Button>
-    </Dialog.Trigger>
-    <Dialog.Content close>
-      <Text size="5" style={{ fontWeight: 500, marginBottom: '12px' }}>Dialog Heading</Text>
-      <Text size="3" style={{ lineHeight: '25px' }}>
-        There are 5 variants to choose from. Use is for positive states. This is a link
-        Traditional business literature won’t help you solve it- most of that stuff is
-        focused on life after product/market fit, after the Trough of Sorrow.
-      </Text>
-    </Dialog.Content>
-  </Dialog>
+  <Flex
+    style={{
+      flexDirection: 'column',
+      alignItems: 'center',
+      gap: '12px',
+    }}
+  >
+    <Dialog>
+      <Dialog.Trigger asChild>
+        <Button variant="ghost" size="small">
+          Dialog button
+        </Button>
+      </Dialog.Trigger>
+      <Dialog.Content close>
+        <Text size="5" style={{ fontWeight: 500, marginBottom: '12px' }}>
+          Dialog Heading
+        </Text>
+        <Text size="3" style={{ lineHeight: '25px' }}>
+          There are 5 variants to choose from. Use is for positive states. This
+          is a link Traditional business literature won’t help you solve it-
+          most of that stuff is focused on life after product/market fit, after
+          the Trough of Sorrow.
+        </Text>
+      </Dialog.Content>
+    </Dialog>
+
+    <Dialog>
+      <Dialog.Trigger asChild>
+        <Button variant="ghost" size="small">
+          Dialog with blur button
+        </Button>
+      </Dialog.Trigger>
+      <Dialog.Content overlayBlur={true} close>
+        <Text size="5" style={{ fontWeight: 500, marginBottom: '12px' }}>
+          Dialog Heading
+        </Text>
+        <Text size="3" style={{ lineHeight: '25px' }}>
+          There are 5 variants to choose from. Use is for positive states. This
+          is a link Traditional business literature won’t help you solve it-
+          most of that stuff is focused on life after product/market fit, after
+          the Trough of Sorrow.
+        </Text>
+      </Dialog.Content>
+    </Dialog>
+  </Flex>
 </Preview>
 
 ## Installation
@@ -53,5 +85,25 @@ import { Dialog } from '@raystack/apsara'
     </Text>
   </Dialog.Content>
 </Dialog>
+
+<Dialog>
+  <Dialog.Trigger asChild>
+    <Button variant="ghost" size="small">
+          Dialog with blur button
+    </Button>
+  </Dialog.Trigger>
+  <Dialog.Content overlayBlur={true} close>
+    <Text size="5" style={{ fontWeight: 500, marginBottom: '12px' }}>
+          Dialog Heading
+    </Text>
+    <Text size="3" style={{ lineHeight: '25px' }}>
+          There are 5 variants to choose from. Use is for positive states. This
+          is a link Traditional business literature won’t help you solve it-
+          most of that stuff is focused on life after product/market fit, after
+          the Trough of Sorrow.
+    </Text>
+  </Dialog.Content>
+</Dialog>
+
 `} border />
 </LiveProvider>

--- a/packages/raystack/dialog/dialog.module.css
+++ b/packages/raystack/dialog/dialog.module.css
@@ -15,6 +15,10 @@
   border: 1px solid var(--border-subtle);
 }
 
+.overlayBlur {
+  backdrop-filter: blur(2px);
+}
+
 .dialogContent:focus {
   outline: none;
 }

--- a/packages/raystack/dialog/dialog.tsx
+++ b/packages/raystack/dialog/dialog.tsx
@@ -22,15 +22,16 @@ export const DialogContent = forwardRef<
     close?: boolean;
     overlayStyle?: React.CSSProperties;
     overlayClassname?: string;
+    overlayBlur?: boolean;
   }
 >(
   (
-    { className, children, close, overlayStyle, overlayClassname, ...props },
+    { className, children, close, overlayStyle, overlayClassname, overlayBlur, ...props },
     forwardedRef
   ) => {
     return (
       <DialogPrimitive.Portal>
-        <Overlay className={overlayClassname} style={overlayStyle}>
+        <Overlay className={overlayClassname} style={overlayStyle} blur={overlayBlur}>
           <DialogPrimitive.Content
             {...props}
             ref={forwardedRef}
@@ -49,7 +50,13 @@ export const DialogContent = forwardRef<
   }
 );
 
-const overlay = cva(styles.overlay);
+const overlay = cva(styles.overlay, {
+  variants: {
+    blur: {
+      true: styles.overlayBlur,
+    },
+  },
+});
 export interface OverlayProps
   extends ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>,
     VariantProps<typeof overlay> {}
@@ -57,10 +64,10 @@ export interface OverlayProps
 const Overlay = forwardRef<
   ElementRef<typeof DialogPrimitive.Overlay>,
   OverlayProps
->(({ className, ...props }, ref) => (
+>(({ className, blur, ...props }, ref) => (
   <DialogPrimitive.Overlay
     ref={ref}
-    className={overlay({ className })}
+    className={overlay({ className, blur })}
     {...props}
   />
 ));


### PR DESCRIPTION
Added a prop, `overlayBlur` for the `DialogContent` component to show the blur effect on the Dialog overlay.
<img width="1512" alt="Screenshot 2024-10-10 at 12 53 28 PM" src="https://github.com/user-attachments/assets/388be624-ae65-4f6e-b98e-b2cbf5c16d86">
