### PR TITLE
feat: add new badge on side nav

### DIFF
--- a/apps/www/components/page.module.css
+++ b/apps/www/components/page.module.css
@@ -10,11 +10,11 @@
 }
 
 .badge {
-  background-color: #007bff; 
-  color: #fff;
-  padding: 0px 6px;
-  margin-left: 8px;
-  border-radius: 3px;
+  background-color: var(--rs-accent-9); 
+  color: var(--rs-accent-contrast);
+  padding: var(--rs-space-1) var(--rs-space-3);
+  margin-left: var(--rs-space-2);
+  border-radius: var(--rs-radius-2);
   font-size: 0.55em;
   font-weight: bold;
   display: inline-block;

--- a/apps/www/components/page.module.css
+++ b/apps/www/components/page.module.css
@@ -8,3 +8,15 @@
 .content > :last-child {
   margin-bottom: 100px;
 }
+
+.badge {
+  background-color: #007bff; 
+  color: #fff;
+  padding: 0px 6px;
+  margin-left: 8px;
+  border-radius: 3px;
+  font-size: 0.55em;
+  font-weight: bold;
+  display: inline-block;
+  vertical-align: middle;
+}

--- a/apps/www/components/page.module.css
+++ b/apps/www/components/page.module.css
@@ -12,7 +12,7 @@
 .badge {
   background-color: var(--rs-accent-9); 
   color: var(--rs-accent-contrast);
-  padding: var(--rs-space-1) var(--rs-space-3);
+  padding: 0 var(--rs-space-2);
   margin-left: var(--rs-space-2);
   border-radius: var(--rs-radius-2);
   font-size: 0.55em;

--- a/apps/www/components/primitive-page.tsx
+++ b/apps/www/components/primitive-page.tsx
@@ -150,6 +150,7 @@ const LeftSideBar = () => {
             >
               <NavItemTitle active={currentPageSlug === page.slug}>
                 {page.title}
+                {page.newBadge && <span className={styles.badge}>New</span>}
               </NavItemTitle>
             </NavItem>
           ))}
@@ -162,7 +163,10 @@ const LeftSideBar = () => {
               href={`/${page.slug}`}
               active={currentPageSlug === page.slug}
             >
-              {page.title}
+              <NavItemTitle active={currentPageSlug === page.slug}>
+                {page.title}
+                {page.newBadge && <span className={styles.badge}>New</span>}
+              </NavItemTitle>
             </NavItem>
           ))}
         </Box>

--- a/apps/www/utils/routes.ts
+++ b/apps/www/utils/routes.ts
@@ -12,10 +12,10 @@ export const primitivesRoutes = [
   {
     label: "Components",
     pages: [
-      { title: "Avatar", slug: "docs/primitives/components/avatar" },
+      { title: "Avatar", slug: "docs/primitives/components/avatar", newBadge: true, },
       { title: "Badge", slug: "docs/primitives/components/badge" },
-      { title: "Breadcrumb", slug: "docs/primitives/components/breadcrumb" },
-      { title: "Button", slug: "docs/primitives/components/button" },
+      { title: "Breadcrumb", slug: "docs/primitives/components/breadcrumb", newBadge: true, },
+      { title: "Button", slug: "docs/primitives/components/button", newBadge: true, },
       { title: "Calendar", slug: "docs/primitives/components/calendar" },
       { title: "Command", slug: "docs/primitives/components/command" },
       { title: "Checkbox", slug: "docs/primitives/components/checkbox" },
@@ -37,7 +37,7 @@ export const primitivesRoutes = [
       { title: "Select", slug: "docs/primitives/components/select" },
       { title: "Seprator", slug: "docs/primitives/components/separator" },
       { title: "Sheet", slug: "docs/primitives/components/sheet" },
-      { title: "Spinner", slug: "docs/primitives/components/spinner" },
+      { title: "Spinner", slug: "docs/primitives/components/spinner", newBadge: true, },
       { title: "Switch", slug: "docs/primitives/components/switch" },
       { title: "Tabs", slug: "docs/primitives/components/tabs" },
       { title: "Table", slug: "docs/primitives/components/table" },
@@ -55,6 +55,7 @@ export type PageProps = {
   slug: string;
   deprecated?: boolean;
   preview?: boolean;
+  newBadge?: boolean;
 };
 
 export type RouteProps = {


### PR DESCRIPTION
Adds a "New" badge in the docs side bar if newBadge: true is passed in the route.

`{ title: "Button", slug: "docs/primitives/components/button", newBadge: true, },`

<img width="228" alt="Screenshot 2024-10-30 at 3 27 19 PM" src="https://github.com/user-attachments/assets/801ebe90-1e1a-432d-97e8-1b865571ef95">
