### PR TITLE
fix: prevert node_modules to publish to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+node_modules
+src
+tests
+.turbo
+.gitignore
+.npmignore
+rollup.config.mjs
+tsconfig.json
+*.log

--- a/packages/raystack/package.json
+++ b/packages/raystack/package.json
@@ -22,14 +22,14 @@
     "README.md"
   ],
   "scripts": {
+    "prebuild": "npm run clean",
     "build": "rollup --config",
     "dev": "rollup --config --watch",
     "lint": "eslint \"**/*.ts*\"",
     "release": "release-it",
     "release:ci": "release-it --ci --no-increment --npm.ignoreVersion",
     "bump-version": "node scripts/bump-version.js",
-    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf react/dist",
-    "test": "echo \"Error: no test specified\" && exit 0"
+    "clean": "rm -rf .turbo && rm -rf dist"
   },
   "typesVersions": {
     "*": {


### PR DESCRIPTION
Prevent node_modules and other folders/files from getting published to npm.