### PR TITLE
chore: match style for breadcrumb

### DIFF
--- a/apps/www/pages/_app.tsx
+++ b/apps/www/pages/_app.tsx
@@ -1,4 +1,4 @@
-import { ThemeProvider } from "@raystack/apsara";
+import { ThemeProvider } from "@raystack/apsara/v1";
 import type { AppProps } from "next/app";
 import { Inter, Roboto_Mono } from "next/font/google";
 import { Navbar } from "~/components/Navbar";

--- a/packages/raystack/v1/components/breadcrumb/breadcrumb.module.css
+++ b/packages/raystack/v1/components/breadcrumb/breadcrumb.module.css
@@ -22,7 +22,6 @@
 .breadcrumb-item {
   display: flex;
   align-items: center;
-  margin-right: var(--rs-space-2);
   text-wrap: nowrap;
 }
 
@@ -31,7 +30,6 @@
   align-items: center;
   color: var(--rs-color-text-base-tertiary);
   text-decoration: none;
-  margin-right: var(--rs-space-1);
   text-wrap: nowrap;
 }
 
@@ -48,19 +46,18 @@
 .breadcrumb-icon {
   display: flex;
   align-items: center;
-  margin-right: var(--rs-space-1);
+  margin-right: var(--rs-space-2);
 }
 
 .breadcrumb-separator {
   color: var(--rs-color-text-base-tertiary);
-  margin: 0 var(--rs-space-2);
+  margin: 0 var(--rs-space-5);
 }
 
 .breadcrumb-ellipsis {
   display: flex;
   align-items: center;
   color: var(--rs-color-text-base-secondary);
-  margin: 0 var(--rs-space-3) 0 var(--rs-space-2);
 }
 
 .breadcrumb-ellipsis svg {
@@ -81,11 +78,9 @@
   font-weight: inherit;
   outline: none;
   padding: 0;
-  margin-right: var(--rs-space-1);
 }
 
 .breadcrumb-dropdown-icon {
-  margin-left: var(--rs-space-1);
   height: var(--rs-space-3);
 }
 

--- a/packages/raystack/v1/styles/accent.css
+++ b/packages/raystack/v1/styles/accent.css
@@ -77,7 +77,7 @@
     --rs-accent-10: #7de0cb;
     --rs-accent-11: #027864;
     --rs-accent-12: #16433c;
-    --rs-accent-contrast: #000000;
+    --rs-accent-contrast: #ffffff;
 }
 
 [data-accent-color='mint'][data-theme='dark'] {
@@ -93,5 +93,5 @@
     --rs-accent-10: #a8f5e5;
     --rs-accent-11: #58d5ba;
     --rs-accent-12: #c4f5e1;
-    --rs-accent-contrast: #000000;
+    --rs-accent-contrast: #ffffff;
 }


### PR DESCRIPTION
1. Match breadcrumb style.
2. Import v1 theme in _app instead of the older one.
3. Revert --rs-accent-contrast for mint accent color.