### PR TITLE
feat: Upgrade to React v19.0.0

### DIFF
--- a/apps/www/components/markdown/playground.tsx
+++ b/apps/www/components/markdown/playground.tsx
@@ -33,14 +33,9 @@ export type PlaygroundProps = {
   };
 };
 
-const defaultProps = {
-  code: "",
-  tabs: [] as Tab[],
-  scope: {},
-};
 
 const Playground: React.FC<PlaygroundProps> = React.memo(
-  ({ code, tabs, scope }: PlaygroundProps & typeof defaultProps) => {
+  ({ code, tabs, scope }: PlaygroundProps) => {
     const [visible, setVisible] = useState(false);
 
     if (code) {
@@ -98,6 +93,5 @@ const Playground: React.FC<PlaygroundProps> = React.memo(
   }
 );
 
-Playground.defaultProps = defaultProps;
 Playground.displayName = "Playground";
 export default Playground;

--- a/apps/www/content/primitives/components/togglegroup.mdx
+++ b/apps/www/content/primitives/components/togglegroup.mdx
@@ -7,7 +7,7 @@ description:
 
 
 <Preview>
-  <ToggleGroup>
+  <ToggleGroup type="single" defaultValue="daily">
       <ToggleGroup.Item value="daily"><Text size={3} style={{padding: "8px"}}>Daily</Text></ToggleGroup.Item>
     <ToggleGroup.Item value="weekly"><Text size={3} style={{padding: "8px"}}>Weekly</Text></ToggleGroup.Item>
     <ToggleGroup.Item value="monthly"><Text size={3} style={{padding: "8px"}}>Monthly</Text></ToggleGroup.Item>

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -21,7 +21,9 @@
     "next": "14.2.5",
     "react-live": "^4.1.6",
     "react-loading-skeleton": "^3.4.0",
-    "tslib": "^2.5.0"
+    "tslib": "^2.5.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.4.1",
@@ -29,8 +31,8 @@
     "@radix-ui/react-scroll-area": "^1.0.3",
     "@types/mapbox__rehype-prism": "^0.8.0",
     "@types/node": "^18.15.11",
-    "@types/react": "^18.0.28",
-    "@types/react-dom": "^18.0.11",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "class-variance-authority": "^0.6.0",
     "compare-versions": "^6.0.0-rc.1",
     "eslint-config-custom": "workspace:*",
@@ -39,8 +41,6 @@
     "mdx-bundler": "^9.2.1",
     "next-compose-plugins": "^2.2.1",
     "prism-react-renderer": "^2.3.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "reading-time": "^1.5.0",
     "rehype-autolink-headings": "^6.1.1",
     "rehype-slug": "^5.1.0",

--- a/packages/raystack/package.json
+++ b/packages/raystack/package.json
@@ -59,7 +59,7 @@
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
     "@types/jest": "^29.5.14",
-    "@types/react": "^18.2.12",
+    "@types/react": "^19.0.0",
     "@types/react-select": "^5.0.1",
     "eslint-config-custom": "workspace:*",
     "identity-obj-proxy": "^3.0.0",
@@ -71,7 +71,8 @@
     "postcss": "^8.4.24",
     "postcss-import": "^16.1.0",
     "postcss-modules": "^6.0.0",
-    "react": "^18.2.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "release-it": "^16.2.1",
     "rollup": "^3.25.1",
     "rollup-plugin-postcss": "^4.0.2",
@@ -110,5 +111,9 @@
     "react-select": "^5.7.7",
     "sonner": "^1.5.0",
     "usehooks-ts": "^2.9.1"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   }
 }

--- a/packages/raystack/v1/components/avatar/avatar.tsx
+++ b/packages/raystack/v1/components/avatar/avatar.tsx
@@ -1,12 +1,7 @@
 import * as AvatarPrimitive from "@radix-ui/react-avatar";
 import { cva, VariantProps } from "class-variance-authority";
 import { clsx } from 'clsx';
-import {
-  ComponentPropsWithoutRef,
-  ComponentRef,
-  forwardRef,
-  ReactNode,
-} from "react";
+import { ComponentPropsWithoutRef, ComponentRef, ReactNode } from "react";
 
 import { Box } from "../box";
 import styles from "./avatar.module.css";
@@ -105,10 +100,20 @@ export interface AvatarProps
   className?: string;
 }
 
-const AvatarRoot = forwardRef<
-  ComponentRef<typeof AvatarPrimitive.Root>,
-  AvatarProps
->(({ className, alt, src, fallback, size, radius, variant, color, style, asChild, ...props }, ref) => {
+export const Avatar = ({ 
+  className, 
+  alt, 
+  src, 
+  fallback, 
+  size, 
+  radius, 
+  variant, 
+  color, 
+  style, 
+  asChild,
+  ref,
+  ...props 
+}: AvatarProps & { ref?: React.Ref<ComponentRef<typeof AvatarPrimitive.Root>> }) => {
   return (
     <Box className={styles.imageWrapper} style={style}>
       <AvatarPrimitive.Root
@@ -128,47 +133,48 @@ const AvatarRoot = forwardRef<
       </AvatarPrimitive.Root>
     </Box>
   );
-});
-
-AvatarRoot.displayName = AvatarPrimitive.Root.displayName;
-
-export const Avatar = AvatarRoot;
+};
 
 export interface AvatarGroupProps extends ComponentPropsWithoutRef<'div'> {
   children: React.ReactElement<AvatarProps>[];
   max?: number;
 }
 
-export const AvatarGroup = forwardRef<HTMLDivElement, AvatarGroupProps>(
-  ({ children, max, className, ...props }, ref) => {
-    const avatars = max ? children.slice(0, max) : children;
-    const count = max && children.length > max ? children.length - max : 0;
+export const AvatarGroup = ({ 
+  children, 
+  max, 
+  className,
+  ref,
+  ...props 
+}: AvatarGroupProps & { ref?: React.Ref<ComponentRef<"div">> }) => {
+  const avatars = max ? children.slice(0, max) : children;
+  const count = max && children.length > max ? children.length - max : 0;
 
-    return (
-      <div
-        ref={ref}
-        className={clsx(styles.avatarGroup, className)}
-        {...props}
-      >
-        {avatars.map((avatar, index) => (
-          <div key={index} className={styles.avatarWrapper}>
-            {avatar}
-          </div>
-        ))}
-        {count > 0 && (
-          <div className={styles.avatarWrapper}>
-            <Avatar
-              size={avatars[0].props.size}
-              radius={avatars[0].props.radius}
-              variant={avatars[0].props.variant}
-              color='neutral'
-              fallback={<span>+{count}</span>}
-            />
-          </div>
-        )}
-      </div>
-    );
-  }
-);
+  return (
+    <div
+      ref={ref}
+      className={clsx(styles.avatarGroup, className)}
+      {...props}
+    >
+      {avatars.map((avatar, index) => (
+        <div key={index} className={styles.avatarWrapper}>
+          {avatar}
+        </div>
+      ))}
+      {count > 0 && (
+        <div className={styles.avatarWrapper}>
+          <Avatar
+            size={avatars[0].props.size}
+            radius={avatars[0].props.radius}
+            variant={avatars[0].props.variant}
+            color='neutral'
+            fallback={<span>+{count}</span>}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
 
+Avatar.displayName = 'Avatar';
 AvatarGroup.displayName = 'AvatarGroup';

--- a/packages/raystack/v1/components/avatar/avatar.tsx
+++ b/packages/raystack/v1/components/avatar/avatar.tsx
@@ -3,7 +3,7 @@ import { cva, VariantProps } from "class-variance-authority";
 import { clsx } from 'clsx';
 import {
   ComponentPropsWithoutRef,
-  ElementRef,
+  ComponentRef,
   forwardRef,
   ReactNode,
 } from "react";
@@ -106,13 +106,13 @@ export interface AvatarProps
 }
 
 const AvatarRoot = forwardRef<
-  ElementRef<typeof AvatarPrimitive.Root>,
+  ComponentRef<typeof AvatarPrimitive.Root>,
   AvatarProps
->(
-  (
-    { className, alt, src, fallback, size, radius, variant, color, style, asChild, ...props },
-    ref
-  ) => (
+>(function AvatarRoot(
+  { className, alt, src, fallback, size, radius, variant, color, style, asChild, ...props },
+  ref
+) {
+  return (
     <Box className={styles.imageWrapper} style={style}>
       <AvatarPrimitive.Root
         ref={ref}
@@ -130,8 +130,8 @@ const AvatarRoot = forwardRef<
         </AvatarPrimitive.Fallback>
       </AvatarPrimitive.Root>
     </Box>
-  )
-);
+  );
+});
 
 AvatarRoot.displayName = AvatarPrimitive.Root.displayName;
 
@@ -143,7 +143,7 @@ export interface AvatarGroupProps extends ComponentPropsWithoutRef<'div'> {
 }
 
 export const AvatarGroup = forwardRef<HTMLDivElement, AvatarGroupProps>(
-  ({ children, max, className, ...props }, ref) => {
+  function AvatarGroup({ children, max, className, ...props }, ref) {
     const avatars = max ? children.slice(0, max) : children;
     const count = max && children.length > max ? children.length - max : 0;
 

--- a/packages/raystack/v1/components/avatar/avatar.tsx
+++ b/packages/raystack/v1/components/avatar/avatar.tsx
@@ -100,20 +100,7 @@ export interface AvatarProps
   className?: string;
 }
 
-export const Avatar = ({ 
-  className, 
-  alt, 
-  src, 
-  fallback, 
-  size, 
-  radius, 
-  variant, 
-  color, 
-  style, 
-  asChild,
-  ref,
-  ...props 
-}: AvatarProps & { ref?: React.Ref<ComponentRef<typeof AvatarPrimitive.Root>> }) => {
+export const Avatar = ({ className, alt, src, fallback, size, radius, variant, color, style, asChild, ref, ...props }: AvatarProps & { ref?: React.Ref<ComponentRef<typeof AvatarPrimitive.Root>> }) => {
   return (
     <Box className={styles.imageWrapper} style={style}>
       <AvatarPrimitive.Root
@@ -140,13 +127,7 @@ export interface AvatarGroupProps extends ComponentPropsWithoutRef<'div'> {
   max?: number;
 }
 
-export const AvatarGroup = ({ 
-  children, 
-  max, 
-  className,
-  ref,
-  ...props 
-}: AvatarGroupProps & { ref?: React.Ref<ComponentRef<"div">> }) => {
+export const AvatarGroup = ({ children, max, className, ref, ...props }: AvatarGroupProps & { ref?: React.Ref<ComponentRef<"div">> }) => {
   const avatars = max ? children.slice(0, max) : children;
   const count = max && children.length > max ? children.length - max : 0;
 

--- a/packages/raystack/v1/components/avatar/avatar.tsx
+++ b/packages/raystack/v1/components/avatar/avatar.tsx
@@ -108,10 +108,7 @@ export interface AvatarProps
 const AvatarRoot = forwardRef<
   ComponentRef<typeof AvatarPrimitive.Root>,
   AvatarProps
->(function AvatarRoot(
-  { className, alt, src, fallback, size, radius, variant, color, style, asChild, ...props },
-  ref
-) {
+>(({ className, alt, src, fallback, size, radius, variant, color, style, asChild, ...props }, ref) => {
   return (
     <Box className={styles.imageWrapper} style={style}>
       <AvatarPrimitive.Root
@@ -143,7 +140,7 @@ export interface AvatarGroupProps extends ComponentPropsWithoutRef<'div'> {
 }
 
 export const AvatarGroup = forwardRef<HTMLDivElement, AvatarGroupProps>(
-  function AvatarGroup({ children, max, className, ...props }, ref) {
+  ({ children, max, className, ...props }, ref) => {
     const avatars = max ? children.slice(0, max) : children;
     const count = max && children.length > max ? children.length - max : 0;
 

--- a/packages/raystack/v1/components/badge/badge.tsx
+++ b/packages/raystack/v1/components/badge/badge.tsx
@@ -32,7 +32,16 @@ export interface BadgeProps
   screenReaderText?: string;
 }
 
-export const Badge = ({ className, icon, children, variant, size, screenReaderText, ref, ...props }: BadgeProps & { ref?: React.Ref<ComponentRef<"span">> }) => (
+export const Badge = ({ 
+  className, 
+  icon, 
+  children, 
+  variant, 
+  size, 
+  screenReaderText, 
+  ref, 
+  ...props 
+}: BadgeProps & { ref?: React.Ref<ComponentRef<"span">> }) => (
   <span ref={ref} className={badge({ variant, size, className })} {...props}>
     {icon && <span className={styles['icon']}>{icon}</span>}
     {screenReaderText && <span className={styles['sr-only']}>{screenReaderText}</span>}

--- a/packages/raystack/v1/components/badge/badge.tsx
+++ b/packages/raystack/v1/components/badge/badge.tsx
@@ -1,5 +1,5 @@
 import { cva, type VariantProps } from "class-variance-authority";
-import { ReactNode } from "react";
+import { ReactNode, forwardRef } from "react";
 
 import styles from "./badge.module.css";
 
@@ -17,12 +17,12 @@ const badge = cva(styles['badge'], {
       micro: styles["badge-micro"],
       small: styles["badge-small"],
       regular: styles["badge-regular"],
-    },
-    defaultVariants: {
-      variant: "accent",
-      size: "small"
     }
   },
+  defaultVariants: {
+    variant: "accent",
+    size: "small"
+  }
 });
 
 type BadgeProps = VariantProps<typeof badge> & {
@@ -32,23 +32,25 @@ type BadgeProps = VariantProps<typeof badge> & {
   screenReaderText?: string;
 }
 
-export const Badge = ({ 
-  variant = 'accent',
-  size = 'small',
-  icon,
-  children,
-  className,
-  screenReaderText
-}: BadgeProps) => {
-  return (
-    <span className={badge({ variant, size, className })}>
-      {icon && <span className={styles['icon']}>{icon}</span>}
-      {screenReaderText && (
-        <span className={styles['sr-only']}>{screenReaderText}</span>
-      )}
-      {children}
-    </span>
-  );
-};
+export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
+  function Badge({ 
+    variant = 'accent',
+    size = 'small',
+    icon,
+    children,
+    className,
+    screenReaderText
+  }, ref) {
+    return (
+      <span ref={ref} className={badge({ variant, size, className })}>
+        {icon && <span className={styles['icon']}>{icon}</span>}
+        {screenReaderText && (
+          <span className={styles['sr-only']}>{screenReaderText}</span>
+        )}
+        {children}
+      </span>
+    );
+  }
+);
 
-Badge.displayName = "Badge";
+Badge.displayName = 'Badge';

--- a/packages/raystack/v1/components/badge/badge.tsx
+++ b/packages/raystack/v1/components/badge/badge.tsx
@@ -32,21 +32,10 @@ export interface BadgeProps
   screenReaderText?: string;
 }
 
-export const Badge = ({ 
-  variant = 'accent',
-  size = 'small',
-  icon,
-  children,
-  className,
-  screenReaderText,
-  ref,
-  ...props 
-}: BadgeProps & { ref?: React.Ref<ComponentRef<"span">> }) => (
+export const Badge = ({ variant = 'accent', size = 'small', icon, children, className, screenReaderText, ref, ...props }: BadgeProps & { ref?: React.Ref<ComponentRef<"span">> }) => (
   <span ref={ref} className={badge({ variant, size, className })} {...props}>
     {icon && <span className={styles['icon']}>{icon}</span>}
-    {screenReaderText && (
-      <span className={styles['sr-only']}>{screenReaderText}</span>
-    )}
+    {screenReaderText && <span className={styles['sr-only']}>{screenReaderText}</span>}
     {children}
   </span>
 );

--- a/packages/raystack/v1/components/badge/badge.tsx
+++ b/packages/raystack/v1/components/badge/badge.tsx
@@ -1,5 +1,5 @@
 import { cva, type VariantProps } from "class-variance-authority";
-import { ReactNode, forwardRef } from "react";
+import { ComponentPropsWithoutRef, ComponentRef, ReactNode } from "react";
 
 import styles from "./badge.module.css";
 
@@ -21,34 +21,34 @@ const badge = cva(styles['badge'], {
   },
   defaultVariants: {
     variant: "accent",
-    size: "small"
-  }
+    size: "small",
+  },
 });
 
-type BadgeProps = VariantProps<typeof badge> & {
+export interface BadgeProps
+  extends ComponentPropsWithoutRef<"span">,
+    VariantProps<typeof badge> {
   icon?: ReactNode;
-  children: ReactNode;
-  className?: string;
   screenReaderText?: string;
 }
 
-export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(({ 
+export const Badge = ({ 
   variant = 'accent',
   size = 'small',
   icon,
   children,
   className,
-  screenReaderText
-}, ref) => {
-  return (
-    <span ref={ref} className={badge({ variant, size, className })}>
-      {icon && <span className={styles['icon']}>{icon}</span>}
-      {screenReaderText && (
-        <span className={styles['sr-only']}>{screenReaderText}</span>
-      )}
-      {children}
-    </span>
-  );
-});
+  screenReaderText,
+  ref,
+  ...props 
+}: BadgeProps & { ref?: React.Ref<ComponentRef<"span">> }) => (
+  <span ref={ref} className={badge({ variant, size, className })} {...props}>
+    {icon && <span className={styles['icon']}>{icon}</span>}
+    {screenReaderText && (
+      <span className={styles['sr-only']}>{screenReaderText}</span>
+    )}
+    {children}
+  </span>
+);
 
 Badge.displayName = 'Badge';

--- a/packages/raystack/v1/components/badge/badge.tsx
+++ b/packages/raystack/v1/components/badge/badge.tsx
@@ -32,25 +32,23 @@ type BadgeProps = VariantProps<typeof badge> & {
   screenReaderText?: string;
 }
 
-export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
-  function Badge({ 
-    variant = 'accent',
-    size = 'small',
-    icon,
-    children,
-    className,
-    screenReaderText
-  }, ref) {
-    return (
-      <span ref={ref} className={badge({ variant, size, className })}>
-        {icon && <span className={styles['icon']}>{icon}</span>}
-        {screenReaderText && (
-          <span className={styles['sr-only']}>{screenReaderText}</span>
-        )}
-        {children}
-      </span>
-    );
-  }
-);
+export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(({ 
+  variant = 'accent',
+  size = 'small',
+  icon,
+  children,
+  className,
+  screenReaderText
+}, ref) => {
+  return (
+    <span ref={ref} className={badge({ variant, size, className })}>
+      {icon && <span className={styles['icon']}>{icon}</span>}
+      {screenReaderText && (
+        <span className={styles['sr-only']}>{screenReaderText}</span>
+      )}
+      {children}
+    </span>
+  );
+});
 
 Badge.displayName = 'Badge';

--- a/packages/raystack/v1/components/badge/badge.tsx
+++ b/packages/raystack/v1/components/badge/badge.tsx
@@ -32,7 +32,7 @@ export interface BadgeProps
   screenReaderText?: string;
 }
 
-export const Badge = ({ variant = 'accent', size = 'small', icon, children, className, screenReaderText, ref, ...props }: BadgeProps & { ref?: React.Ref<ComponentRef<"span">> }) => (
+export const Badge = ({ className, icon, children, variant, size, screenReaderText, ref, ...props }: BadgeProps & { ref?: React.Ref<ComponentRef<"span">> }) => (
   <span ref={ref} className={badge({ variant, size, className })} {...props}>
     {icon && <span className={styles['icon']}>{icon}</span>}
     {screenReaderText && <span className={styles['sr-only']}>{screenReaderText}</span>}

--- a/packages/raystack/v1/components/breadcrumb/breadcrumb.tsx
+++ b/packages/raystack/v1/components/breadcrumb/breadcrumb.tsx
@@ -1,6 +1,6 @@
 import { ChevronDownIcon,DotsHorizontalIcon } from "@radix-ui/react-icons";
 import { cva, type VariantProps } from "class-variance-authority";
-import React, { forwardRef, PropsWithChildren } from "react";
+import React, { PropsWithChildren, ComponentRef } from "react";
 
 import { DropdownMenu } from "../dropdown-menu";
 import styles from "./breadcrumb.module.css";
@@ -31,18 +31,19 @@ type BreadcrumbProps = PropsWithChildren<Omit<VariantProps<typeof breadcrumb>, '
   onItemClick?: (item: BreadcrumbItem) => void;
   className?: string;
   size?: 'small' | 'medium';
+  ref?: React.Ref<ComponentRef<'div'>>;
 };
 
-export const Breadcrumb = forwardRef<HTMLDivElement, BreadcrumbProps>(
-  ({ 
-    className, 
-    size = 'medium', 
-    items, 
-    maxVisibleItems, 
-    separator = '/', 
-    onItemClick,
-    ...props 
-  }, ref) => {
+export const Breadcrumb = ({ 
+  className, 
+  size = 'medium', 
+  items, 
+  maxVisibleItems, 
+  separator = '/', 
+  onItemClick,
+  ref,
+  ...props 
+}: BreadcrumbProps) => {
     const visibleItems = maxVisibleItems && items.length > maxVisibleItems
       ? [
           ...items.slice(0, 1),

--- a/packages/raystack/v1/components/breadcrumb/breadcrumb.tsx
+++ b/packages/raystack/v1/components/breadcrumb/breadcrumb.tsx
@@ -31,7 +31,7 @@ type BreadcrumbProps = PropsWithChildren<Omit<VariantProps<typeof breadcrumb>, '
   onItemClick?: (item: BreadcrumbItem) => void;
   className?: string;
   size?: 'small' | 'medium';
-  ref?: React.Ref<ComponentRef<'div'>>;
+  ref?: React.Ref<ComponentRef<"div">>;
 };
 
 export const Breadcrumb = ({ 

--- a/packages/raystack/v1/components/button/button.tsx
+++ b/packages/raystack/v1/components/button/button.tsx
@@ -1,6 +1,6 @@
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
-import { ButtonHTMLAttributes, forwardRef, PropsWithChildren, ReactNode } from "react";
+import { ButtonHTMLAttributes, forwardRef, PropsWithChildren, ReactNode, ComponentPropsWithoutRef, ComponentRef } from "react";
 
 import { Spinner } from "../spinner";
 import styles from "./button.module.css";
@@ -41,7 +41,10 @@ type ButtonProps = PropsWithChildren<VariantProps<typeof button>> &
     width?: string | number
   };
 
-export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+export const Button = forwardRef<
+  ComponentRef<typeof Slot>,
+  ButtonProps
+>(
   ({ className, variant = 'primary', size = 'normal', asChild = false, disabled, loading, loaderText, leadingIcon, trailingIcon, width, children, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
     const isLoaderOnly = loading && !loaderText;

--- a/packages/raystack/v1/components/button/button.tsx
+++ b/packages/raystack/v1/components/button/button.tsx
@@ -41,39 +41,48 @@ type ButtonProps = PropsWithChildren<VariantProps<typeof button>> &
     width?: string | number
   };
 
-export const Button = forwardRef<
-  ComponentRef<typeof Slot>,
-  ButtonProps
->(
-  ({ className, variant = 'primary', size = 'normal', asChild = false, disabled, loading, loaderText, leadingIcon, trailingIcon, width, children, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button";
-    const isLoaderOnly = loading && !loaderText;
-    const widthStyle = width ? { width } : {};
+export const Button = ({ 
+  className, 
+  variant = 'primary', 
+  size = 'normal', 
+  asChild = false, 
+  disabled, 
+  loading, 
+  loaderText, 
+  leadingIcon, 
+  trailingIcon, 
+  width, 
+  children,
+  ref,
+  ...props 
+}: ButtonProps & { ref?: React.Ref<HTMLButtonElement> }) => {
+  const Comp = asChild ? Slot : "button";
+  const isLoaderOnly = loading && !loaderText;
+  const widthStyle = width ? { width } : {};
 
-    const spinnerColor = variant === 'primary' || variant === 'danger' ? 'inverted' : 'default';
+  const spinnerColor = variant === 'primary' || variant === 'danger' ? 'inverted' : 'default';
 
-    return (
-      <Comp
-        className={`${button({ variant, size, disabled, loading, className })} ${isLoaderOnly ? getLoaderOnlyClass(size) : ''}`}
-        ref={ref}
-        disabled={disabled}
-        style={ widthStyle }
-        {...props}
-      >
-        {loading ? (
-          <>
-            <Spinner size={1} color={spinnerColor} />
-            {loaderText && <span className={styles['loader-text']}>{loaderText}</span>}
-          </>
-        ) : (
-          <>
-            {leadingIcon && <span className={`${styles['icon']} ${styles['icon-leading']}`}>{leadingIcon}</span>}
-            {children}
-            {trailingIcon && <span className={`${styles['icon']} ${styles['icon-trailing']}`}>{trailingIcon}</span>}
-          </>
-        )}
-      </Comp>
-    );
-  }
-);
+  return (
+    <Comp
+      className={`${button({ variant, size, disabled, loading, className })} ${isLoaderOnly ? getLoaderOnlyClass(size) : ''}`}
+      ref={ref}
+      disabled={disabled}
+      style={ widthStyle }
+      {...props}
+    >
+      {loading ? (
+        <>
+          <Spinner size={1} color={spinnerColor} />
+          {loaderText && <span className={styles['loader-text']}>{loaderText}</span>}
+        </>
+      ) : (
+        <>
+          {leadingIcon && <span className={`${styles['icon']} ${styles['icon-leading']}`}>{leadingIcon}</span>}
+          {children}
+          {trailingIcon && <span className={`${styles['icon']} ${styles['icon-trailing']}`}>{trailingIcon}</span>}
+        </>
+      )}
+    </Comp>
+  );
+};
 Button.displayName = "Button";

--- a/packages/raystack/v1/components/button/button.tsx
+++ b/packages/raystack/v1/components/button/button.tsx
@@ -1,6 +1,6 @@
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
-import { ButtonHTMLAttributes, forwardRef, PropsWithChildren, ReactNode, ComponentPropsWithoutRef, ComponentRef } from "react";
+import { ButtonHTMLAttributes, PropsWithChildren, ReactNode } from "react";
 
 import { Spinner } from "../spinner";
 import styles from "./button.module.css";

--- a/packages/raystack/v1/components/callout/callout.tsx
+++ b/packages/raystack/v1/components/callout/callout.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { type ComponentPropsWithoutRef } from 'react';
+import { type ComponentPropsWithoutRef, type ComponentRef } from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { InfoCircledIcon } from '@radix-ui/react-icons';
 import styles from './callout.module.css';
@@ -35,86 +35,85 @@ export interface CalloutProps extends ComponentPropsWithoutRef<'div'>, VariantPr
   width?: string | number;
 }
 
-export const Callout = React.forwardRef<HTMLDivElement, CalloutProps>(
-  ({ 
-    className,
-    type = 'grey',
-    outline,
-    highContrast,
-    children,
-    action,
-    dismissible,
-    onDismiss,
-    width,
-    ...props
-  }, ref) => {
-    const style = width ? { width: typeof width === 'number' ? `${width}px` : width } : undefined;
+export const Callout = ({ 
+  className,
+  type = 'grey',
+  outline,
+  highContrast,
+  children,
+  action,
+  dismissible,
+  onDismiss,
+  width,
+  ref,
+  ...props
+}: CalloutProps & { ref?: React.Ref<ComponentRef<'div'>> }) => {
+  const style = width ? { width: typeof width === 'number' ? `${width}px` : width } : undefined;
 
-    const getRole = () => {
-      switch (type) {
-        case 'alert':
-          return 'alert';
-        case 'success':
-          return 'status';
-        default:
-          return 'status';
-      }
-    };
+  const getRole = () => {
+    switch (type) {
+      case 'alert':
+        return 'alert';
+      case 'success':
+        return 'status';
+      default:
+        return 'status';
+    }
+  };
 
-    return (
-      <div
-        ref={ref}
-        className={`${callout({ type, outline, highContrast })} ${className || ''}`}
-        style={style}
-        role={getRole()}
-        aria-live={type === 'alert' ? 'assertive' : 'polite'}
-        {...props}
-      >
-        <div className={styles.container}>
-          <div className={styles.messageContainer}>
-            <InfoCircledIcon 
-              className={styles.icon} 
-              aria-hidden="true"
-            />
-            <div className={styles.message}>{children}</div>
-          </div>
-          
-          <div className={styles.actionsContainer}>
-            {action && (
-              <div className={styles.action}>
-                {action}
-              </div>
-            )}
-            {dismissible && (
-              <button 
-                className={styles.dismiss} 
-                onClick={onDismiss}
-                aria-label="Dismiss message"
-                type="button"
+  return (
+    <div
+      ref={ref}
+      className={`${callout({ type, outline, highContrast })} ${className || ''}`}
+      style={style}
+      role={getRole()}
+      aria-live={type === 'alert' ? 'assertive' : 'polite'}
+      {...props}
+    >
+      <div className={styles.container}>
+        <div className={styles.messageContainer}>
+          <InfoCircledIcon 
+            className={styles.icon} 
+            aria-hidden="true"
+          />
+          <div className={styles.message}>{children}</div>
+        </div>
+        
+        <div className={styles.actionsContainer}>
+          {action && (
+            <div className={styles.action}>
+              {action}
+            </div>
+          )}
+          {dismissible && (
+            <button 
+              className={styles.dismiss} 
+              onClick={onDismiss}
+              aria-label="Dismiss message"
+              type="button"
+            >
+              <svg 
+                width="12" 
+                height="12" 
+                viewBox="0 0 12 12" 
+                fill="none" 
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+                role="presentation"
               >
-                <svg 
-                  width="12" 
-                  height="12" 
-                  viewBox="0 0 12 12" 
-                  fill="none" 
-                  xmlns="http://www.w3.org/2000/svg"
-                  aria-hidden="true"
-                  role="presentation"
-                >
-                  <path 
-                    fillRule="evenodd" 
-                    clipRule="evenodd" 
-                    d="M9.5066 3.3066C9.73115 3.08205 9.73115 2.71798 9.5066 2.49343C9.28205 2.26887 8.91798 2.26887 8.69343 2.49343L6.00001 5.18684L3.3066 2.49343C3.08205 2.26887 2.71798 2.26887 2.49343 2.49343C2.26887 2.71798 2.26887 3.08205 2.49343 3.3066L5.18684 6.00001L2.49343 8.69343C2.26887 8.91798 2.26887 9.28205 2.49343 9.5066C2.71798 9.73115 3.08205 9.73115 3.3066 9.5066L6.00001 6.81318L8.69343 9.5066C8.91798 9.73115 9.28205 9.73115 9.5066 9.5066C9.73115 9.28205 9.73115 8.91798 9.5066 8.69343L6.81318 6.00001L9.5066 3.3066Z" 
-                    fill="currentColor"
-                  />
-                </svg>
-              </button>
-            )}
-          </div>
+                <path 
+                  fillRule="evenodd" 
+                  clipRule="evenodd" 
+                  d="M9.5066 3.3066C9.73115 3.08205 9.73115 2.71798 9.5066 2.49343C9.28205 2.26887 8.91798 2.26887 8.69343 2.49343L6.00001 5.18684L3.3066 2.49343C3.08205 2.26887 2.71798 2.26887 2.49343 2.49343C2.26887 2.71798 2.26887 3.08205 2.49343 3.3066L5.18684 6.00001L2.49343 8.69343C2.26887 8.91798 2.26887 9.28205 2.49343 9.5066C2.71798 9.73115 3.08205 9.73115 3.3066 9.5066L6.00001 6.81318L8.69343 9.5066C8.91798 9.73115 9.28205 9.73115 9.5066 9.5066C9.73115 9.28205 9.73115 8.91798 9.5066 8.69343L6.81318 6.00001L9.5066 3.3066Z" 
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          )}
         </div>
       </div>
-    );
-  }
-);
+    </div>
+  );
+};
 
 Callout.displayName = 'Callout';

--- a/packages/raystack/v1/components/checkbox/checkbox.tsx
+++ b/packages/raystack/v1/components/checkbox/checkbox.tsx
@@ -1,7 +1,7 @@
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
 import { cva, VariantProps } from "class-variance-authority";
 import clsx from 'clsx';
-import { ComponentPropsWithoutRef, ElementRef, forwardRef } from "react";
+import { ComponentPropsWithoutRef, ComponentRef } from "react";
 
 import styles from "./checkbox.module.css";
 
@@ -55,10 +55,15 @@ export interface CheckboxProps
   onCheckedChange?: (checked: CheckedState) => void;
 }
 
-export const Checkbox = forwardRef<
-  ElementRef<typeof CheckboxPrimitive.Root>,
-  CheckboxProps
->(({ className, disabled, checked, defaultChecked, onCheckedChange, ...props }, forwardedRef) => {
+export const Checkbox = ({ 
+  className, 
+  disabled, 
+  checked, 
+  defaultChecked, 
+  onCheckedChange, 
+  ref, 
+  ...props 
+}: CheckboxProps & { ref?: React.Ref<ComponentRef<typeof CheckboxPrimitive.Root>> }) => {
   const isIndeterminate = checked === 'indeterminate' || defaultChecked === 'indeterminate';
   
   return (
@@ -82,7 +87,7 @@ export const Checkbox = forwardRef<
         }
       }}
       disabled={disabled}
-      ref={forwardedRef}
+      ref={ref}
       {...props}
     >
       <CheckboxPrimitive.Indicator className={styles.indicator}>
@@ -90,6 +95,6 @@ export const Checkbox = forwardRef<
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   );
-});
+};
 
 Checkbox.displayName = "Checkbox";

--- a/packages/raystack/v1/components/checkbox/checkbox.tsx
+++ b/packages/raystack/v1/components/checkbox/checkbox.tsx
@@ -1,43 +1,95 @@
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
-import { CheckIcon } from "@radix-ui/react-icons";
-import { ComponentPropsWithoutRef, ComponentRef } from "react";
+import { cva, VariantProps } from "class-variance-authority";
+import clsx from 'clsx';
+import { ComponentPropsWithoutRef, ElementRef, forwardRef } from "react";
 
 import styles from "./checkbox.module.css";
 
-export interface CheckboxProps extends ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root> {
-  label?: string;
-  error?: boolean;
-  helperText?: string;
-  disabled?: boolean;
+
+const CheckMarkIcon = () => (
+    <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    className={styles.icon}
+    >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M11.9005 4.9671C12.0894 4.6782 12.0083 4.29086 11.7194 4.10197C11.4305 3.91307 11.0432 3.99414 10.8543 4.28304L7.15577 9.93961L5.04542 8.02112C4.79001 7.78893 4.39473 7.80775 4.16254 8.06316C3.93035 8.31857 3.94917 8.71385 4.20458 8.94605L6.85731 11.3576C6.99274 11.4807 7.17532 11.5383 7.35686 11.5151C7.53841 11.492 7.70068 11.3904 7.80084 11.2372L11.9005 4.9671Z"
+      fill="currentColor"
+      />
+  </svg>
+);
+
+const IndeterminateIcon = () => (
+    <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    className={styles.icon}
+    >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M11.5 8.5H4.5C4.22386 8.5 4 8.27614 4 8C4 7.72386 4.22386 7.5 4.5 7.5H11.5C11.7761 7.5 12 7.72386 12 8C12 8.27614 11.7761 8.5 11.5 8.5Z"
+      fill="currentColor"
+      />
+  </svg>
+);
+
+const checkbox = cva(styles.checkbox);
+
+type CheckboxVariants = VariantProps<typeof checkbox>;
+type CheckedState = boolean | 'indeterminate';
+
+export interface CheckboxProps
+  extends Omit<ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>, keyof CheckboxVariants>,
+    CheckboxVariants {
+  checked?: CheckedState;
+  defaultChecked?: CheckedState;
+  onCheckedChange?: (checked: CheckedState) => void;
 }
 
-export const Checkbox = ({ className, label, error, helperText, disabled, ref, ...props }: CheckboxProps & { ref?: React.Ref<ComponentRef<typeof CheckboxPrimitive.Root>> }) => {
+export const Checkbox = forwardRef<
+  ElementRef<typeof CheckboxPrimitive.Root>,
+  CheckboxProps
+>(({ className, disabled, checked, defaultChecked, onCheckedChange, ...props }, forwardedRef) => {
+  const isIndeterminate = checked === 'indeterminate' || defaultChecked === 'indeterminate';
+  
   return (
-    <div className={styles.container}>
-      <div className={styles.wrapper}>
-        <CheckboxPrimitive.Root
-          ref={ref}
-          className={styles.checkbox}
-          disabled={disabled}
-          {...props}
-        >
-          <CheckboxPrimitive.Indicator className={styles.indicator}>
-            <CheckIcon className={styles.icon} />
-          </CheckboxPrimitive.Indicator>
-        </CheckboxPrimitive.Root>
-        {label && (
-          <label className={styles.label} data-disabled={disabled}>
-            {label}
-          </label>
-        )}
-      </div>
-      {helperText && (
-        <span className={`${styles.helperText} ${error ? styles.error : ''}`} data-disabled={disabled}>
-          {helperText}
-        </span>
-      )}
-    </div>
+    <CheckboxPrimitive.Root
+      className={checkbox({ 
+        className: clsx(className, {
+          [styles["checkbox-disabled"]]: disabled,
+          [styles["checkbox-indeterminate"]]: isIndeterminate
+        })
+      })}
+      checked={isIndeterminate || (checked === true)}
+      defaultChecked={defaultChecked === true}
+      onCheckedChange={(value) => {
+        if (onCheckedChange) {
+          // If it's currently indeterminate, next state will be unchecked
+          if (checked === 'indeterminate') {
+            onCheckedChange(false);
+          } else {
+            onCheckedChange(value);
+          }
+        }
+      }}
+      disabled={disabled}
+      ref={forwardedRef}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator className={styles.indicator}>
+        {isIndeterminate ? <IndeterminateIcon /> : <CheckMarkIcon />}
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
   );
-};
+});
 
 Checkbox.displayName = "Checkbox";

--- a/packages/raystack/v1/components/checkbox/checkbox.tsx
+++ b/packages/raystack/v1/components/checkbox/checkbox.tsx
@@ -1,95 +1,51 @@
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
-import { cva, VariantProps } from "class-variance-authority";
-import clsx from 'clsx';
-import { ComponentPropsWithoutRef, ComponentRef, forwardRef } from "react";
+import { CheckIcon } from "@radix-ui/react-icons";
+import { ComponentPropsWithoutRef, ComponentRef } from "react";
 
 import styles from "./checkbox.module.css";
 
-
-const CheckMarkIcon = () => (
-    <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="16"
-    height="16"
-    viewBox="0 0 16 16"
-    fill="none"
-    className={styles.icon}
-    >
-    <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M11.9005 4.9671C12.0894 4.6782 12.0083 4.29086 11.7194 4.10197C11.4305 3.91307 11.0432 3.99414 10.8543 4.28304L7.15577 9.93961L5.04542 8.02112C4.79001 7.78893 4.39473 7.80775 4.16254 8.06316C3.93035 8.31857 3.94917 8.71385 4.20458 8.94605L6.85731 11.3576C6.99274 11.4807 7.17532 11.5383 7.35686 11.5151C7.53841 11.492 7.70068 11.3904 7.80084 11.2372L11.9005 4.9671Z"
-      fill="currentColor"
-      />
-  </svg>
-);
-
-const IndeterminateIcon = () => (
-    <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="16"
-    height="16"
-    viewBox="0 0 16 16"
-    fill="none"
-    className={styles.icon}
-    >
-    <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M11.5 8.5H4.5C4.22386 8.5 4 8.27614 4 8C4 7.72386 4.22386 7.5 4.5 7.5H11.5C11.7761 7.5 12 7.72386 12 8C12 8.27614 11.7761 8.5 11.5 8.5Z"
-      fill="currentColor"
-      />
-  </svg>
-);
-
-const checkbox = cva(styles.checkbox);
-
-type CheckboxVariants = VariantProps<typeof checkbox>;
-type CheckedState = boolean | 'indeterminate';
-
-export interface CheckboxProps
-  extends Omit<ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>, keyof CheckboxVariants>,
-    CheckboxVariants {
-  checked?: CheckedState;
-  defaultChecked?: CheckedState;
-  onCheckedChange?: (checked: CheckedState) => void;
+export interface CheckboxProps extends ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root> {
+  label?: string;
+  error?: boolean;
+  helperText?: string;
+  disabled?: boolean;
 }
 
-export const Checkbox = forwardRef<
-  ComponentRef<typeof CheckboxPrimitive.Root>,
-  CheckboxProps
->(({ className, disabled, checked, defaultChecked, onCheckedChange, ...props }, forwardedRef) => {
-  const isIndeterminate = checked === 'indeterminate' || defaultChecked === 'indeterminate';
-  
+export const Checkbox = ({ 
+  className, 
+  label, 
+  error, 
+  helperText, 
+  disabled,
+  ref,
+  ...props 
+}: CheckboxProps & { ref?: React.Ref<ComponentRef<typeof CheckboxPrimitive.Root>> }) => {
   return (
-    <CheckboxPrimitive.Root
-      className={checkbox({ 
-        className: clsx(className, {
-          [styles["checkbox-disabled"]]: disabled,
-          [styles["checkbox-indeterminate"]]: isIndeterminate
-        })
-      })}
-      checked={isIndeterminate || (checked === true)}
-      defaultChecked={defaultChecked === true}
-      onCheckedChange={(value) => {
-        if (onCheckedChange) {
-          // If it's currently indeterminate, next state will be unchecked
-          if (checked === 'indeterminate') {
-            onCheckedChange(false);
-          } else {
-            onCheckedChange(value);
-          }
-        }
-      }}
-      disabled={disabled}
-      ref={forwardedRef}
-      {...props}
-    >
-      <CheckboxPrimitive.Indicator className={styles.indicator}>
-        {isIndeterminate ? <IndeterminateIcon /> : <CheckMarkIcon />}
-      </CheckboxPrimitive.Indicator>
-    </CheckboxPrimitive.Root>
+    <div className={styles.container}>
+      <div className={styles.wrapper}>
+        <CheckboxPrimitive.Root
+          ref={ref}
+          className={styles.checkbox}
+          disabled={disabled}
+          {...props}
+        >
+          <CheckboxPrimitive.Indicator className={styles.indicator}>
+            <CheckIcon className={styles.icon} />
+          </CheckboxPrimitive.Indicator>
+        </CheckboxPrimitive.Root>
+        {label && (
+          <label className={styles.label} data-disabled={disabled}>
+            {label}
+          </label>
+        )}
+      </div>
+      {helperText && (
+        <span className={`${styles.helperText} ${error ? styles.error : ''}`} data-disabled={disabled}>
+          {helperText}
+        </span>
+      )}
+    </div>
   );
-});
+};
 
 Checkbox.displayName = "Checkbox";

--- a/packages/raystack/v1/components/checkbox/checkbox.tsx
+++ b/packages/raystack/v1/components/checkbox/checkbox.tsx
@@ -11,15 +11,7 @@ export interface CheckboxProps extends ComponentPropsWithoutRef<typeof CheckboxP
   disabled?: boolean;
 }
 
-export const Checkbox = ({ 
-  className, 
-  label, 
-  error, 
-  helperText, 
-  disabled,
-  ref,
-  ...props 
-}: CheckboxProps & { ref?: React.Ref<ComponentRef<typeof CheckboxPrimitive.Root>> }) => {
+export const Checkbox = ({ className, label, error, helperText, disabled, ref, ...props }: CheckboxProps & { ref?: React.Ref<ComponentRef<typeof CheckboxPrimitive.Root>> }) => {
   return (
     <div className={styles.container}>
       <div className={styles.wrapper}>

--- a/packages/raystack/v1/components/checkbox/checkbox.tsx
+++ b/packages/raystack/v1/components/checkbox/checkbox.tsx
@@ -1,7 +1,7 @@
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
 import { cva, VariantProps } from "class-variance-authority";
 import clsx from 'clsx';
-import { ComponentPropsWithoutRef, ElementRef, forwardRef } from "react";
+import { ComponentPropsWithoutRef, ComponentRef, forwardRef } from "react";
 
 import styles from "./checkbox.module.css";
 
@@ -56,7 +56,7 @@ export interface CheckboxProps
 }
 
 export const Checkbox = forwardRef<
-  ElementRef<typeof CheckboxPrimitive.Root>,
+  ComponentRef<typeof CheckboxPrimitive.Root>,
   CheckboxProps
 >(({ className, disabled, checked, defaultChecked, onCheckedChange, ...props }, forwardedRef) => {
   const isIndeterminate = checked === 'indeterminate' || defaultChecked === 'indeterminate';

--- a/packages/raystack/v1/components/dropdown-menu/dropdown-menu.tsx
+++ b/packages/raystack/v1/components/dropdown-menu/dropdown-menu.tsx
@@ -1,12 +1,13 @@
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { cva, VariantProps } from "class-variance-authority";
 import * as React from "react";
+import { ComponentRef } from "react";
 
 import styles from "./dropdown-menu.module.css";
 
 const content = cva(styles.content);
 const DropdownMenuContent = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  ComponentRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> &
     React.PropsWithChildren<VariantProps<typeof content>>
 >(({ className, sideOffset = 4, ...props }, ref) => (
@@ -23,7 +24,7 @@ DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
 const menuitem = cva(styles.menuitem);
 const DropdownMenuItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  ComponentRef<typeof DropdownMenuPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
     leadingIcon?: React.ReactNode;
     trailingIcon?: React.ReactNode;
@@ -43,7 +44,7 @@ DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
 
 const label = cva(styles.label);
 const DropdownMenuLabel = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  ComponentRef<typeof DropdownMenuPrimitive.Label>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> &
     React.PropsWithChildren<VariantProps<typeof label>>
 >(({ className, ...props }, ref) => (
@@ -57,7 +58,7 @@ DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
 
 const separator = cva(styles.separator);
 const DropdownMenuSeparator = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  ComponentRef<typeof DropdownMenuPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator> &
     React.PropsWithChildren<VariantProps<typeof separator>>
 >(({ className, ...props }, ref) => (
@@ -71,7 +72,7 @@ DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
 
 const menugroup = cva(styles.menugroup);
 const DropdownMenuGroup = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Group>,
+  ComponentRef<typeof DropdownMenuPrimitive.Group>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Group> &
     React.PropsWithChildren<VariantProps<typeof menugroup>>
 >(({ className, ...props }, ref) => (

--- a/packages/raystack/v1/components/dropdown-menu/dropdown-menu.tsx
+++ b/packages/raystack/v1/components/dropdown-menu/dropdown-menu.tsx
@@ -1,119 +1,115 @@
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
-import { cva, VariantProps } from "class-variance-authority";
-import * as React from "react";
-import { ComponentRef } from "react";
+import { ComponentPropsWithoutRef, ComponentRef, ElementType, ReactNode } from "react";
+import { ChevronRightIcon } from "@radix-ui/react-icons";
 
 import styles from "./dropdown-menu.module.css";
 
-const content = cva(styles.content);
-const DropdownMenuContent = React.forwardRef<
-  ComponentRef<typeof DropdownMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> &
-    React.PropsWithChildren<VariantProps<typeof content>>
->(({ className, sideOffset = 4, ...props }, ref) => (
-  <DropdownMenuPrimitive.Portal>
-    <DropdownMenuPrimitive.Content
-      ref={ref}
-      sideOffset={sideOffset}
-      className={content({ className })}
-      {...props}
-    />
-  </DropdownMenuPrimitive.Portal>
-));
-DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
-
-const menuitem = cva(styles.menuitem);
-const DropdownMenuItem = React.forwardRef<
-  ComponentRef<typeof DropdownMenuPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
-    leadingIcon?: React.ReactNode;
-    trailingIcon?: React.ReactNode;
-  } & React.PropsWithChildren<VariantProps<typeof menuitem>>
->(({ className, children, leadingIcon, trailingIcon, ...props }, ref) => (
-  <DropdownMenuPrimitive.Item
-    ref={ref}
-    className={menuitem({ className })}
-    {...props}
-  >
-    {leadingIcon && <span className={styles.leadingIcon}>{leadingIcon}</span>}
-    {children}
-    {trailingIcon && <span className={styles.trailingIcon}>{trailingIcon}</span>}
-  </DropdownMenuPrimitive.Item>
-));
-DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
-
-const label = cva(styles.label);
-const DropdownMenuLabel = React.forwardRef<
-  ComponentRef<typeof DropdownMenuPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> &
-    React.PropsWithChildren<VariantProps<typeof label>>
->(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.Label
-    ref={ref}
-    className={label({ className })}
-    {...props}
-  />
-));
-DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
-
-const separator = cva(styles.separator);
-const DropdownMenuSeparator = React.forwardRef<
-  ComponentRef<typeof DropdownMenuPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator> &
-    React.PropsWithChildren<VariantProps<typeof separator>>
->(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.Separator
-    ref={ref}
-    className={separator({ className })}
-    {...props}
-  />
-));
-DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
-
-const menugroup = cva(styles.menugroup);
-const DropdownMenuGroup = React.forwardRef<
-  ComponentRef<typeof DropdownMenuPrimitive.Group>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Group> &
-    React.PropsWithChildren<VariantProps<typeof menugroup>>
->(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.Group
-    ref={ref}
-    className={menugroup({ className })}
-    {...props}
-  />
-));
-DropdownMenuGroup.displayName = DropdownMenuPrimitive.Group.displayName;
-
-const emptystate = cva(styles.empty);
-const DropdownMenuEmptyState = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & {
-    children: React.ReactNode;
-  }
->(({ className, children, ...props }, ref) => (
-  <div ref={ref} className={emptystate({ className })} {...props}>
-    {children}
-  </div>
-));
-DropdownMenuEmptyState.displayName = "DropdownMenuEmptyState";
-
-type DropdownMenuProps = React.ComponentProps<
-  typeof DropdownMenuPrimitive.Root
->;
-export function RootDropdownMenu({ children, ...props }: DropdownMenuProps) {
-  return (
-    <DropdownMenuPrimitive.Root {...props}>
-      {children}
-    </DropdownMenuPrimitive.Root>
-  );
+export interface DropdownMenuProps extends ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Root> {
+  trigger: ReactNode;
 }
 
-export const DropdownMenu = Object.assign(DropdownMenuPrimitive.Root, {
-  Trigger: DropdownMenuPrimitive.Trigger,
-  Content: DropdownMenuContent,
-  Item: DropdownMenuItem,
-  Group: DropdownMenuGroup,
-  Label: DropdownMenuLabel,
-  Separator: DropdownMenuSeparator,
-  EmptyState: DropdownMenuEmptyState
-});
+export const DropdownMenu = ({ 
+  children, 
+  trigger,
+  ref,
+  ...props 
+}: DropdownMenuProps & { ref?: React.Ref<ComponentRef<typeof DropdownMenuPrimitive.Root>> }) => {
+  return (
+    <DropdownMenuPrimitive.Root {...props}>
+      <DropdownMenuPrimitive.Trigger className={styles.trigger} asChild>
+        {trigger}
+      </DropdownMenuPrimitive.Trigger>
+
+      <DropdownMenuPrimitive.Portal>
+        <DropdownMenuPrimitive.Content
+          ref={ref}
+          className={styles.content}
+          sideOffset={5}
+          align="start"
+        >
+          {children}
+        </DropdownMenuPrimitive.Content>
+      </DropdownMenuPrimitive.Portal>
+    </DropdownMenuPrimitive.Root>
+  );
+};
+
+export interface DropdownMenuItemProps extends ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> {
+  icon?: ReactNode;
+  shortcut?: string;
+  as?: ElementType;
+}
+
+export const DropdownMenuItem = ({ 
+  className, 
+  children, 
+  icon, 
+  shortcut, 
+  as: Component = "div",
+  ref,
+  ...props 
+}: DropdownMenuItemProps & { ref?: React.Ref<ComponentRef<typeof DropdownMenuPrimitive.Item>> }) => {
+  return (
+    <DropdownMenuPrimitive.Item
+      ref={ref}
+      className={styles.item}
+      {...props}
+      asChild
+    >
+      <Component className={className}>
+        {icon && <span className={styles.icon}>{icon}</span>}
+        {children}
+        {shortcut && <span className={styles.shortcut}>{shortcut}</span>}
+      </Component>
+    </DropdownMenuPrimitive.Item>
+  );
+};
+
+export interface DropdownMenuSubProps extends ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Sub> {
+  trigger: ReactNode;
+}
+
+export const DropdownMenuSub = ({ 
+  children, 
+  trigger,
+  ref,
+  ...props 
+}: DropdownMenuSubProps & { ref?: React.Ref<ComponentRef<typeof DropdownMenuPrimitive.Sub>> }) => {
+  return (
+    <DropdownMenuPrimitive.Sub {...props}>
+      <DropdownMenuPrimitive.SubTrigger className={styles.subTrigger}>
+        {trigger}
+        <ChevronRightIcon className={styles.subTriggerIcon} />
+      </DropdownMenuPrimitive.SubTrigger>
+
+      <DropdownMenuPrimitive.Portal>
+        <DropdownMenuPrimitive.SubContent
+          ref={ref}
+          className={styles.subContent}
+          sideOffset={2}
+          alignOffset={-5}
+        >
+          {children}
+        </DropdownMenuPrimitive.SubContent>
+      </DropdownMenuPrimitive.Portal>
+    </DropdownMenuPrimitive.Sub>
+  );
+};
+
+export const DropdownMenuSeparator = ({ 
+  className,
+  ref,
+  ...props 
+}: ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator> & 
+   { ref?: React.Ref<ComponentRef<typeof DropdownMenuPrimitive.Separator>> }) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={styles.separator}
+    {...props}
+  />
+);
+
+DropdownMenu.displayName = "DropdownMenu";
+DropdownMenuItem.displayName = "DropdownMenuItem";
+DropdownMenuSub.displayName = "DropdownMenuSub";
+DropdownMenuSeparator.displayName = "DropdownMenuSeparator";

--- a/packages/raystack/v1/components/dropdown-menu/dropdown-menu.tsx
+++ b/packages/raystack/v1/components/dropdown-menu/dropdown-menu.tsx
@@ -1,115 +1,127 @@
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
-import { ComponentPropsWithoutRef, ComponentRef, ElementType, ReactNode } from "react";
-import { ChevronRightIcon } from "@radix-ui/react-icons";
+import { cva, VariantProps } from "class-variance-authority";
+import * as React from "react";
 
 import styles from "./dropdown-menu.module.css";
+import { ComponentRef } from "react";
 
-export interface DropdownMenuProps extends ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Root> {
-  trigger: ReactNode;
-}
-
-export const DropdownMenu = ({ 
-  children, 
-  trigger,
-  ref,
+const content = cva(styles.content);
+const DropdownMenuContent = ({ 
+  className, 
+  sideOffset = 4, 
+  ref, 
   ...props 
-}: DropdownMenuProps & { ref?: React.Ref<ComponentRef<typeof DropdownMenuPrimitive.Root>> }) => {
-  return (
-    <DropdownMenuPrimitive.Root {...props}>
-      <DropdownMenuPrimitive.Trigger className={styles.trigger} asChild>
-        {trigger}
-      </DropdownMenuPrimitive.Trigger>
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> & 
+   React.PropsWithChildren<VariantProps<typeof content>> & 
+   { ref?: React.Ref<ComponentRef<typeof DropdownMenuPrimitive.Content>> }) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={content({ className })}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+);
 
-      <DropdownMenuPrimitive.Portal>
-        <DropdownMenuPrimitive.Content
-          ref={ref}
-          className={styles.content}
-          sideOffset={5}
-          align="start"
-        >
-          {children}
-        </DropdownMenuPrimitive.Content>
-      </DropdownMenuPrimitive.Portal>
-    </DropdownMenuPrimitive.Root>
-  );
-};
-
-export interface DropdownMenuItemProps extends ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> {
-  icon?: ReactNode;
-  shortcut?: string;
-  as?: ElementType;
-}
-
-export const DropdownMenuItem = ({ 
+const menuitem = cva(styles.menuitem);
+const DropdownMenuItem = ({ 
   className, 
   children, 
-  icon, 
-  shortcut, 
-  as: Component = "div",
-  ref,
+  leadingIcon, 
+  trailingIcon, 
+  ref, 
   ...props 
-}: DropdownMenuItemProps & { ref?: React.Ref<ComponentRef<typeof DropdownMenuPrimitive.Item>> }) => {
-  return (
-    <DropdownMenuPrimitive.Item
-      ref={ref}
-      className={styles.item}
-      {...props}
-      asChild
-    >
-      <Component className={className}>
-        {icon && <span className={styles.icon}>{icon}</span>}
-        {children}
-        {shortcut && <span className={styles.shortcut}>{shortcut}</span>}
-      </Component>
-    </DropdownMenuPrimitive.Item>
-  );
-};
-
-export interface DropdownMenuSubProps extends ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Sub> {
-  trigger: ReactNode;
-}
-
-export const DropdownMenuSub = ({ 
-  children, 
-  trigger,
-  ref,
-  ...props 
-}: DropdownMenuSubProps & { ref?: React.Ref<ComponentRef<typeof DropdownMenuPrimitive.Sub>> }) => {
-  return (
-    <DropdownMenuPrimitive.Sub {...props}>
-      <DropdownMenuPrimitive.SubTrigger className={styles.subTrigger}>
-        {trigger}
-        <ChevronRightIcon className={styles.subTriggerIcon} />
-      </DropdownMenuPrimitive.SubTrigger>
-
-      <DropdownMenuPrimitive.Portal>
-        <DropdownMenuPrimitive.SubContent
-          ref={ref}
-          className={styles.subContent}
-          sideOffset={2}
-          alignOffset={-5}
-        >
-          {children}
-        </DropdownMenuPrimitive.SubContent>
-      </DropdownMenuPrimitive.Portal>
-    </DropdownMenuPrimitive.Sub>
-  );
-};
-
-export const DropdownMenuSeparator = ({ 
-  className,
-  ref,
-  ...props 
-}: ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator> & 
-   { ref?: React.Ref<ComponentRef<typeof DropdownMenuPrimitive.Separator>> }) => (
-  <DropdownMenuPrimitive.Separator
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & 
+   { leadingIcon?: React.ReactNode; trailingIcon?: React.ReactNode; } & 
+   React.PropsWithChildren<VariantProps<typeof menuitem>> & 
+   { ref?: React.Ref<ComponentRef<typeof DropdownMenuPrimitive.Item>> }) => (
+  <DropdownMenuPrimitive.Item
     ref={ref}
-    className={styles.separator}
+    className={menuitem({ className })}
+    {...props}
+  >
+    {leadingIcon && <span className={styles.leadingIcon}>{leadingIcon}</span>}
+    {children}
+    {trailingIcon && <span className={styles.trailingIcon}>{trailingIcon}</span>}
+  </DropdownMenuPrimitive.Item>
+);
+
+const label = cva(styles.label);
+const DropdownMenuLabel = ({ 
+  className, 
+  ref, 
+  ...props 
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & 
+   React.PropsWithChildren<VariantProps<typeof label>> & 
+   { ref?: React.Ref<ComponentRef<typeof DropdownMenuPrimitive.Label>> }) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={label({ className })}
     {...props}
   />
 );
 
-DropdownMenu.displayName = "DropdownMenu";
-DropdownMenuItem.displayName = "DropdownMenuItem";
-DropdownMenuSub.displayName = "DropdownMenuSub";
-DropdownMenuSeparator.displayName = "DropdownMenuSeparator";
+const separator = cva(styles.separator);
+const DropdownMenuSeparator = ({ 
+  className, 
+  ref, 
+  ...props 
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator> & 
+   React.PropsWithChildren<VariantProps<typeof separator>> & 
+   { ref?: React.Ref<ComponentRef<typeof DropdownMenuPrimitive.Separator>> }) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={separator({ className })}
+    {...props}
+  />
+);
+
+const menugroup = cva(styles.menugroup);
+const DropdownMenuGroup = ({ 
+  className, 
+  ref, 
+  ...props 
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Group> & 
+   React.PropsWithChildren<VariantProps<typeof menugroup>> & 
+   { ref?: React.Ref<ComponentRef<typeof DropdownMenuPrimitive.Group>> }) => (
+  <DropdownMenuPrimitive.Group
+    ref={ref}
+    className={menugroup({ className })}
+    {...props}
+  />
+);
+
+const emptystate = cva(styles.empty);
+const DropdownMenuEmptyState = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & {
+    children: React.ReactNode;
+  }
+>(({ className, children, ...props }, ref) => (
+  <div ref={ref} className={emptystate({ className })} {...props}>
+    {children}
+  </div>
+));
+DropdownMenuEmptyState.displayName = "DropdownMenuEmptyState";
+
+type DropdownMenuProps = React.ComponentProps<
+  typeof DropdownMenuPrimitive.Root
+>;
+export function RootDropdownMenu({ children, ...props }: DropdownMenuProps) {
+  return (
+    <DropdownMenuPrimitive.Root {...props}>
+      {children}
+    </DropdownMenuPrimitive.Root>
+  );
+}
+
+export const DropdownMenu = Object.assign(DropdownMenuPrimitive.Root, {
+  Trigger: DropdownMenuPrimitive.Trigger,
+  Content: DropdownMenuContent,
+  Item: DropdownMenuItem,
+  Group: DropdownMenuGroup,
+  Label: DropdownMenuLabel,
+  Separator: DropdownMenuSeparator,
+  EmptyState: DropdownMenuEmptyState
+});

--- a/packages/raystack/v1/components/dropdown-menu/dropdown-menu.tsx
+++ b/packages/raystack/v1/components/dropdown-menu/dropdown-menu.tsx
@@ -93,16 +93,19 @@ const DropdownMenuGroup = ({
 );
 
 const emptystate = cva(styles.empty);
-const DropdownMenuEmptyState = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & {
-    children: React.ReactNode;
-  }
->(({ className, children, ...props }, ref) => (
+const DropdownMenuEmptyState = ({ 
+  className, 
+  children, 
+  ref,
+  ...props 
+}: React.HTMLAttributes<HTMLDivElement> & {
+  children: React.ReactNode;
+  ref?: React.Ref<ComponentRef<"div">>;
+}) => (
   <div ref={ref} className={emptystate({ className })} {...props}>
     {children}
   </div>
-));
+);
 DropdownMenuEmptyState.displayName = "DropdownMenuEmptyState";
 
 type DropdownMenuProps = React.ComponentProps<

--- a/packages/raystack/v1/components/flex/flex.tsx
+++ b/packages/raystack/v1/components/flex/flex.tsx
@@ -1,5 +1,5 @@
 import { cva, VariantProps } from "class-variance-authority";
-import { forwardRef, HTMLAttributes, PropsWithChildren } from "react";
+import { HTMLAttributes, PropsWithChildren, ComponentRef } from "react";
 
 import styles from "./flex.module.css";
 
@@ -48,19 +48,24 @@ const flex = cva(styles.flex, {
 type BoxProps = PropsWithChildren<VariantProps<typeof flex>> &
   HTMLAttributes<HTMLDivElement>;
 
-export const Flex = forwardRef<HTMLDivElement, BoxProps>(
-  (
-    { children, direction, align, justify, wrap, gap, className, ...props },
-    ref
-  ) => {
-    return (
-      <div
-        className={flex({ direction, align, justify, wrap, gap, className })}
-        {...props}
-        ref={ref}
-      >
-        {children}
-      </div>
-    );
-  }
-);
+export const Flex = ({ 
+  children, 
+  direction, 
+  align, 
+  justify, 
+  wrap, 
+  gap, 
+  className,
+  ref,
+  ...props 
+}: BoxProps & { ref?: React.Ref<ComponentRef<'div'>> }) => {
+  return (
+    <div
+      className={flex({ direction, align, justify, wrap, gap, className })}
+      {...props}
+      ref={ref}
+    >
+      {children}
+    </div>
+  );
+};

--- a/packages/raystack/v1/components/icon-button/icon-button.tsx
+++ b/packages/raystack/v1/components/icon-button/icon-button.tsx
@@ -1,5 +1,5 @@
 import { cva, VariantProps } from "class-variance-authority";
-import { ComponentPropsWithoutRef, ComponentRef, forwardRef } from "react";
+import { ComponentPropsWithoutRef, ComponentRef } from "react";
 
 import styles from './icon-button.module.css';
 
@@ -24,22 +24,28 @@ export interface IconButtonProps
   'aria-label'?: string;
 }
 
-export const IconButton = forwardRef<ComponentRef<"button">, IconButtonProps>(
-  ({ className, size, disabled, children, 'aria-label': ariaLabel, ...props }, ref) => (
-    <button
-      ref={ref}
-      className={iconButton({ size, className })}
-      disabled={disabled}
-      type="button"
-      aria-label={ariaLabel}
-      aria-disabled={disabled}
-      {...props}
-    >
-      <div aria-hidden="true">
-        {children}
-      </div>
-    </button>
-  )
+export const IconButton = ({ 
+  className, 
+  size, 
+  disabled, 
+  children, 
+  'aria-label': ariaLabel,
+  ref,
+  ...props 
+}: IconButtonProps & { ref?: React.Ref<ComponentRef<"button">> }) => (
+  <button
+    ref={ref}
+    className={iconButton({ size, className })}
+    disabled={disabled}
+    type="button"
+    aria-label={ariaLabel}
+    aria-disabled={disabled}
+    {...props}
+  >
+    <div aria-hidden="true">
+      {children}
+    </div>
+  </button>
 );
 
 IconButton.displayName = 'IconButton';

--- a/packages/raystack/v1/components/icon-button/icon-button.tsx
+++ b/packages/raystack/v1/components/icon-button/icon-button.tsx
@@ -1,5 +1,5 @@
 import { cva, VariantProps } from "class-variance-authority";
-import { ComponentPropsWithoutRef, ElementRef, forwardRef } from "react";
+import { ComponentPropsWithoutRef, ComponentRef, forwardRef } from "react";
 
 import styles from './icon-button.module.css';
 
@@ -24,7 +24,7 @@ export interface IconButtonProps
   'aria-label'?: string;
 }
 
-export const IconButton = forwardRef<ElementRef<"button">, IconButtonProps>(
+export const IconButton = forwardRef<ComponentRef<"button">, IconButtonProps>(
   ({ className, size, disabled, children, 'aria-label': ariaLabel, ...props }, ref) => (
     <button
       ref={ref}

--- a/packages/raystack/v1/components/input-field/input-field.tsx
+++ b/packages/raystack/v1/components/input-field/input-field.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { ComponentPropsWithoutRef, ElementRef, forwardRef, ReactNode, useEffect, useRef, useState } from "react";
+import { ComponentPropsWithoutRef, ComponentRef, forwardRef, ReactNode, useEffect, useRef, useState } from "react";
 
 import styles from "./input-field.module.css";
 
@@ -20,7 +20,7 @@ export interface InputFieldProps
   width?: string | number;
 }
 
-export const InputField = forwardRef<ElementRef<"input">, InputFieldProps>(
+export const InputField = forwardRef<ComponentRef<"input">, InputFieldProps>(
   ({
     className,
     disabled,

--- a/packages/raystack/v1/components/input-field/input-field.tsx
+++ b/packages/raystack/v1/components/input-field/input-field.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { ComponentPropsWithoutRef, ComponentRef, forwardRef, ReactNode, useEffect, useRef, useState } from "react";
+import { ComponentPropsWithoutRef, ComponentRef, ReactNode, useEffect, useRef, useState } from "react";
 
 import styles from "./input-field.module.css";
 
@@ -20,88 +20,87 @@ export interface InputFieldProps
   width?: string | number;
 }
 
-export const InputField = forwardRef<ComponentRef<"input">, InputFieldProps>(
-  ({
-    className,
-    disabled,
-    label,
-    helperText,
-    placeholder,
-    error,
-    leadingIcon,
-    trailingIcon,
-    optional,
-    prefix,
-    suffix,
-    width,
-    ...props
-  }, ref) => {
-    const prefixRef = useRef<HTMLSpanElement>(null);
-    const suffixRef = useRef<HTMLSpanElement>(null);
-    const [prefixWidth, setPrefixWidth] = useState(0);
-    const [suffixWidth, setSuffixWidth] = useState(0);
+export const InputField = ({ 
+  className,
+  disabled,
+  label,
+  helperText,
+  placeholder,
+  error,
+  leadingIcon,
+  trailingIcon,
+  optional,
+  prefix,
+  suffix,
+  width,
+  ref,
+  ...props 
+}: InputFieldProps & { ref?: React.Ref<ComponentRef<"input">> }) => {
+  const prefixRef = useRef<HTMLSpanElement>(null);
+  const suffixRef = useRef<HTMLSpanElement>(null);
+  const [prefixWidth, setPrefixWidth] = useState(0);
+  const [suffixWidth, setSuffixWidth] = useState(0);
 
-    useEffect(() => {
-      if (prefixRef.current && prefix) {
-        const width = prefixRef.current.getBoundingClientRect().width;
-        setPrefixWidth(width);
-      }
-    }, [prefix]);
+  useEffect(() => {
+    if (prefixRef.current && prefix) {
+      const width = prefixRef.current.getBoundingClientRect().width;
+      setPrefixWidth(width);
+    }
+  }, [prefix]);
 
-    useEffect(() => {
-      if (suffixRef.current && suffix) {
-        const width = suffixRef.current.getBoundingClientRect().width;
-        setSuffixWidth(width);
-      }
-    }, [suffix]);
+  useEffect(() => {
+    if (suffixRef.current && suffix) {
+      const width = suffixRef.current.getBoundingClientRect().width;
+      setSuffixWidth(width);
+    }
+  }, [suffix]);
 
-    return (
-      <div className={styles.container} style={{ width: width || '100%' }}>
-        {label && (
-          <label className={clsx(styles.label, disabled && styles["label-disabled"])}>
-            {label}
-            {optional && <span className={styles.optional}>(optional)</span>}
-          </label>
-        )}
-        <div className={styles.inputWrapper}>
-          {leadingIcon && <span className={styles.leadingIcon}>{leadingIcon}</span>}
-          {prefix && <span ref={prefixRef} className={styles.prefix}>{prefix}</span>}
-          <input
-            ref={ref}
-            style={{
-              paddingLeft: prefix ? `calc(${prefixWidth}px + var(--rs-space-3))` : undefined,
-              paddingRight: suffix ? `calc(${suffixWidth}px + var(--rs-space-3))` : undefined,
-            }}
-            className={clsx(
-              styles.inputField,
-              leadingIcon && styles.hasLeadingIcon,
-              trailingIcon && styles.hasTrailingIcon,
-              error && styles["input-error"],
-              disabled && styles["input-disabled"],
-              className
-            )}
-            aria-invalid={!!error}
-            placeholder={placeholder}
-            disabled={disabled}
-            {...props}
-          />
-          {suffix && <span ref={suffixRef} className={styles.suffix}>{suffix}</span>}
-          {trailingIcon && <span className={styles.trailingIcon}>{trailingIcon}</span>}
-        </div>
-        {(error || helperText) && (
-          <span 
-            className={clsx(
-              styles.helperText, 
-              error && styles["helperText-error"],
-              disabled && styles["helperText-disabled"]
-            )}
-          >
-            {error || helperText}
-          </span>
-        )}
+  return (
+    <div className={styles.container} style={{ width: width || '100%' }}>
+      {label && (
+        <label className={clsx(styles.label, disabled && styles["label-disabled"])}>
+          {label}
+          {optional && <span className={styles.optional}>(optional)</span>}
+        </label>
+      )}
+      <div className={styles.inputWrapper}>
+        {leadingIcon && <span className={styles.leadingIcon}>{leadingIcon}</span>}
+        {prefix && <span ref={prefixRef} className={styles.prefix}>{prefix}</span>}
+        <input
+          ref={ref}
+          style={{
+            paddingLeft: prefix ? `calc(${prefixWidth}px + var(--rs-space-3))` : undefined,
+            paddingRight: suffix ? `calc(${suffixWidth}px + var(--rs-space-3))` : undefined,
+          }}
+          className={clsx(
+            styles.inputField,
+            leadingIcon && styles.hasLeadingIcon,
+            trailingIcon && styles.hasTrailingIcon,
+            error && styles["input-error"],
+            disabled && styles["input-disabled"],
+            className
+          )}
+          aria-invalid={!!error}
+          placeholder={placeholder}
+          disabled={disabled}
+          {...props}
+        />
+        {suffix && <span ref={suffixRef} className={styles.suffix}>{suffix}</span>}
+        {trailingIcon && <span className={styles.trailingIcon}>{trailingIcon}</span>}
       </div>
-    );
-  }
-);
+      {(error || helperText) && (
+        <span 
+          className={clsx(
+            styles.helperText, 
+            error && styles["helperText-error"],
+            disabled && styles["helperText-disabled"]
+          )}
+        >
+          {error || helperText}
+        </span>
+      )}
+    </div>
+  );
+};
 
 InputField.displayName = "InputField";

--- a/packages/raystack/v1/components/radio/radio.tsx
+++ b/packages/raystack/v1/components/radio/radio.tsx
@@ -1,11 +1,11 @@
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
 import { cva, VariantProps } from "class-variance-authority";
-import { ComponentPropsWithoutRef, ElementRef, forwardRef } from "react";
+import { ComponentPropsWithoutRef, ComponentRef, forwardRef } from "react";
 
 import styles from "./radio.module.css";
 
 const RadioRoot = forwardRef<
-  ElementRef<typeof RadioGroupPrimitive.Root>,
+  ComponentRef<typeof RadioGroupPrimitive.Root>,
   ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
 >(({ className, ...props }, ref) => (
   <RadioGroupPrimitive.Root ref={ref} className={styles.radio} {...props} />
@@ -17,7 +17,7 @@ export interface RadioItemProps
   extends ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item> {}
 
 export const RadioItem = forwardRef<
-  ElementRef<typeof RadioGroupPrimitive.Item>,
+  ComponentRef<typeof RadioGroupPrimitive.Item>,
   RadioItemProps
 >(({ className, ...props }, forwardedRef) => (
   <RadioGroupPrimitive.Item
@@ -35,7 +35,7 @@ export interface thumbProps
     VariantProps<typeof indicator> {}
 
 const Indicator = forwardRef<
-  ElementRef<typeof RadioGroupPrimitive.Indicator>,
+  ComponentRef<typeof RadioGroupPrimitive.Indicator>,
   thumbProps
 >(({ className, ...props }, ref) => (
   <RadioGroupPrimitive.Indicator

--- a/packages/raystack/v1/components/radio/radio.tsx
+++ b/packages/raystack/v1/components/radio/radio.tsx
@@ -1,49 +1,55 @@
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
 import { cva, VariantProps } from "class-variance-authority";
-import { ComponentPropsWithoutRef, ComponentRef, forwardRef } from "react";
+import { ComponentPropsWithoutRef, ComponentRef } from "react";
 
 import styles from "./radio.module.css";
 
-const RadioRoot = forwardRef<
-  ComponentRef<typeof RadioGroupPrimitive.Root>,
-  ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
->(({ className, ...props }, ref) => (
+const RadioRoot = ({ 
+  className,
+  ref,
+  ...props 
+}: ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root> & 
+   { ref?: React.Ref<ComponentRef<typeof RadioGroupPrimitive.Root>> }) => (
   <RadioGroupPrimitive.Root ref={ref} className={styles.radio} {...props} />
-));
+);
 
 const radioItem = cva(styles.radioitem);
 
 export interface RadioItemProps
   extends ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item> {}
 
-export const RadioItem = forwardRef<
-  ComponentRef<typeof RadioGroupPrimitive.Item>,
-  RadioItemProps
->(({ className, ...props }, forwardedRef) => (
+export const RadioItem = ({ 
+  className,
+  ref,
+  ...props 
+}: RadioItemProps & 
+   { ref?: React.Ref<ComponentRef<typeof RadioGroupPrimitive.Item>> }) => (
   <RadioGroupPrimitive.Item
     {...props}
-    ref={forwardedRef}
+    ref={ref}
     className={radioItem({ className })}
   >
     <Indicator />
   </RadioGroupPrimitive.Item>
-));
+);
 
 const indicator = cva(styles.indicator);
 export interface thumbProps
   extends ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Indicator>,
     VariantProps<typeof indicator> {}
 
-const Indicator = forwardRef<
-  ComponentRef<typeof RadioGroupPrimitive.Indicator>,
-  thumbProps
->(({ className, ...props }, ref) => (
+const Indicator = ({ 
+  className,
+  ref,
+  ...props 
+}: thumbProps & 
+   { ref?: React.Ref<ComponentRef<typeof RadioGroupPrimitive.Indicator>> }) => (
   <RadioGroupPrimitive.Indicator
     ref={ref}
     className={indicator({ className })}
     {...props}
   />
-));
+);
 
 Indicator.displayName = RadioGroupPrimitive.Indicator.displayName;
 

--- a/packages/raystack/v1/components/slider/slider.tsx
+++ b/packages/raystack/v1/components/slider/slider.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { type ComponentPropsWithoutRef } from 'react';
+import { type ComponentPropsWithoutRef, ComponentRef } from 'react';
 import * as RadixSlider from '@radix-ui/react-slider';
 import { cva, type VariantProps } from 'class-variance-authority';
 import styles from './slider.module.css';
@@ -31,73 +31,72 @@ export interface SliderProps
   'aria-valuetext'?: string;
 }
 
-export const Slider = React.forwardRef<React.ElementRef<typeof RadixSlider.Root>, SliderProps>(
-  ({ 
-    className, 
-    variant = 'single', 
-    value, 
-    defaultValue, 
-    min = 0, 
-    max = 100, 
-    step = 1, 
-    label, 
-    onChange,
-    'aria-label': ariaLabel,
-    'aria-valuetext': ariaValueText,
-    ...props 
-  }, ref) => {
-    const isRange = variant === 'range';
-    const defaultVal = isRange 
-      ? (defaultValue as [number, number]) || [min, max] 
-      : [defaultValue as number || min];
-    const currentValue = value ? (isRange ? value as [number, number] : [value as number]) : defaultVal;
+export const Slider = ({ 
+  className, 
+  variant = 'single', 
+  value, 
+  defaultValue, 
+  min = 0, 
+  max = 100, 
+  step = 1, 
+  label, 
+  onChange,
+  'aria-label': ariaLabel,
+  'aria-valuetext': ariaValueText,
+  ref,
+  ...props 
+}: SliderProps & { ref?: React.Ref<ComponentRef<typeof RadixSlider.Root>> }) => {
+  const isRange = variant === 'range';
+  const defaultVal = isRange 
+    ? (defaultValue as [number, number]) || [min, max] 
+    : [defaultValue as number || min];
+  const currentValue = value ? (isRange ? value as [number, number] : [value as number]) : defaultVal;
 
-    const getLabel = (index: number) => {
-      if (!label) return undefined;
-      if (typeof label === 'string') return label;
-      return label[index];
-    };
+  const getLabel = (index: number) => {
+    if (!label) return undefined;
+    if (typeof label === 'string') return label;
+    return label[index];
+  };
 
-    const getAriaValueText = (index: number) => {
-      if (ariaValueText) return ariaValueText;
-      const labelText = getLabel(index);
-      const val = currentValue[index];
-      return labelText ? `${labelText}: ${val}` : `${val}`;
-    };
+  const getAriaValueText = (index: number) => {
+    if (ariaValueText) return ariaValueText;
+    const labelText = getLabel(index);
+    const val = currentValue[index];
+    return labelText ? `${labelText}: ${val}` : `${val}`;
+  };
 
-    return (
-      <RadixSlider.Root
-        ref={ref}
-        className={`${slider({ variant })} ${className || ''}`}
-        value={value ? currentValue : undefined}
-        defaultValue={defaultVal}
-        min={min}
-        max={max}
-        step={step}
-        onValueChange={(val) => onChange?.(isRange ? val as [number, number] : val[0])}
-        aria-label={ariaLabel || (isRange ? 'Range slider' : 'Slider')}
-        {...props}
-      >
-        <RadixSlider.Track className={styles.track}>
-          <RadixSlider.Range className={styles.range} />
-        </RadixSlider.Track>
-        {defaultVal.map((_, i) => (
-          <RadixSlider.Thumb 
-            key={i} 
-            className={styles.thumb} 
-            asChild
-            aria-label={getLabel(i) || `Thumb ${i + 1}`}
-            aria-valuetext={getAriaValueText(i)}
-          >
-            <div>
-              <ThumbIcon />
-              {getLabel(i) && <div className={styles.label}>{getLabel(i)}</div>}
-            </div>
-          </RadixSlider.Thumb>
-        ))}
-      </RadixSlider.Root>
-    );
-  }
-);
+  return (
+    <RadixSlider.Root
+      ref={ref}
+      className={`${slider({ variant })} ${className || ''}`}
+      value={value ? currentValue : undefined}
+      defaultValue={defaultVal}
+      min={min}
+      max={max}
+      step={step}
+      onValueChange={(val) => onChange?.(isRange ? val as [number, number] : val[0])}
+      aria-label={ariaLabel || (isRange ? 'Range slider' : 'Slider')}
+      {...props}
+    >
+      <RadixSlider.Track className={styles.track}>
+        <RadixSlider.Range className={styles.range} />
+      </RadixSlider.Track>
+      {defaultVal.map((_, i) => (
+        <RadixSlider.Thumb 
+          key={i} 
+          className={styles.thumb} 
+          asChild
+          aria-label={getLabel(i) || `Thumb ${i + 1}`}
+          aria-valuetext={getAriaValueText(i)}
+        >
+          <div>
+            <ThumbIcon />
+            {getLabel(i) && <div className={styles.label}>{getLabel(i)}</div>}
+          </div>
+        </RadixSlider.Thumb>
+      ))}
+    </RadixSlider.Root>
+  );
+};
 
 Slider.displayName = 'Slider';

--- a/packages/raystack/v1/components/slider/slider.tsx
+++ b/packages/raystack/v1/components/slider/slider.tsx
@@ -31,7 +31,7 @@ export interface SliderProps
   'aria-valuetext'?: string;
 }
 
-export const Slider = ({ 
+export const Slider = React.forwardRef<ComponentRef<typeof RadixSlider.Root>, SliderProps>(({ 
   className, 
   variant = 'single', 
   value, 
@@ -97,6 +97,6 @@ export const Slider = ({
       ))}
     </RadixSlider.Root>
   );
-};
+});
 
 Slider.displayName = 'Slider';

--- a/packages/raystack/v1/components/slider/slider.tsx
+++ b/packages/raystack/v1/components/slider/slider.tsx
@@ -31,21 +31,7 @@ export interface SliderProps
   'aria-valuetext'?: string;
 }
 
-export const Slider = React.forwardRef<ComponentRef<typeof RadixSlider.Root>, SliderProps>(({ 
-  className, 
-  variant = 'single', 
-  value, 
-  defaultValue, 
-  min = 0, 
-  max = 100, 
-  step = 1, 
-  label, 
-  onChange,
-  'aria-label': ariaLabel,
-  'aria-valuetext': ariaValueText,
-  ref,
-  ...props 
-}: SliderProps & { ref?: React.Ref<ComponentRef<typeof RadixSlider.Root>> }) => {
+export const Slider = ({ className, variant = 'single', value, defaultValue, min = 0, max = 100, step = 1, label, onChange, 'aria-label': ariaLabel, 'aria-valuetext': ariaValueText, ref, ...props }: SliderProps & { ref?: React.Ref<ComponentRef<typeof RadixSlider.Root>> }) => {
   const isRange = variant === 'range';
   const defaultVal = isRange 
     ? (defaultValue as [number, number]) || [min, max] 
@@ -97,6 +83,6 @@ export const Slider = React.forwardRef<ComponentRef<typeof RadixSlider.Root>, Sl
       ))}
     </RadixSlider.Root>
   );
-});
+};
 
 Slider.displayName = 'Slider';

--- a/packages/raystack/v1/components/spinner/spinner.tsx
+++ b/packages/raystack/v1/components/spinner/spinner.tsx
@@ -1,5 +1,5 @@
 import { cva, VariantProps } from "class-variance-authority";
-import { ComponentPropsWithoutRef, ElementRef, forwardRef } from "react";
+import { ComponentPropsWithoutRef, ComponentRef, forwardRef } from "react";
 
 import styles from './spinner.module.css';
 
@@ -31,7 +31,7 @@ export interface SpinnerProps
   color?: "default" | "inverted";
 }
 
-export const Spinner = forwardRef<ElementRef<"div">, SpinnerProps>(
+export const Spinner = forwardRef<ComponentRef<"div">, SpinnerProps>(
   ({ className, size, color, ...props }, ref) => (
     <div
       ref={ref}

--- a/packages/raystack/v1/components/spinner/spinner.tsx
+++ b/packages/raystack/v1/components/spinner/spinner.tsx
@@ -1,5 +1,5 @@
 import { cva, VariantProps } from "class-variance-authority";
-import { ComponentPropsWithoutRef, ComponentRef, forwardRef } from "react";
+import { ComponentPropsWithoutRef, ComponentRef } from "react";
 
 import styles from './spinner.module.css';
 
@@ -31,20 +31,24 @@ export interface SpinnerProps
   color?: "default" | "inverted";
 }
 
-export const Spinner = forwardRef<ComponentRef<"div">, SpinnerProps>(
-  ({ className, size, color, ...props }, ref) => (
-    <div
-      ref={ref}
-      className={spinner({ size, color, className })}
-      role="status"
-      aria-hidden="true"
-      {...props}
-    >
-      {[...Array(8)].map((_, index) => (
-        <div key={index} className={styles.pole} />
-      ))}
-    </div>
-  )
+export const Spinner = ({ 
+  className,
+  size,
+  color,
+  ref,
+  ...props 
+}: SpinnerProps & { ref?: React.Ref<ComponentRef<"div">> }) => (
+  <div
+    ref={ref}
+    className={spinner({ size, color, className })}
+    role="status"
+    aria-hidden="true"
+    {...props}
+  >
+    {[...Array(8)].map((_, index) => (
+      <div key={index} className={styles.pole} />
+    ))}
+  </div>
 );
 
 Spinner.displayName = 'Spinner';

--- a/packages/raystack/v1/components/switch/switch.tsx
+++ b/packages/raystack/v1/components/switch/switch.tsx
@@ -1,6 +1,6 @@
 import * as SwitchPrimitive from "@radix-ui/react-switch";
 import { cva } from "class-variance-authority";
-import { ComponentPropsWithoutRef, ComponentRef, forwardRef } from "react";
+import { ComponentPropsWithoutRef, ComponentRef } from "react";
 import styles from "./switch.module.css";
 
 const switchVariants = cva(styles.switch);
@@ -11,13 +11,16 @@ export interface SwitchProps
   required?: boolean;
 }
 
-export const Switch = forwardRef<
-  ComponentRef<typeof SwitchPrimitive.Root>,
-  SwitchProps
->(({ className, disabled, required, ...props }, forwardedRef) => (
+export const Switch = ({ 
+  className,
+  disabled,
+  required,
+  ref,
+  ...props 
+}: SwitchProps & { ref?: React.Ref<ComponentRef<typeof SwitchPrimitive.Root>> }) => (
   <SwitchPrimitive.Root
     {...props}
-    ref={forwardedRef}
+    ref={ref}
     disabled={disabled}
     required={required}
     className={switchVariants({ className })}
@@ -25,22 +28,23 @@ export const Switch = forwardRef<
   >
     <SwitchThumb />
   </SwitchPrimitive.Root>
-));
+);
 
 const thumbVariants = cva(styles.thumb);
 
 interface ThumbProps
   extends ComponentPropsWithoutRef<typeof SwitchPrimitive.Thumb> {}
 
-const SwitchThumb = forwardRef<
-  ComponentRef<typeof SwitchPrimitive.Thumb>,
-  ThumbProps
->(({ className, ...props }, ref) => (
+const SwitchThumb = ({ 
+  className,
+  ref,
+  ...props 
+}: ThumbProps & { ref?: React.Ref<ComponentRef<typeof SwitchPrimitive.Thumb>> }) => (
   <SwitchPrimitive.Thumb
     ref={ref}
     className={thumbVariants({ className })}
     {...props}
   />
-));
+);
 
 Switch.displayName = "Switch";

--- a/packages/raystack/v1/components/switch/switch.tsx
+++ b/packages/raystack/v1/components/switch/switch.tsx
@@ -1,6 +1,6 @@
 import * as SwitchPrimitive from "@radix-ui/react-switch";
 import { cva } from "class-variance-authority";
-import { ComponentPropsWithoutRef, ElementRef, forwardRef } from "react";
+import { ComponentPropsWithoutRef, ComponentRef, forwardRef } from "react";
 import styles from "./switch.module.css";
 
 const switchVariants = cva(styles.switch);
@@ -12,7 +12,7 @@ export interface SwitchProps
 }
 
 export const Switch = forwardRef<
-  ElementRef<typeof SwitchPrimitive.Root>,
+  ComponentRef<typeof SwitchPrimitive.Root>,
   SwitchProps
 >(({ className, disabled, required, ...props }, forwardedRef) => (
   <SwitchPrimitive.Root
@@ -33,7 +33,7 @@ interface ThumbProps
   extends ComponentPropsWithoutRef<typeof SwitchPrimitive.Thumb> {}
 
 const SwitchThumb = forwardRef<
-  ElementRef<typeof SwitchPrimitive.Thumb>,
+  ComponentRef<typeof SwitchPrimitive.Thumb>,
   ThumbProps
 >(({ className, ...props }, ref) => (
   <SwitchPrimitive.Thumb

--- a/packages/raystack/v1/components/tabs/tabs.tsx
+++ b/packages/raystack/v1/components/tabs/tabs.tsx
@@ -19,7 +19,6 @@ interface TabsRootProps
 interface TabsTriggerProps
   extends ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger> {
   icon?: ReactNode;
-  disabled?: boolean;
 }
 
 const TabsRoot = ({ 

--- a/packages/raystack/v1/components/tabs/tabs.tsx
+++ b/packages/raystack/v1/components/tabs/tabs.tsx
@@ -1,6 +1,6 @@
 import * as TabsPrimitive from "@radix-ui/react-tabs";
 import { cva, type VariantProps } from "class-variance-authority";
-import { ComponentPropsWithoutRef, ComponentRef, forwardRef, ReactNode } from "react";
+import { ComponentPropsWithoutRef, ComponentRef, ReactNode } from "react";
 
 import styles from "./tabs.module.css";
 
@@ -22,33 +22,42 @@ interface TabsTriggerProps
   disabled?: boolean;
 }
 
-const TabsRoot = forwardRef<ComponentRef<typeof TabsPrimitive.Root>, TabsRootProps>(
-  ({ className, 'aria-label': ariaLabel, ...props }, ref) => (
-    <TabsPrimitive.Root
-      ref={ref}
-      className={root({ className })}
-      aria-label={ariaLabel || "Tabs"}
-      {...props}
-    />
-  )
+const TabsRoot = ({ 
+  className,
+  'aria-label': ariaLabel,
+  ref,
+  ...props 
+}: TabsRootProps & { ref?: React.Ref<ComponentRef<typeof TabsPrimitive.Root>> }) => (
+  <TabsPrimitive.Root
+    ref={ref}
+    className={root({ className })}
+    aria-label={ariaLabel || "Tabs"}
+    {...props}
+  />
 );
 
-const TabsList = forwardRef<
-  ComponentRef<typeof TabsPrimitive.List>,
-  ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
+const TabsList = ({ 
+  className,
+  ref,
+  ...props 
+}: ComponentPropsWithoutRef<typeof TabsPrimitive.List> & 
+   { ref?: React.Ref<ComponentRef<typeof TabsPrimitive.List>> }) => (
   <TabsPrimitive.List
     ref={ref}
     role="tablist"
     className={list({ className })}
     {...props}
   />
-));
+);
 
-const TabsTrigger = forwardRef<
-  ComponentRef<typeof TabsPrimitive.Trigger>,
-  TabsTriggerProps
->(({ className, icon, children, disabled, ...props }, ref) => (
+const TabsTrigger = ({ 
+  className,
+  icon,
+  children,
+  disabled,
+  ref,
+  ...props 
+}: TabsTriggerProps & { ref?: React.Ref<ComponentRef<typeof TabsPrimitive.Trigger>> }) => (
   <TabsPrimitive.Trigger
     ref={ref}
     className={trigger({ className })}
@@ -59,19 +68,21 @@ const TabsTrigger = forwardRef<
     {icon && <span className={styles["trigger-icon"]}>{icon}</span>}
     {children}
   </TabsPrimitive.Trigger>
-));
+);
 
-const TabsContent = forwardRef<
-  ComponentRef<typeof TabsPrimitive.Content>,
-  ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->(({ className, ...props }, ref) => (
+const TabsContent = ({ 
+  className,
+  ref,
+  ...props 
+}: ComponentPropsWithoutRef<typeof TabsPrimitive.Content> & 
+   { ref?: React.Ref<ComponentRef<typeof TabsPrimitive.Content>> }) => (
   <TabsPrimitive.Content
     ref={ref}
     role="tabpanel"
     className={content({ className })}
     {...props}
   />
-));
+);
 
 TabsRoot.displayName = TabsPrimitive.Root.displayName;
 TabsList.displayName = TabsPrimitive.List.displayName;

--- a/packages/raystack/v1/components/tabs/tabs.tsx
+++ b/packages/raystack/v1/components/tabs/tabs.tsx
@@ -1,6 +1,6 @@
 import * as TabsPrimitive from "@radix-ui/react-tabs";
 import { cva, type VariantProps } from "class-variance-authority";
-import { ComponentPropsWithoutRef, ElementRef, forwardRef, ReactNode } from "react";
+import { ComponentPropsWithoutRef, ComponentRef, forwardRef, ReactNode } from "react";
 
 import styles from "./tabs.module.css";
 
@@ -22,7 +22,7 @@ interface TabsTriggerProps
   disabled?: boolean;
 }
 
-const TabsRoot = forwardRef<ElementRef<typeof TabsPrimitive.Root>, TabsRootProps>(
+const TabsRoot = forwardRef<ComponentRef<typeof TabsPrimitive.Root>, TabsRootProps>(
   ({ className, 'aria-label': ariaLabel, ...props }, ref) => (
     <TabsPrimitive.Root
       ref={ref}
@@ -34,7 +34,7 @@ const TabsRoot = forwardRef<ElementRef<typeof TabsPrimitive.Root>, TabsRootProps
 );
 
 const TabsList = forwardRef<
-  ElementRef<typeof TabsPrimitive.List>,
+  ComponentRef<typeof TabsPrimitive.List>,
   ComponentPropsWithoutRef<typeof TabsPrimitive.List>
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.List
@@ -46,7 +46,7 @@ const TabsList = forwardRef<
 ));
 
 const TabsTrigger = forwardRef<
-  ElementRef<typeof TabsPrimitive.Trigger>,
+  ComponentRef<typeof TabsPrimitive.Trigger>,
   TabsTriggerProps
 >(({ className, icon, children, disabled, ...props }, ref) => (
   <TabsPrimitive.Trigger
@@ -62,7 +62,7 @@ const TabsTrigger = forwardRef<
 ));
 
 const TabsContent = forwardRef<
-  ElementRef<typeof TabsPrimitive.Content>,
+  ComponentRef<typeof TabsPrimitive.Content>,
   ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.Content

--- a/packages/raystack/v1/components/text-area/text-area.tsx
+++ b/packages/raystack/v1/components/text-area/text-area.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { HTMLAttributes, PropsWithChildren } from "react";
+import { ComponentRef, HTMLAttributes, PropsWithChildren } from "react";
 import { VariantProps, cva, cx } from "class-variance-authority";
 import { InfoCircledIcon } from "@radix-ui/react-icons";
 
@@ -25,33 +25,41 @@ export interface TextAreaProps extends PropsWithChildren<VariantProps<typeof tex
   onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
 }
 
-const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
-  ({ className, style, label, required, helperText, error, width = "200px", value, onChange, ...props }, ref) => {
-    return (
-      <div className={styles.container} style={{ width }}>
-        {label && (
-          <div className={styles.labelContainer}>
-            <label className={styles.label}>
-              {label}
-            </label>
-            {!required && <span className={styles.optional}>(optional)</span>}
-            {/* {tooltip && <span className={styles.helpIcon}><InfoCircledIcon /></span>} */}
-          </div>
-        )}
-        <textarea
-          className={cx(textArea({ error }), className)}
-          ref={ref}
-          value={value}
-          onChange={onChange}
-          required={required}
-          {...props}
-        />
-        {helperText && <span className={styles.helperText}>{helperText}</span>}
-      </div>
-    );
-  }
-);
+export const TextArea = ({ 
+  className, 
+  style, 
+  label, 
+  required, 
+  helperText, 
+  error, 
+  width = "200px", 
+  value, 
+  onChange,
+  ref,
+  ...props 
+}: TextAreaProps & { ref?: React.Ref<ComponentRef<"textarea">> }) => {
+  return (
+    <div className={styles.container} style={{ width }}>
+      {label && (
+        <div className={styles.labelContainer}>
+          <label className={styles.label}>
+            {label}
+          </label>
+          {!required && <span className={styles.optional}>(optional)</span>}
+          {/* {tooltip && <span className={styles.helpIcon}><InfoCircledIcon /></span>} */}
+        </div>
+      )}
+      <textarea
+        className={cx(textArea({ error }), className)}
+        ref={ref}
+        value={value}
+        onChange={onChange}
+        required={required}
+        {...props}
+      />
+      {helperText && <span className={styles.helperText}>{helperText}</span>}
+    </div>
+  );
+};
 
 TextArea.displayName = "TextArea";
-
-export { TextArea };

--- a/packages/raystack/v1/components/tooltip/tooltip.tsx
+++ b/packages/raystack/v1/components/tooltip/tooltip.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ComponentRef } from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { cva, VariantProps } from "class-variance-authority";
 import { Text } from "../text";
@@ -33,17 +33,7 @@ interface TooltipProps extends VariantProps<typeof tooltip> {
   asChild?: boolean;
 }
 
-export const Tooltip: React.FC<TooltipProps> = ({
-  children,
-  message,
-  disabled,
-  side = "top",
-  className,
-  delayDuration = 200,
-  skipDelayDuration = 200,
-  'aria-label': ariaLabel,
-  asChild = true,
-}) => {
+export const Tooltip = ({ children, message, delayDuration = 700, skipDelayDuration, disabled, asChild, 'aria-label': ariaLabel, side, className, ref, ...props }: TooltipProps & { ref?: React.Ref<ComponentRef<typeof TooltipPrimitive.Root>> }) => {
   return disabled ? (
     children
   ) : (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,16 +43,16 @@ importers:
         version: 2.3.0(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.12))(esbuild@0.23.0))
       '@radix-ui/react-icons':
         specifier: ^1.3.0
-        version: 1.3.0(react@18.2.0)
+        version: 1.3.0(react@19.0.0)
       '@radix-ui/react-slot':
         specifier: ^1.0.1
-        version: 1.0.2(@types/react@18.2.12)(react@18.2.0)
+        version: 1.0.2(@types/react@19.0.6)(react@19.0.0)
       '@raystack/apsara':
         specifier: workspace:*
         version: link:../../packages/raystack
       '@tanstack/react-table':
         specifier: ^8.9.2
-        version: 8.9.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 8.9.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       copy-to-clipboard:
         specifier: ^3.3.3
         version: 3.3.3
@@ -61,16 +61,22 @@ importers:
         version: 1.11.11
       framer-motion:
         specifier: ^10.12.16
-        version: 10.12.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 10.12.16(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       next:
         specifier: 14.2.5
-        version: 14.2.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 14.2.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react:
+        specifier: ^19.0.0
+        version: 19.0.0
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.0.0(react@19.0.0)
       react-live:
         specifier: ^4.1.6
-        version: 4.1.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 4.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-loading-skeleton:
         specifier: ^3.4.0
-        version: 3.4.0(react@18.2.0)
+        version: 3.4.0(react@19.0.0)
       tslib:
         specifier: ^2.5.0
         version: 2.5.0
@@ -83,7 +89,7 @@ importers:
         version: 0.8.0
       '@radix-ui/react-scroll-area':
         specifier: ^1.0.3
-        version: 1.0.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 1.0.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@types/mapbox__rehype-prism':
         specifier: ^0.8.0
         version: 0.8.0
@@ -91,11 +97,11 @@ importers:
         specifier: ^18.15.11
         version: 18.15.11
       '@types/react':
-        specifier: ^18.0.28
-        version: 18.2.12
+        specifier: ^19.0.0
+        version: 19.0.6
       '@types/react-dom':
-        specifier: ^18.0.11
-        version: 18.0.11
+        specifier: ^19.0.0
+        version: 19.0.3(@types/react@19.0.6)
       class-variance-authority:
         specifier: ^0.6.0
         version: 0.6.0(typescript@4.7.2)
@@ -119,13 +125,7 @@ importers:
         version: 2.2.1
       prism-react-renderer:
         specifier: ^2.3.1
-        version: 2.3.1(react@18.2.0)
-      react:
-        specifier: ^18.2.0
-        version: 18.2.0
-      react-dom:
-        specifier: ^18.2.0
-        version: 18.2.0(react@18.2.0)
+        version: 2.3.1(react@19.0.0)
       reading-time:
         specifier: ^1.5.0
         version: 1.5.0
@@ -171,61 +171,61 @@ importers:
     dependencies:
       '@radix-ui/react-accordion':
         specifier: ^1.1.2
-        version: 1.1.2(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-avatar':
         specifier: ^1.0.3
-        version: 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-checkbox':
         specifier: ^1.0.4
-        version: 1.0.4(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 1.0.4(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-dialog':
         specifier: ^1.0.4
-        version: 1.0.4(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 1.0.4(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.0.5
-        version: 2.0.5(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 2.0.5(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-icons':
         specifier: ^1.3.0
-        version: 1.3.0(react@18.2.0)
+        version: 1.3.0(react@19.0.0)
       '@radix-ui/react-popover':
         specifier: ^1.0.6
-        version: 1.0.6(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 1.0.6(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-radio-group':
         specifier: ^1.1.3
-        version: 1.1.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 1.1.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-scroll-area':
         specifier: ^1.1.0
-        version: 1.1.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 1.1.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-select':
         specifier: ^2.1.1
-        version: 2.1.1(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 2.1.1(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-separator':
         specifier: ^1.0.3
-        version: 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-slider':
         specifier: ^1.2.2
-        version: 1.2.2(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 1.2.2(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-slot':
         specifier: ^1.0.2
-        version: 1.0.2(@types/react@18.2.12)(react@18.2.0)
+        version: 1.0.2(@types/react@19.0.6)(react@19.0.0)
       '@radix-ui/react-switch':
         specifier: ^1.0.3
-        version: 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-tabs':
         specifier: ^1.0.4
-        version: 1.0.4(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 1.0.4(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-toggle-group':
         specifier: ^1.0.4
-        version: 1.0.4(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 1.0.4(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-tooltip':
         specifier: ^1.0.7
-        version: 1.0.7(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 1.0.7(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@tanstack/match-sorter-utils':
         specifier: ^8.8.4
         version: 8.8.4
       '@tanstack/react-table':
         specifier: ^8.9.2
-        version: 8.9.2(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 8.9.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@tanstack/table-core':
         specifier: ^8.9.2
         version: 8.9.2
@@ -237,25 +237,25 @@ importers:
         version: 2.1.1
       cmdk:
         specifier: ^0.2.0
-        version: 0.2.0(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 0.2.0(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       dayjs:
         specifier: ^1.11.11
         version: 1.11.11
       react-day-picker:
         specifier: ^9.0.4
-        version: 9.0.4(react@18.2.0)
+        version: 9.0.4(react@19.0.0)
       react-loading-skeleton:
         specifier: ^3.4.0
-        version: 3.4.0(react@18.2.0)
+        version: 3.4.0(react@19.0.0)
       react-select:
         specifier: ^5.7.7
-        version: 5.7.7(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 5.7.7(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       sonner:
         specifier: ^1.5.0
-        version: 1.5.0(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 1.5.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       usehooks-ts:
         specifier: ^2.9.1
-        version: 2.9.1(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 2.9.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: ^25.0.2
@@ -274,7 +274,7 @@ importers:
         version: 6.6.3
       '@testing-library/react':
         specifier: ^16.1.0
-        version: 16.1.0(@testing-library/dom@10.4.0)(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 16.1.0(@testing-library/dom@10.4.0)(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.5.2(@testing-library/dom@10.4.0)
@@ -282,11 +282,11 @@ importers:
         specifier: ^29.5.14
         version: 29.5.14
       '@types/react':
-        specifier: ^18.2.12
-        version: 18.2.12
+        specifier: ^19.0.0
+        version: 19.0.6
       '@types/react-select':
         specifier: ^5.0.1
-        version: 5.0.1(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 5.0.1(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       eslint-config-custom:
         specifier: workspace:*
         version: link:../eslint-config-custom
@@ -318,8 +318,11 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(postcss@8.4.24)
       react:
-        specifier: ^18.2.0
-        version: 18.2.0
+        specifier: ^19.0.0
+        version: 19.0.0
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.0.0(react@19.0.0)
       release-it:
         specifier: ^16.2.1
         version: 16.2.1(typescript@5.4.3)
@@ -2880,11 +2883,10 @@ packages:
   '@types/prismjs@1.26.4':
     resolution: {integrity: sha512-rlAnzkW2sZOjbqZ743IHUhFcvzaGbqijwOu8QZnZCjfQzBqFE3s4lOTJEsxikImav9uzz/42I+O7YUs1mWgMlg==}
 
-  '@types/prop-types@15.7.12':
-    resolution: {integrity: sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==}
-
-  '@types/react-dom@18.0.11':
-    resolution: {integrity: sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==}
+  '@types/react-dom@19.0.3':
+    resolution: {integrity: sha512-0Knk+HJiMP/qOZgMyNFamlIjw9OFCsyC2ZbigmEEyXXixgre6IQpm/4V+r3qH4GC1JPvRJKInw+on2rV6YZLeA==}
+    peerDependencies:
+      '@types/react': ^19.0.0
 
   '@types/react-select@5.0.1':
     resolution: {integrity: sha512-h5Im0AP0dr4AVeHtrcvQrLV+gmPa7SA0AGdxl2jOhtwiE6KgXBFSogWw8az32/nusE6AQHlCOHQWjP1S/+oMWA==}
@@ -2893,8 +2895,8 @@ packages:
   '@types/react-transition-group@4.4.10':
     resolution: {integrity: sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==}
 
-  '@types/react@18.2.12':
-    resolution: {integrity: sha512-ndmBMLCgn38v3SntMeoJaIrO6tGHYKMEBohCUmw8HoLLQdRMOIGXfeYaBTLe2lsFaSB3MOK1VXscYFnmLtTSmw==}
+  '@types/react@19.0.6':
+    resolution: {integrity: sha512-gIlMztcTeDgXCUj0vCBOqEuSEhX//63fW9SZtCJ+agxoQTOklwDfiEMlTWn4mR/C/UK5VHlpwsCsOyf7/hc4lw==}
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -2904,9 +2906,6 @@ packages:
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
-
-  '@types/scheduler@0.23.0':
-    resolution: {integrity: sha512-YIoDCTH3Af6XM5VuwGG/QL/CJqga1Zm3NkU3HZ4ZHK2fRMPYP1VczsTUqtsf43PH/iJNVlPHAo2oWX7BSdB2Hw==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -7224,15 +7223,10 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
 
-  react-dom@18.2.0:
-    resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
+  react-dom@19.0.0:
+    resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
     peerDependencies:
-      react: ^18.2.0
-
-  react-dom@18.3.1:
-    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
-    peerDependencies:
-      react: ^18.3.1
+      react: ^19.0.0
 
   react-error-overlay@6.0.9:
     resolution: {integrity: sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==}
@@ -7324,8 +7318,8 @@ packages:
       react: '>=16.6.0'
       react-dom: '>=16.6.0'
 
-  react@18.2.0:
-    resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
+  react@19.0.0:
+    resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
     engines: {node: '>=0.10.0'}
 
   read-cache@1.0.0:
@@ -7596,8 +7590,8 @@ packages:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
 
-  scheduler@0.23.2:
-    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+  scheduler@0.25.0:
+    resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
 
   schema-utils@3.3.0:
     resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
@@ -9107,19 +9101,19 @@ snapshots:
 
   '@emotion/memoize@0.8.1': {}
 
-  '@emotion/react@11.11.4(@types/react@18.2.12)(react@18.2.0)':
+  '@emotion/react@11.11.4(@types/react@19.0.6)(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@emotion/babel-plugin': 11.11.0
       '@emotion/cache': 11.11.0
       '@emotion/serialize': 1.1.4
-      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)
+      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@19.0.0)
       '@emotion/utils': 1.2.1
       '@emotion/weak-memoize': 0.3.1
       hoist-non-react-statics: 3.3.2
-      react: 18.2.0
+      react: 19.0.0
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
     transitivePeerDependencies:
       - supports-color
 
@@ -9135,9 +9129,9 @@ snapshots:
 
   '@emotion/unitless@0.8.1': {}
 
-  '@emotion/use-insertion-effect-with-fallbacks@1.0.1(react@18.2.0)':
+  '@emotion/use-insertion-effect-with-fallbacks@1.0.1(react@19.0.0)':
     dependencies:
-      react: 18.2.0
+      react: 19.0.0
 
   '@emotion/utils@1.2.1': {}
 
@@ -9252,11 +9246,11 @@ snapshots:
       '@floating-ui/core': 1.6.4
       '@floating-ui/utils': 0.2.4
 
-  '@floating-ui/react-dom@2.1.1(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@floating-ui/react-dom@2.1.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@floating-ui/dom': 1.6.7
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   '@floating-ui/utils@0.2.4': {}
 
@@ -9835,7 +9829,7 @@ snapshots:
       '@parcel/source-map': 2.1.1
       '@parcel/types': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
       '@parcel/utils': 2.12.0
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
       abortcontroller-polyfill: 1.7.5
       base-x: 3.0.10
       browserslist: 4.24.3
@@ -9900,7 +9894,7 @@ snapshots:
       '@parcel/types': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
       '@parcel/utils': 2.12.0
       '@parcel/watcher': 2.4.1
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -10062,7 +10056,7 @@ snapshots:
       '@parcel/node-resolver-core': 3.3.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))
       '@parcel/types': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
       '@parcel/utils': 2.12.0
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
       '@swc/core': 1.6.13(@swc/helpers@0.5.12)
       semver: 7.6.3
     transitivePeerDependencies:
@@ -10391,7 +10385,7 @@ snapshots:
       '@parcel/fs': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
       '@parcel/package-manager': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
       '@parcel/source-map': 2.1.1
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
       utility-types: 3.11.0
     transitivePeerDependencies:
       - '@parcel/core'
@@ -10499,7 +10493,7 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.4.1
       '@parcel/watcher-win32-x64': 2.4.1
 
-  '@parcel/workers@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))':
+  '@parcel/workers@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)':
     dependencies:
       '@parcel/core': 2.12.0(@swc/helpers@0.5.12)
       '@parcel/diagnostic': 2.12.0
@@ -10508,6 +10502,8 @@ snapshots:
       '@parcel/types': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
       '@parcel/utils': 2.12.0
       nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@swc/helpers'
 
   '@parcel/workers@2.9.2(@parcel/core@2.12.0(@swc/helpers@0.5.12))':
     dependencies:
@@ -10562,986 +10558,978 @@ snapshots:
 
   '@radix-ui/primitive@1.1.1': {}
 
-  '@radix-ui/react-accordion@1.1.2(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-accordion@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-collapsible': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-id': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-collapsible': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-collection': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-direction': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-arrow@1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-arrow@1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-arrow@1.1.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-arrow@1.1.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-avatar@1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@babel/runtime': 7.24.8
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
-    optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
-
-  '@radix-ui/react-checkbox@1.0.4(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-avatar@1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-previous': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-size': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-collapsible@1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-checkbox@1.0.4(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-id': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-previous': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-size': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-collection@1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-collapsible@1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-collection@1.1.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-context': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-slot': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
-    optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
-
-  '@radix-ui/react-collection@1.1.1(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-context': 1.1.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-slot': 1.1.1(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
-    optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
-
-  '@radix-ui/react-compose-refs@1.0.0(react@18.2.0)':
+  '@radix-ui/react-collection@1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      react: 18.2.0
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-compose-refs@1.0.1(@types/react@18.2.12)(react@18.2.0)':
+  '@radix-ui/react-collection@1.1.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
+
+  '@radix-ui/react-collection@1.1.1(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot': 1.1.1(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
+
+  '@radix-ui/react-compose-refs@1.0.0(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      react: 18.2.0
-    optionalDependencies:
-      '@types/react': 18.2.12
+      react: 19.0.0
 
-  '@radix-ui/react-compose-refs@1.1.0(@types/react@18.2.12)(react@18.2.0)':
-    dependencies:
-      react: 18.2.0
-    optionalDependencies:
-      '@types/react': 18.2.12
-
-  '@radix-ui/react-compose-refs@1.1.1(@types/react@18.2.12)(react@18.2.0)':
-    dependencies:
-      react: 18.2.0
-    optionalDependencies:
-      '@types/react': 18.2.12
-
-  '@radix-ui/react-context@1.0.0(react@18.2.0)':
+  '@radix-ui/react-compose-refs@1.0.1(@types/react@19.0.6)(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      react: 18.2.0
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.6
 
-  '@radix-ui/react-context@1.0.1(@types/react@18.2.12)(react@18.2.0)':
+  '@radix-ui/react-compose-refs@1.1.0(@types/react@19.0.6)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.6
+
+  '@radix-ui/react-compose-refs@1.1.1(@types/react@19.0.6)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.6
+
+  '@radix-ui/react-context@1.0.0(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      react: 18.2.0
-    optionalDependencies:
-      '@types/react': 18.2.12
+      react: 19.0.0
 
-  '@radix-ui/react-context@1.1.0(@types/react@18.2.12)(react@18.2.0)':
+  '@radix-ui/react-context@1.0.1(@types/react@19.0.6)(react@19.0.0)':
     dependencies:
-      react: 18.2.0
+      '@babel/runtime': 7.24.8
+      react: 19.0.0
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  '@radix-ui/react-context@1.1.1(@types/react@18.2.12)(react@18.2.0)':
+  '@radix-ui/react-context@1.1.0(@types/react@19.0.6)(react@19.0.0)':
     dependencies:
-      react: 18.2.0
+      react: 19.0.0
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  '@radix-ui/react-dialog@1.0.0(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-context@1.1.1(@types/react@19.0.6)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.6
+
+  '@radix-ui/react-dialog@1.0.0(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@radix-ui/primitive': 1.0.0
-      '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
-      '@radix-ui/react-context': 1.0.0(react@18.2.0)
-      '@radix-ui/react-dismissable-layer': 1.0.0(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-focus-guards': 1.0.0(react@18.2.0)
-      '@radix-ui/react-focus-scope': 1.0.0(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-id': 1.0.0(react@18.2.0)
-      '@radix-ui/react-portal': 1.0.0(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-presence': 1.0.0(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.0(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-slot': 1.0.0(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.0.0(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.0(react@19.0.0)
+      '@radix-ui/react-context': 1.0.0(react@19.0.0)
+      '@radix-ui/react-dismissable-layer': 1.0.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-focus-guards': 1.0.0(react@19.0.0)
+      '@radix-ui/react-focus-scope': 1.0.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-id': 1.0.0(react@19.0.0)
+      '@radix-ui/react-portal': 1.0.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-presence': 1.0.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot': 1.0.0(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.0.0(react@19.0.0)
       aria-hidden: 1.2.4
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
-      react-remove-scroll: 2.5.4(@types/react@18.2.12)(react@18.2.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      react-remove-scroll: 2.5.4(@types/react@19.0.6)(react@19.0.0)
     transitivePeerDependencies:
       - '@types/react'
 
-  '@radix-ui/react-dialog@1.0.4(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-dialog@1.0.4(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-dismissable-layer': 1.0.4(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-focus-scope': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-id': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-portal': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.12)(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-dismissable-layer': 1.0.4(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-focus-scope': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-portal': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@19.0.6)(react@19.0.0)
       aria-hidden: 1.2.4
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
-      react-remove-scroll: 2.5.5(@types/react@18.2.12)(react@18.2.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      react-remove-scroll: 2.5.5(@types/react@19.0.6)(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-direction@1.0.0(react@18.2.0)':
+  '@radix-ui/react-direction@1.0.0(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      react: 18.2.0
+      react: 19.0.0
 
-  '@radix-ui/react-direction@1.0.1(@types/react@18.2.12)(react@18.2.0)':
+  '@radix-ui/react-direction@1.0.1(@types/react@19.0.6)(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      react: 18.2.0
+      react: 19.0.0
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  '@radix-ui/react-direction@1.1.0(@types/react@18.2.12)(react@18.2.0)':
+  '@radix-ui/react-direction@1.1.0(@types/react@19.0.6)(react@19.0.0)':
     dependencies:
-      react: 18.2.0
+      react: 19.0.0
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  '@radix-ui/react-dismissable-layer@1.0.0(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-dismissable-layer@1.0.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@radix-ui/primitive': 1.0.0
-      '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.0(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.0(react@18.2.0)
-      '@radix-ui/react-use-escape-keydown': 1.0.0(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.0(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.0.0(react@19.0.0)
+      '@radix-ui/react-use-escape-keydown': 1.0.0(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
-  '@radix-ui/react-dismissable-layer@1.0.4(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-dismissable-layer@1.0.4(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-escape-keydown': 1.0.3(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-escape-keydown': 1.0.3(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-dismissable-layer@1.0.5(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-dismissable-layer@1.0.5(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-escape-keydown': 1.0.3(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-escape-keydown': 1.0.3(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-dismissable-layer@1.1.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-dismissable-layer@1.1.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.0
-      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-escape-keydown': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-dropdown-menu@2.0.5(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-dropdown-menu@2.0.5(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-id': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-menu': 2.0.5(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-menu': 2.0.5(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-focus-guards@1.0.0(react@18.2.0)':
+  '@radix-ui/react-focus-guards@1.0.0(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      react: 18.2.0
+      react: 19.0.0
 
-  '@radix-ui/react-focus-guards@1.0.1(@types/react@18.2.12)(react@18.2.0)':
+  '@radix-ui/react-focus-guards@1.0.1(@types/react@19.0.6)(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      react: 18.2.0
+      react: 19.0.0
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  '@radix-ui/react-focus-guards@1.1.0(@types/react@18.2.12)(react@18.2.0)':
+  '@radix-ui/react-focus-guards@1.1.0(@types/react@19.0.6)(react@19.0.0)':
     dependencies:
-      react: 18.2.0
+      react: 19.0.0
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  '@radix-ui/react-focus-scope@1.0.0(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-focus-scope@1.0.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.0(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.0(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.0(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.0.0(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
-  '@radix-ui/react-focus-scope@1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-focus-scope@1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-focus-scope@1.1.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-focus-scope@1.1.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-icons@1.3.0(react@18.2.0)':
+  '@radix-ui/react-icons@1.3.0(react@19.0.0)':
     dependencies:
-      react: 18.2.0
+      react: 19.0.0
 
-  '@radix-ui/react-id@1.0.0(react@18.2.0)':
+  '@radix-ui/react-id@1.0.0(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-use-layout-effect': 1.0.0(react@18.2.0)
-      react: 18.2.0
+      '@radix-ui/react-use-layout-effect': 1.0.0(react@19.0.0)
+      react: 19.0.0
 
-  '@radix-ui/react-id@1.0.1(@types/react@18.2.12)(react@18.2.0)':
+  '@radix-ui/react-id@1.0.1(@types/react@19.0.6)(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  '@radix-ui/react-id@1.1.0(@types/react@18.2.12)(react@18.2.0)':
+  '@radix-ui/react-id@1.1.0(@types/react@19.0.6)(react@19.0.0)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  '@radix-ui/react-menu@2.0.5(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-menu@2.0.5(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-dismissable-layer': 1.0.4(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-focus-scope': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-id': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-popper': 1.1.2(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-portal': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-roving-focus': 1.0.4(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.12)(react@18.2.0)
+      '@radix-ui/react-collection': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-direction': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-dismissable-layer': 1.0.4(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-focus-scope': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-popper': 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-portal': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-roving-focus': 1.0.4(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.0.6)(react@19.0.0)
       aria-hidden: 1.2.4
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
-      react-remove-scroll: 2.5.5(@types/react@18.2.12)(react@18.2.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      react-remove-scroll: 2.5.5(@types/react@19.0.6)(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-popover@1.0.6(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-popover@1.0.6(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-dismissable-layer': 1.0.4(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-focus-scope': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-id': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-popper': 1.1.2(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-portal': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.12)(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-dismissable-layer': 1.0.4(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-focus-scope': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-popper': 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-portal': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@19.0.6)(react@19.0.0)
       aria-hidden: 1.2.4
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
-      react-remove-scroll: 2.5.5(@types/react@18.2.12)(react@18.2.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      react-remove-scroll: 2.5.5(@types/react@19.0.6)(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-popper@1.1.2(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-popper@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@floating-ui/react-dom': 2.1.1(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-arrow': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-rect': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-size': 1.0.1(@types/react@18.2.12)(react@18.2.0)
+      '@floating-ui/react-dom': 2.1.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-arrow': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-rect': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-size': 1.0.1(@types/react@19.0.6)(react@19.0.0)
       '@radix-ui/rect': 1.0.1
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-popper@1.1.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-popper@1.1.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@floating-ui/react-dom': 2.1.1(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-arrow': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-rect': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-size': 1.0.1(@types/react@18.2.12)(react@18.2.0)
+      '@floating-ui/react-dom': 2.1.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-arrow': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-rect': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-size': 1.0.1(@types/react@19.0.6)(react@19.0.0)
       '@radix-ui/rect': 1.0.1
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-popper@1.2.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-popper@1.2.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.1(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-arrow': 1.1.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-context': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-rect': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-size': 1.1.0(@types/react@18.2.12)(react@18.2.0)
+      '@floating-ui/react-dom': 2.1.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-arrow': 1.1.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-rect': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@19.0.6)(react@19.0.0)
       '@radix-ui/rect': 1.1.0
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-portal@1.0.0(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-portal@1.0.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-primitive': 1.0.0(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
-  '@radix-ui/react-portal@1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-portal@1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-portal@1.0.4(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-portal@1.0.4(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-portal@1.1.1(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-portal@1.1.1(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-presence@1.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-presence@1.0.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
-      '@radix-ui/react-use-layout-effect': 1.0.0(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.0(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.0.0(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
-  '@radix-ui/react-presence@1.0.0(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-presence@1.0.1(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
-      '@radix-ui/react-use-layout-effect': 1.0.0(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-presence@1.0.1(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-presence@1.1.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
+
+  '@radix-ui/react-primitive@1.0.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
-    optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@radix-ui/react-slot': 1.0.0(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
-  '@radix-ui/react-presence@1.1.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
-    optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
-
-  '@radix-ui/react-primitive@1.0.0(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-primitive@1.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-slot': 1.0.0(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.1(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
-  '@radix-ui/react-primitive@1.0.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-primitive@1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-slot': 1.0.1(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-
-  '@radix-ui/react-primitive@1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@babel/runtime': 7.24.8
-      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-primitive@2.0.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-primitive@2.0.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@radix-ui/react-slot': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-slot': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-primitive@2.0.1(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-primitive@2.0.1(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@radix-ui/react-slot': 1.1.1(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-slot': 1.1.1(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-radio-group@1.1.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-radio-group@1.1.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-roving-focus': 1.0.4(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-previous': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-size': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-direction': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-roving-focus': 1.0.4(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-previous': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-size': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-roving-focus@1.0.4(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-roving-focus@1.0.4(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-id': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-collection': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-direction': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-scroll-area@1.0.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-scroll-area@1.0.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@radix-ui/number': 1.0.0
       '@radix-ui/primitive': 1.0.0
-      '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
-      '@radix-ui/react-context': 1.0.0(react@18.2.0)
-      '@radix-ui/react-direction': 1.0.0(react@18.2.0)
-      '@radix-ui/react-presence': 1.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.0(react@18.2.0)
-      '@radix-ui/react-use-layout-effect': 1.0.0(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.0(react@19.0.0)
+      '@radix-ui/react-context': 1.0.0(react@19.0.0)
+      '@radix-ui/react-direction': 1.0.0(react@19.0.0)
+      '@radix-ui/react-presence': 1.0.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.0.0(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.0.0(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
-  '@radix-ui/react-scroll-area@1.1.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-scroll-area@1.1.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/number': 1.1.0
       '@radix-ui/primitive': 1.1.0
-      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-context': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-direction': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-presence': 1.1.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-direction': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-presence': 1.1.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-select@2.1.1(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-select@2.1.1(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/number': 1.1.0
       '@radix-ui/primitive': 1.1.0
-      '@radix-ui/react-collection': 1.1.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-context': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-direction': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-dismissable-layer': 1.1.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-focus-guards': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-focus-scope': 1.1.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-id': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-popper': 1.2.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-portal': 1.1.1(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-slot': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-previous': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-visually-hidden': 1.1.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-collection': 1.1.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-direction': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-dismissable-layer': 1.1.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-focus-guards': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-focus-scope': 1.1.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-id': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-popper': 1.2.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-portal': 1.1.1(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-visually-hidden': 1.1.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       aria-hidden: 1.2.4
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
-      react-remove-scroll: 2.5.7(@types/react@18.2.12)(react@18.2.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      react-remove-scroll: 2.5.7(@types/react@19.0.6)(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-separator@1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-separator@1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-slider@1.2.2(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-slider@1.2.2(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/number': 1.1.0
       '@radix-ui/primitive': 1.1.1
-      '@radix-ui/react-collection': 1.1.1(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-context': 1.1.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-direction': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-previous': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-size': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-collection': 1.1.1(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-direction': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-slot@1.0.0(react@18.2.0)':
+  '@radix-ui/react-slot@1.0.0(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
-      react: 18.2.0
+      '@radix-ui/react-compose-refs': 1.0.0(react@19.0.0)
+      react: 19.0.0
 
-  '@radix-ui/react-slot@1.0.1(react@18.2.0)':
+  '@radix-ui/react-slot@1.0.1(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
-      react: 18.2.0
+      '@radix-ui/react-compose-refs': 1.0.0(react@19.0.0)
+      react: 19.0.0
 
-  '@radix-ui/react-slot@1.0.2(@types/react@18.2.12)(react@18.2.0)':
+  '@radix-ui/react-slot@1.0.2(@types/react@19.0.6)(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  '@radix-ui/react-slot@1.1.0(@types/react@18.2.12)(react@18.2.0)':
+  '@radix-ui/react-slot@1.1.0(@types/react@19.0.6)(react@19.0.0)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  '@radix-ui/react-slot@1.1.1(@types/react@18.2.12)(react@18.2.0)':
+  '@radix-ui/react-slot@1.1.1(@types/react@19.0.6)(react@19.0.0)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  '@radix-ui/react-switch@1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@babel/runtime': 7.24.8
-      '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-previous': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-size': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
-    optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
-
-  '@radix-ui/react-tabs@1.0.4(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-switch@1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-id': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-roving-focus': 1.0.4(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-previous': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-size': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-toggle-group@1.0.4(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-tabs@1.0.4(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-roving-focus': 1.0.4(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-toggle': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-direction': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-roving-focus': 1.0.4(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-toggle@1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-toggle-group@1.0.4(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-direction': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-roving-focus': 1.0.4(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-toggle': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-tooltip@1.0.7(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-toggle@1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-dismissable-layer': 1.0.5(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-id': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-popper': 1.1.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-portal': 1.0.4(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      '@radix-ui/react-visually-hidden': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-use-callback-ref@1.0.0(react@18.2.0)':
+  '@radix-ui/react-tooltip@1.0.7(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      react: 18.2.0
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-dismissable-layer': 1.0.5(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-popper': 1.1.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-portal': 1.0.4(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      '@radix-ui/react-visually-hidden': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-use-callback-ref@1.0.1(@types/react@18.2.12)(react@18.2.0)':
+  '@radix-ui/react-use-callback-ref@1.0.0(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      react: 18.2.0
-    optionalDependencies:
-      '@types/react': 18.2.12
+      react: 19.0.0
 
-  '@radix-ui/react-use-callback-ref@1.1.0(@types/react@18.2.12)(react@18.2.0)':
-    dependencies:
-      react: 18.2.0
-    optionalDependencies:
-      '@types/react': 18.2.12
-
-  '@radix-ui/react-use-controllable-state@1.0.0(react@18.2.0)':
+  '@radix-ui/react-use-callback-ref@1.0.1(@types/react@19.0.6)(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-use-callback-ref': 1.0.0(react@18.2.0)
-      react: 18.2.0
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.6
 
-  '@radix-ui/react-use-controllable-state@1.0.1(@types/react@18.2.12)(react@18.2.0)':
+  '@radix-ui/react-use-callback-ref@1.1.0(@types/react@19.0.6)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.6
+
+  '@radix-ui/react-use-controllable-state@1.0.0(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-    optionalDependencies:
-      '@types/react': 18.2.12
+      '@radix-ui/react-use-callback-ref': 1.0.0(react@19.0.0)
+      react: 19.0.0
 
-  '@radix-ui/react-use-controllable-state@1.1.0(@types/react@18.2.12)(react@18.2.0)':
-    dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-    optionalDependencies:
-      '@types/react': 18.2.12
-
-  '@radix-ui/react-use-escape-keydown@1.0.0(react@18.2.0)':
+  '@radix-ui/react-use-controllable-state@1.0.1(@types/react@19.0.6)(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-use-callback-ref': 1.0.0(react@18.2.0)
-      react: 18.2.0
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.6
 
-  '@radix-ui/react-use-escape-keydown@1.0.3(@types/react@18.2.12)(react@18.2.0)':
+  '@radix-ui/react-use-controllable-state@1.1.0(@types/react@19.0.6)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.6
+
+  '@radix-ui/react-use-escape-keydown@1.0.0(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-    optionalDependencies:
-      '@types/react': 18.2.12
+      '@radix-ui/react-use-callback-ref': 1.0.0(react@19.0.0)
+      react: 19.0.0
 
-  '@radix-ui/react-use-escape-keydown@1.1.0(@types/react@18.2.12)(react@18.2.0)':
-    dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
-    optionalDependencies:
-      '@types/react': 18.2.12
-
-  '@radix-ui/react-use-layout-effect@1.0.0(react@18.2.0)':
+  '@radix-ui/react-use-escape-keydown@1.0.3(@types/react@19.0.6)(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      react: 18.2.0
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.6
 
-  '@radix-ui/react-use-layout-effect@1.0.1(@types/react@18.2.12)(react@18.2.0)':
+  '@radix-ui/react-use-escape-keydown@1.1.0(@types/react@19.0.6)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.6
+
+  '@radix-ui/react-use-layout-effect@1.0.0(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      react: 18.2.0
-    optionalDependencies:
-      '@types/react': 18.2.12
+      react: 19.0.0
 
-  '@radix-ui/react-use-layout-effect@1.1.0(@types/react@18.2.12)(react@18.2.0)':
-    dependencies:
-      react: 18.2.0
-    optionalDependencies:
-      '@types/react': 18.2.12
-
-  '@radix-ui/react-use-previous@1.0.1(@types/react@18.2.12)(react@18.2.0)':
+  '@radix-ui/react-use-layout-effect@1.0.1(@types/react@19.0.6)(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      react: 18.2.0
+      react: 19.0.0
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  '@radix-ui/react-use-previous@1.1.0(@types/react@18.2.12)(react@18.2.0)':
+  '@radix-ui/react-use-layout-effect@1.1.0(@types/react@19.0.6)(react@19.0.0)':
     dependencies:
-      react: 18.2.0
+      react: 19.0.0
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  '@radix-ui/react-use-rect@1.0.1(@types/react@18.2.12)(react@18.2.0)':
+  '@radix-ui/react-use-previous@1.0.1(@types/react@19.0.6)(react@19.0.0)':
+    dependencies:
+      '@babel/runtime': 7.24.8
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.6
+
+  '@radix-ui/react-use-previous@1.1.0(@types/react@19.0.6)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.6
+
+  '@radix-ui/react-use-rect@1.0.1(@types/react@19.0.6)(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@radix-ui/rect': 1.0.1
-      react: 18.2.0
+      react: 19.0.0
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  '@radix-ui/react-use-rect@1.1.0(@types/react@18.2.12)(react@18.2.0)':
+  '@radix-ui/react-use-rect@1.1.0(@types/react@19.0.6)(react@19.0.0)':
     dependencies:
       '@radix-ui/rect': 1.1.0
-      react: 18.2.0
+      react: 19.0.0
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  '@radix-ui/react-use-size@1.0.1(@types/react@18.2.12)(react@18.2.0)':
+  '@radix-ui/react-use-size@1.0.1(@types/react@19.0.6)(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  '@radix-ui/react-use-size@1.1.0(@types/react@18.2.12)(react@18.2.0)':
+  '@radix-ui/react-use-size@1.1.0(@types/react@19.0.6)(react@19.0.0)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.2.12)(react@18.2.0)
-      react: 18.2.0
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.6)(react@19.0.0)
+      react: 19.0.0
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  '@radix-ui/react-visually-hidden@1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-visually-hidden@1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
-  '@radix-ui/react-visually-hidden@1.1.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-visually-hidden@1.1.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
   '@radix-ui/rect@1.0.1':
     dependencies:
@@ -11699,17 +11687,11 @@ snapshots:
     dependencies:
       remove-accents: 0.4.2
 
-  '@tanstack/react-table@8.9.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@tanstack/react-table@8.9.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@tanstack/table-core': 8.9.2
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-
-  '@tanstack/react-table@8.9.2(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@tanstack/table-core': 8.9.2
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   '@tanstack/table-core@8.9.2': {}
 
@@ -11734,15 +11716,15 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
 
-  '@testing-library/react@16.1.0(@testing-library/dom@10.4.0)(@types/react-dom@18.0.11)(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@testing-library/react@16.1.0(@testing-library/dom@10.4.0)(@types/react-dom@19.0.3(@types/react@19.0.6))(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@testing-library/dom': 10.4.0
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
-      '@types/react-dom': 18.0.11
+      '@types/react': 19.0.6
+      '@types/react-dom': 19.0.3(@types/react@19.0.6)
 
   '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)':
     dependencies:
@@ -11914,15 +11896,13 @@ snapshots:
 
   '@types/prismjs@1.26.4': {}
 
-  '@types/prop-types@15.7.12': {}
-
-  '@types/react-dom@18.0.11':
+  '@types/react-dom@19.0.3(@types/react@19.0.6)':
     dependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  '@types/react-select@5.0.1(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@types/react-select@5.0.1(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      react-select: 5.7.7(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      react-select: 5.7.7(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     transitivePeerDependencies:
       - '@types/react'
       - react
@@ -11931,12 +11911,10 @@ snapshots:
 
   '@types/react-transition-group@4.4.10':
     dependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  '@types/react@18.2.12':
+  '@types/react@19.0.6':
     dependencies:
-      '@types/prop-types': 15.7.12
-      '@types/scheduler': 0.23.0
       csstype: 3.1.3
 
   '@types/resolve@1.20.2': {}
@@ -11946,8 +11924,6 @@ snapshots:
   '@types/responselike@1.0.3':
     dependencies:
       '@types/node': 18.19.39
-
-  '@types/scheduler@0.23.0': {}
 
   '@types/stack-utils@2.0.3': {}
 
@@ -12762,12 +12738,12 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  cmdk@0.2.0(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0):
+  cmdk@0.2.0(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
-      '@radix-ui/react-dialog': 1.0.0(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-dialog': 1.0.0(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       command-score: 0.1.2
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
     transitivePeerDependencies:
       - '@types/react'
 
@@ -13948,13 +13924,13 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
-  framer-motion@10.12.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  framer-motion@10.12.16(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       tslib: 2.5.0
     optionalDependencies:
       '@emotion/is-prop-valid': 0.8.8
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   fs-exists-sync@0.1.0: {}
 
@@ -16202,7 +16178,7 @@ snapshots:
 
   next-compose-plugins@2.2.1: {}
 
-  next@14.2.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@14.2.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@next/env': 14.2.5
       '@swc/helpers': 0.5.5
@@ -16210,9 +16186,9 @@ snapshots:
       caniuse-lite: 1.0.30001642
       graceful-fs: 4.2.11
       postcss: 8.4.31
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(react@18.2.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      styled-jsx: 5.1.1(react@19.0.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.5
       '@next/swc-darwin-x64': 14.2.5
@@ -17043,11 +17019,11 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
-  prism-react-renderer@2.3.1(react@18.2.0):
+  prism-react-renderer@2.3.1(react@19.0.0):
     dependencies:
       '@types/prismjs': 1.26.4
       clsx: 2.1.1
-      react: 18.2.0
+      react: 19.0.0
 
   prismjs@1.27.0: {}
 
@@ -17146,22 +17122,15 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-day-picker@9.0.4(react@18.2.0):
+  react-day-picker@9.0.4(react@19.0.0):
     dependencies:
       date-fns: 3.6.0
-      react: 18.2.0
+      react: 19.0.0
 
-  react-dom@18.2.0(react@18.2.0):
+  react-dom@19.0.0(react@19.0.0):
     dependencies:
-      loose-envify: 1.4.0
-      react: 18.2.0
-      scheduler: 0.23.2
-
-  react-dom@18.3.1(react@18.2.0):
-    dependencies:
-      loose-envify: 1.4.0
-      react: 18.2.0
-      scheduler: 0.23.2
+      react: 19.0.0
+      scheduler: 0.25.0
 
   react-error-overlay@6.0.9: {}
 
@@ -17171,99 +17140,97 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-live@4.1.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  react-live@4.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
-      prism-react-renderer: 2.3.1(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      prism-react-renderer: 2.3.1(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
       sucrase: 3.35.0
-      use-editable: 2.3.3(react@18.2.0)
+      use-editable: 2.3.3(react@19.0.0)
 
-  react-loading-skeleton@3.4.0(react@18.2.0):
+  react-loading-skeleton@3.4.0(react@19.0.0):
     dependencies:
-      react: 18.2.0
+      react: 19.0.0
 
   react-refresh@0.9.0: {}
 
-  react-remove-scroll-bar@2.3.6(@types/react@18.2.12)(react@18.2.0):
+  react-remove-scroll-bar@2.3.6(@types/react@19.0.6)(react@19.0.0):
     dependencies:
-      react: 18.2.0
-      react-style-singleton: 2.2.1(@types/react@18.2.12)(react@18.2.0)
+      react: 19.0.0
+      react-style-singleton: 2.2.1(@types/react@19.0.6)(react@19.0.0)
       tslib: 2.6.3
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  react-remove-scroll@2.5.4(@types/react@18.2.12)(react@18.2.0):
+  react-remove-scroll@2.5.4(@types/react@19.0.6)(react@19.0.0):
     dependencies:
-      react: 18.2.0
-      react-remove-scroll-bar: 2.3.6(@types/react@18.2.12)(react@18.2.0)
-      react-style-singleton: 2.2.1(@types/react@18.2.12)(react@18.2.0)
+      react: 19.0.0
+      react-remove-scroll-bar: 2.3.6(@types/react@19.0.6)(react@19.0.0)
+      react-style-singleton: 2.2.1(@types/react@19.0.6)(react@19.0.0)
       tslib: 2.6.3
-      use-callback-ref: 1.3.2(@types/react@18.2.12)(react@18.2.0)
-      use-sidecar: 1.1.2(@types/react@18.2.12)(react@18.2.0)
+      use-callback-ref: 1.3.2(@types/react@19.0.6)(react@19.0.0)
+      use-sidecar: 1.1.2(@types/react@19.0.6)(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  react-remove-scroll@2.5.5(@types/react@18.2.12)(react@18.2.0):
+  react-remove-scroll@2.5.5(@types/react@19.0.6)(react@19.0.0):
     dependencies:
-      react: 18.2.0
-      react-remove-scroll-bar: 2.3.6(@types/react@18.2.12)(react@18.2.0)
-      react-style-singleton: 2.2.1(@types/react@18.2.12)(react@18.2.0)
+      react: 19.0.0
+      react-remove-scroll-bar: 2.3.6(@types/react@19.0.6)(react@19.0.0)
+      react-style-singleton: 2.2.1(@types/react@19.0.6)(react@19.0.0)
       tslib: 2.6.3
-      use-callback-ref: 1.3.2(@types/react@18.2.12)(react@18.2.0)
-      use-sidecar: 1.1.2(@types/react@18.2.12)(react@18.2.0)
+      use-callback-ref: 1.3.2(@types/react@19.0.6)(react@19.0.0)
+      use-sidecar: 1.1.2(@types/react@19.0.6)(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  react-remove-scroll@2.5.7(@types/react@18.2.12)(react@18.2.0):
+  react-remove-scroll@2.5.7(@types/react@19.0.6)(react@19.0.0):
     dependencies:
-      react: 18.2.0
-      react-remove-scroll-bar: 2.3.6(@types/react@18.2.12)(react@18.2.0)
-      react-style-singleton: 2.2.1(@types/react@18.2.12)(react@18.2.0)
+      react: 19.0.0
+      react-remove-scroll-bar: 2.3.6(@types/react@19.0.6)(react@19.0.0)
+      react-style-singleton: 2.2.1(@types/react@19.0.6)(react@19.0.0)
       tslib: 2.6.3
-      use-callback-ref: 1.3.2(@types/react@18.2.12)(react@18.2.0)
-      use-sidecar: 1.1.2(@types/react@18.2.12)(react@18.2.0)
+      use-callback-ref: 1.3.2(@types/react@19.0.6)(react@19.0.0)
+      use-sidecar: 1.1.2(@types/react@19.0.6)(react@19.0.0)
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  react-select@5.7.7(@types/react@18.2.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0):
+  react-select@5.7.7(@types/react@19.0.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@babel/runtime': 7.24.8
       '@emotion/cache': 11.11.0
-      '@emotion/react': 11.11.4(@types/react@18.2.12)(react@18.2.0)
+      '@emotion/react': 11.11.4(@types/react@19.0.6)(react@19.0.0)
       '@floating-ui/dom': 1.6.7
       '@types/react-transition-group': 4.4.10
       memoize-one: 6.0.0
       prop-types: 15.8.1
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
-      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      use-isomorphic-layout-effect: 1.1.2(@types/react@18.2.12)(react@18.2.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      react-transition-group: 4.4.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      use-isomorphic-layout-effect: 1.1.2(@types/react@19.0.6)(react@19.0.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
 
-  react-style-singleton@2.2.1(@types/react@18.2.12)(react@18.2.0):
+  react-style-singleton@2.2.1(@types/react@19.0.6)(react@19.0.0):
     dependencies:
       get-nonce: 1.0.1
       invariant: 2.2.4
-      react: 18.2.0
+      react: 19.0.0
       tslib: 2.6.3
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  react-transition-group@4.4.5(react-dom@18.3.1(react@18.2.0))(react@18.2.0):
+  react-transition-group@4.4.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@babel/runtime': 7.24.8
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
-  react@18.2.0:
-    dependencies:
-      loose-envify: 1.4.0
+  react@19.0.0: {}
 
   read-cache@1.0.0:
     dependencies:
@@ -17623,9 +17590,7 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
-  scheduler@0.23.2:
-    dependencies:
-      loose-envify: 1.4.0
+  scheduler@0.25.0: {}
 
   schema-utils@3.3.0:
     dependencies:
@@ -17765,10 +17730,10 @@ snapshots:
       ip-address: 9.0.5
       smart-buffer: 4.2.0
 
-  sonner@1.5.0(react-dom@18.3.1(react@18.2.0))(react@18.2.0):
+  sonner@1.5.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   source-map-js@1.2.0: {}
 
@@ -17971,10 +17936,10 @@ snapshots:
     dependencies:
       inline-style-parser: 0.1.1
 
-  styled-jsx@5.1.1(react@18.2.0):
+  styled-jsx@5.1.1(react@19.0.0):
     dependencies:
       client-only: 0.0.1
-      react: 18.2.0
+      react: 19.0.0
 
   stylehacks@5.1.1(postcss@8.4.24):
     dependencies:
@@ -18505,35 +18470,35 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
-  use-callback-ref@1.3.2(@types/react@18.2.12)(react@18.2.0):
+  use-callback-ref@1.3.2(@types/react@19.0.6)(react@19.0.0):
     dependencies:
-      react: 18.2.0
+      react: 19.0.0
       tslib: 2.6.3
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  use-editable@2.3.3(react@18.2.0):
+  use-editable@2.3.3(react@19.0.0):
     dependencies:
-      react: 18.2.0
+      react: 19.0.0
 
-  use-isomorphic-layout-effect@1.1.2(@types/react@18.2.12)(react@18.2.0):
+  use-isomorphic-layout-effect@1.1.2(@types/react@19.0.6)(react@19.0.0):
     dependencies:
-      react: 18.2.0
+      react: 19.0.0
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  use-sidecar@1.1.2(@types/react@18.2.12)(react@18.2.0):
+  use-sidecar@1.1.2(@types/react@19.0.6)(react@19.0.0):
     dependencies:
       detect-node-es: 1.1.0
-      react: 18.2.0
+      react: 19.0.0
       tslib: 2.6.3
     optionalDependencies:
-      '@types/react': 18.2.12
+      '@types/react': 19.0.6
 
-  usehooks-ts@2.9.1(react-dom@18.3.1(react@18.2.0))(react@18.2.0):
+  usehooks-ts@2.9.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   user-home@2.0.0:
     dependencies:


### PR DESCRIPTION
**Changes:**

1. Update dependencies and peer dependencies to React v19.0.0.
2. Remove `elementRef` (deprecated) and use `componentRef`.
3. Remove `forwardRef` (deprecated). React v19 now supports passing `ref` directly as a prop thus forwardRef exclusively is not needed.
4. `defaultProps` is no more supported as ES6 default values is a better option.
6. Formatted code.
7. Minor fixes.


**Note: Old components are untouched.**
