### PR TITLE
Fix/callout css override

### DIFF
--- a/apps/www/content/primitives/components/callout.mdx
+++ b/apps/www/content/primitives/components/callout.mdx
@@ -59,6 +59,7 @@ The `Callout` component accepts the following props:
 - `width`: Custom width for the callout
 - `className`: Additional CSS class names
 - `style`: Additional CSS styles
+- `icon`: Custom leading icon. Default is `InfoCircledIcon`.
 - All other HTMLDivElement attributes from React
 
 ## Type

--- a/apps/www/content/primitives/components/callout.mdx
+++ b/apps/www/content/primitives/components/callout.mdx
@@ -58,6 +58,7 @@ The `Callout` component accepts the following props:
 - `onDismiss`: Callback function when dismiss button is clicked
 - `width`: Custom width for the callout
 - `className`: Additional CSS class names
+- `style`: Additional CSS styles
 - All other HTMLDivElement attributes from React
 
 ## Type

--- a/packages/raystack/v1/components/callout/callout.module.css
+++ b/packages/raystack/v1/components/callout/callout.module.css
@@ -26,10 +26,18 @@
 }
 
 .icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 16px;
   height: 16px;
   flex-shrink: 0;
   color: currentColor;
+}
+
+.icon svg {
+  width: 100%;
+  height: 100%;
 }
 
 .message {

--- a/packages/raystack/v1/components/callout/callout.tsx
+++ b/packages/raystack/v1/components/callout/callout.tsx
@@ -34,6 +34,7 @@ export interface CalloutProps extends ComponentPropsWithoutRef<'div'>, VariantPr
   dismissible?: boolean;
   onDismiss?: () => void;
   width?: string | number;
+  style?: React.CSSProperties;
 }
 
 export const Callout = React.forwardRef<HTMLDivElement, CalloutProps>(
@@ -47,9 +48,13 @@ export const Callout = React.forwardRef<HTMLDivElement, CalloutProps>(
     dismissible,
     onDismiss,
     width,
+    style,
     ...props
   }, ref) => {
-    const style = width ? { width: typeof width === 'number' ? `${width}px` : width } : undefined;
+    const combinedStyle = {
+      ...style,
+      ...(width && { width: typeof width === 'number' ? `${width}px` : width }),
+    };
 
     const getRole = () => {
       switch (type) {
@@ -66,7 +71,7 @@ export const Callout = React.forwardRef<HTMLDivElement, CalloutProps>(
       <div
         ref={ref}
         className={`${callout({ type, outline, highContrast })} ${className || ''}`}
-        style={style}
+        style={combinedStyle}
         role={getRole()}
         aria-live={type === 'alert' ? 'assertive' : 'polite'}
         {...props}

--- a/packages/raystack/v1/components/callout/callout.tsx
+++ b/packages/raystack/v1/components/callout/callout.tsx
@@ -35,6 +35,7 @@ export interface CalloutProps extends ComponentPropsWithoutRef<'div'>, VariantPr
   onDismiss?: () => void;
   width?: string | number;
   style?: React.CSSProperties;
+  icon?: React.ReactNode;
 }
 
 export const Callout = React.forwardRef<HTMLDivElement, CalloutProps>(
@@ -49,6 +50,7 @@ export const Callout = React.forwardRef<HTMLDivElement, CalloutProps>(
     onDismiss,
     width,
     style,
+    icon,
     ...props
   }, ref) => {
     const combinedStyle = {
@@ -78,10 +80,16 @@ export const Callout = React.forwardRef<HTMLDivElement, CalloutProps>(
       >
         <div className={styles.container}>
           <div className={styles.messageContainer}>
-            <InfoCircledIcon 
-              className={styles.icon} 
-              aria-hidden="true"
-            />
+            {icon !== undefined ? (
+              <div className={styles.icon} aria-hidden="true">
+                {icon}
+              </div>
+            ) : (
+              <InfoCircledIcon 
+                className={styles.icon} 
+                aria-hidden="true"
+              />
+            )}
             <div className={styles.message}>{children}</div>
           </div>
           


### PR DESCRIPTION
## Description

- Feat: Add support for custom leading icon.
- Fix: `style` prop overriding `width` prop.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [x] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (.mdx files)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

