### PR TITLE
fix: imports and remove unnecessary deprecate

### DIFF
--- a/packages/raystack/toggle-group/togglegroup.tsx
+++ b/packages/raystack/toggle-group/togglegroup.tsx
@@ -5,17 +5,11 @@ import { cva, VariantProps } from "class-variance-authority";
 
 const root = cva(styles.root);
 
-/**
- * @deprecated Use Tabs from '@raystack/apsara/v1' instead.
- */
 export type ToggleGroupProps = ComponentPropsWithoutRef<
   typeof ToggleGroupPrimitive.Root
 > &
   VariantProps<typeof root>;
 
-/**
- * @deprecated Use Tabs from '@raystack/apsara/v1' instead.
- */
 export const ToggleGroupRoot = ({ className, ...props }: ToggleGroupProps) => {
   return (
     <ToggleGroupPrimitive.Root className={root({ className })} {...props} />
@@ -26,16 +20,10 @@ ToggleGroupRoot.defaultProps = { type: "single" };
 
 const item = cva(styles.item);
 
-/**
- * @deprecated Use Tabs from '@raystack/apsara/v1' instead.
- */
 export interface ToggleGroupItemProps
   extends ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item>,
     VariantProps<typeof item> {}
 
-/**
- * @deprecated Use Tabs from '@raystack/apsara/v1' instead.
- */
 export const ToggleGroupItem = ({
   className,
   ...props
@@ -45,9 +33,6 @@ export const ToggleGroupItem = ({
   );
 };
 
-/**
- * @deprecated Use Tabs from '@raystack/apsara/v1' instead.
- */
 export const ToggleGroup = Object.assign(ToggleGroupRoot, {
   Item: ToggleGroupItem,
 });

--- a/packages/raystack/v1/index.tsx
+++ b/packages/raystack/v1/index.tsx
@@ -38,4 +38,4 @@ export {
   useTheme,
 } from "./components/theme-provider";
 export { toast, ToastContainer } from "./components/toast";
-export { Tooltip } from "./components/tooltip";
+export { Tooltip, TooltipProvider } from "./components/tooltip";


### PR DESCRIPTION
## Description

- Add missing import for tooltip provider
- Remove deprecation notice for toggleGroup old component as it is not yet present in v1.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (.mdx files)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

