### PR TITLE
fix: remove overriding style for default html tags

### DIFF
--- a/packages/raystack/v1/styles/typography.css
+++ b/packages/raystack/v1/styles/typography.css
@@ -66,17 +66,10 @@
   --rs-font-body: var(--rs-font-josefin-sans);
 }
 
-h1 { font-family: var(--rs-font-title); font-size: var(--rs-font-size-t4); font-weight: var(--rs-font-weight-medium); line-height: var(--rs-line-height-t4); }
-h2 { font-family: var(--rs-font-title); font-size: var(--rs-font-size-t3); font-weight: var(--rs-font-weight-medium); line-height: var(--rs-line-height-t3); }
-h3 { font-family: var(--rs-font-title); font-size: var(--rs-font-size-t2); font-weight: var(--rs-font-weight-medium); line-height: var(--rs-line-height-t2); }
+h1 { font-family: var(--rs-font-title); font-size: var(--rs-font-size-t4); font-weight: var(--rs-font-weight-medium); line-height: var(--rs-line-height-t1); }
+h2 { font-family: var(--rs-font-title); font-size: var(--rs-font-size-t3); font-weight: var(--rs-font-weight-medium); line-height: var(--rs-line-height-t1); }
+h3 { font-family: var(--rs-font-title); font-size: var(--rs-font-size-t2); font-weight: var(--rs-font-weight-medium); line-height: var(--rs-line-height-t1); }
 h4 { font-family: var(--rs-font-title); font-size: var(--rs-font-size-t1); font-weight: var(--rs-font-weight-medium); line-height: var(--rs-line-height-t1); }
-
-body, p, div, span {
-  font-family: var(--rs-font-body);
-  font-size: var(--rs-font-size-regular);
-  font-weight: var(--rs-font-weight-regular);
-  line-height: var(--rs-line-height-regular);
-}
 
 /* CSS for the text cursor */
 input, textarea {


### PR DESCRIPTION
## Description

Fix: revert default styling for html tags.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

[Describe the tests that you ran to verify your changes]

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (.mdx files)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

[Add screenshots here]

## Related Issues

[Link any related issues here using #issue-number]
