### PR TITLE
fix: override prevent

### DIFF
--- a/packages/raystack/v1/components/dropdown-menu/dropdown-menu.module.css
+++ b/packages/raystack/v1/components/dropdown-menu/dropdown-menu.module.css
@@ -13,7 +13,7 @@
   background-color: var(--rs-color-background-base-primary);
   border-radius: var(--rs-radius-2);
   box-shadow: var(--shadow-sm);
-  outline: 1px solid var(--rs-color-border-base-primary);
+  border: 1px solid var(--rs-color-border-base-primary);
   color: var(--rs-color-foreground-base-primary);
   min-width: var(--radix-dropdown-menu-trigger-width);
 }

--- a/packages/raystack/v1/components/select/select.module.css
+++ b/packages/raystack/v1/components/select/select.module.css
@@ -3,13 +3,16 @@
   z-index: 50;
   font-family: var(--rs-font-body);
   font-size: var(--rs-font-size-small);
-  line-height: 16px;
+  line-height: var(--rs-line-height-small);
+
   box-sizing: border-box;
-  padding: var(--pd-4);
-  background-color: var(--background-base);
-  border-radius: var(--br-4);
+
+  padding: var(--rs-space-2);
+  background-color: var(--rs-color-background-base-primary);
+  border-radius: var(--rs-radius-2);
   box-shadow: var(--shadow-sm);
-  border: 1px solid var(--border-subtle);
+  border: 1px solid var(--rs-color-border-base-primary);
+
   min-width: var(--radix-select-trigger-width);
   margin-top: 4px;
 }

--- a/packages/raystack/v1/components/select/select.module.css
+++ b/packages/raystack/v1/components/select/select.module.css
@@ -3,16 +3,13 @@
   z-index: 50;
   font-family: var(--rs-font-body);
   font-size: var(--rs-font-size-small);
-  line-height: var(--rs-line-height-small);
-
+  line-height: 16px;
   box-sizing: border-box;
-
-  padding: var(--rs-space-2);
-  background-color: var(--rs-color-background-base-primary);
-  border-radius: var(--rs-radius-2);
+  padding: var(--pd-4);
+  background-color: var(--background-base);
+  border-radius: var(--br-4);
   box-shadow: var(--shadow-sm);
-  outline: 1px solid var(--rs-color-border-base-primary);
-
+  border: 1px solid var(--border-subtle);
   min-width: var(--radix-select-trigger-width);
   margin-top: 4px;
 }


### PR DESCRIPTION
## Description

Fix: Radix is overriding the outline css defined in `select.module.css` and making the outline transparent. Changing it to border.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [x] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (.mdx files)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

<img width="175" alt="Screenshot 2025-02-28 at 12 13 45 PM" src="https://github.com/user-attachments/assets/b950f0b7-c391-43a7-8c38-a5a430710531" />

