### PR TITLE
Feat/dialog v1 add props 4738

### DIFF
--- a/apps/www/content/primitives/components/dialog.mdx
+++ b/apps/www/content/primitives/components/dialog.mdx
@@ -85,7 +85,7 @@ The Dialog component consists of several parts:
 - `overlayBlur`: Enables backdrop blur effect (boolean)
 - `overlayClassName`: Custom class for overlay styling
 - `overlayStyle`: Custom styles for overlay
-- `close`: Controls visibility of close button (boolean)
+- `close`: Controls visibility of close button (boolean). Note: Make sure to conditionally render `<Dialog.Close>` as well if passing custom Icon for close in it.
 - `className`: Additional CSS class names
 - `side`: Position of the dialog ("top" | "right" | "bottom" | "left")
 
@@ -102,6 +102,7 @@ The Dialog component consists of several parts:
 
 - `asChild`: Boolean to merge props onto child element
 - `className`: Additional CSS class names
+- `children`: Custom Close icon. Note: If this is passed, the `close` prop value is not respected. The close icon will always be visible.
 
 ## Examples
 

--- a/apps/www/content/primitives/components/dialog.mdx
+++ b/apps/www/content/primitives/components/dialog.mdx
@@ -17,6 +17,7 @@ import React from "react";
         <Button variant="primary">Basic Dialog</Button>
       </Dialog.Trigger>
       <Dialog.Content 
+        width={600}
         ariaLabel="Basic Dialog"
         ariaDescription="A simple dialog example"
       >
@@ -53,6 +54,7 @@ The Dialog component provides a modal window that overlays the page content.
     <Button variant="primary">Open Dialog</Button>
   </Dialog.Trigger>
   <Dialog.Content 
+    width={600}
     ariaLabel="Example Dialog"
     ariaDescription="Dialog description for screen readers"
   >
@@ -79,10 +81,17 @@ The Dialog component consists of several parts:
 
 - `ariaLabel`: Accessible label for the dialog
 - `ariaDescription`: Detailed description for screen readers
+- `width`: Controls dialog width (string | number)
 - `overlayBlur`: Enables backdrop blur effect (boolean)
-- `close`: Shows close button in top-right corner (boolean)
-- `side`: Position of the dialog ("top" | "right" | "bottom" | "left")
+- `overlayClassName`: Custom class for overlay styling
+- `overlayStyle`: Custom styles for overlay
+- `close`: Controls visibility of close button (boolean)
 - `className`: Additional CSS class names
+- `side`: Position of the dialog ("top" | "right" | "bottom" | "left")
+
+### Description Props
+
+- `className`: Additional CSS class names for description
 
 ### Trigger Props
 
@@ -110,7 +119,7 @@ A simple dialog with title and description.
   <Dialog.Trigger asChild>
     <Button variant="primary">Open Dialog</Button>
   </Dialog.Trigger>
-  <Dialog.Content>
+  <Dialog.Content width={600}>
     <Dialog.Title>Welcome</Dialog.Title>
     <Dialog.Description>
       This is a basic dialog example.
@@ -140,7 +149,7 @@ function ControlledDialog() {
       <Dialog.Trigger asChild>
         <Button variant="primary">Controlled Dialog</Button>
       </Dialog.Trigger>
-      <Dialog.Content>
+      <Dialog.Content width={600}>
         <Dialog.Title>Controlled State</Dialog.Title>
         <Dialog.Description>
           This dialog's state is controlled externally.
@@ -150,6 +159,62 @@ function ControlledDialog() {
     </Dialog>
   );
 }`,
+    },
+  ]}
+/>
+
+### Custom Width and Overlay
+
+Example with custom width and overlay styling.
+
+<Playground
+  scope={{ Dialog, Button, Flex }}
+  tabs={[
+    {
+      name: "Custom Styling",
+      code: `
+<Dialog>
+  <Dialog.Trigger asChild>
+    <Button variant="primary">Styled Dialog</Button>
+  </Dialog.Trigger>
+  <Dialog.Content
+    width="400px"
+    overlayBlur
+    overlayClassName="custom-overlay"
+    overlayStyle={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }}
+  >
+    <Dialog.Title>Custom Styled Dialog</Dialog.Title>
+    <Dialog.Description className="custom-description">
+      This dialog has custom width and overlay styling.
+    </Dialog.Description>
+    <Dialog.Close />
+  </Dialog.Content>
+</Dialog>`,
+    },
+  ]}
+/>
+
+### Without Close Button
+
+Example of dialog without the close button.
+
+<Playground
+  scope={{ Dialog, Button }}
+  tabs={[
+    {
+      name: "No Close",
+      code: `
+<Dialog>
+  <Dialog.Trigger asChild>
+    <Button variant="primary">Open Dialog</Button>
+  </Dialog.Trigger>
+  <Dialog.Content width={600} close={false}>
+    <Dialog.Title>No Close Button</Dialog.Title>
+    <Dialog.Description>
+      This dialog doesn't show the close button.
+    </Dialog.Description>
+  </Dialog.Content>
+</Dialog>`,
     },
   ]}
 />

--- a/apps/www/examples/shield-ts/assets.tsx
+++ b/apps/www/examples/shield-ts/assets.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useCallback, useEffect } from "react";
 import dayjs from "dayjs";
 import { HomeIcon, CheckIcon } from "@radix-ui/react-icons";
-import { DataTable, Title, useTable } from "@raystack/apsara";
+import { DataTable, Title, useTable, Dialog as DialogLegacy } from "@raystack/apsara";
 
 import {
   toast,
@@ -129,6 +129,7 @@ export const Assets = () => {
   });
   const [sheetOpen, setSheetOpen] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [legacyDialogOpen, setLegacyDialogOpen] = useState(false);
 
   const activeFilters = [
     {
@@ -241,6 +242,9 @@ export const Assets = () => {
         <Flex direction="column" style={{ width: "100%" }}>
           <Flex direction="column" gap="large" style={{ width: "100%" }}>
             <Flex gap="large" wrap="wrap">
+              <Button size="small" onClick={() => setDialogOpen(true)}>Open V1 Dialog</Button>
+              <Button size="small" onClick={() => setLegacyDialogOpen(true)}>Open Legacy Dialog</Button>
+
               {/* Basic Input - Small */}
               <InputField
                 label="Asset Name (Small)"
@@ -428,6 +432,46 @@ export const Assets = () => {
         </Flex>
       </Flex>
       </Flex>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <Dialog.Content overlayBlur={false} width="800px">
+          <Dialog.Title>Sample Dialog Title</Dialog.Title>
+          <Dialog.Description>
+            This is an example of the new V1 Dialog component.
+          </Dialog.Description>
+          <Flex direction="column" gap="large" style={{ marginTop: '20px' }}>
+            <InputField
+              label="Sample Input"
+              placeholder="Enter some text"
+            />
+            <Flex justify="end" gap="small">
+              <Button variant="solid" onClick={() => setDialogOpen(false)}>Cancel</Button>
+              <Button onClick={() => setDialogOpen(false)}>Save</Button>
+            </Flex>
+          </Flex>
+          <Dialog.Close />
+        </Dialog.Content>
+      </Dialog>
+
+      <DialogLegacy open={legacyDialogOpen} onOpenChange={setLegacyDialogOpen}>
+        <DialogLegacy.Content close overlayBlur={false}>
+          <DialogLegacy.Title>Legacy Dialog Title</DialogLegacy.Title>
+          <DialogLegacy.Description>
+            This is an example of the legacy Dialog component.
+          </DialogLegacy.Description>
+          <Flex direction="column" gap="large" style={{ marginTop: '20px' }}>
+            <InputField
+              label="Sample Input"
+              placeholder="Enter some text"
+            />
+            <Flex justify="end" gap="small">
+              <Button variant="solid" onClick={() => setLegacyDialogOpen(false)}>Cancel</Button>
+              <Button onClick={() => setLegacyDialogOpen(false)}>Save</Button>
+            </Flex>
+          </Flex>
+        </DialogLegacy.Content>
+      </DialogLegacy>
+
       <ToastContainer />
     </div>
   );

--- a/packages/raystack/v1/components/button/button.module.css
+++ b/packages/raystack/v1/components/button/button.module.css
@@ -38,7 +38,7 @@
   font-size: var(--rs-font-size-mini);
   line-height: var(--rs-line-height-mini);
   letter-spacing: var(--rs-letter-spacing-mini);
-  min-height: 24px;
+  height: 24px;
 }
 
 .button-normal {
@@ -46,7 +46,7 @@
   font-size: var(--rs-font-size-small);
   line-height: var(--rs-line-height-small);
   letter-spacing: var(--rs-letter-spacing-small);
-  min-height: 32px;
+  height: 32px;
 }
 
 .button-solid {

--- a/packages/raystack/v1/components/dialog/dialog.module.css
+++ b/packages/raystack/v1/components/dialog/dialog.module.css
@@ -21,6 +21,10 @@
   z-index: 9999;
 }
 
+.dialogContent:focus {
+  outline: none;
+}
+
 .close {
   position: absolute;
   top: var(--rs-space-3);
@@ -42,6 +46,9 @@
   color: var(--rs-color-foreground-base-primary);
 }
 
+.overlayBlur {
+  backdrop-filter: blur(2px);
+}
 
 .dialogOverlay[data-state="open"] {
   animation: fadeIn 150ms cubic-bezier(0.22, 1, 0.36, 1);

--- a/packages/raystack/v1/components/dialog/dialog.module.css
+++ b/packages/raystack/v1/components/dialog/dialog.module.css
@@ -26,19 +26,16 @@
 }
 
 .close {
+  all: unset;
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--rs-radius-2);
+  padding: var(--rs-space-2);
+  font-weight: var(--rs-font-weight-medium);
   position: absolute;
   top: var(--rs-space-3);
   right: var(--rs-space-3);
-  width: var(--rs-space-7);
-  height: var(--rs-space-7);
-  border-radius: var(--rs-radius-2);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--rs-color-foreground-base-secondary);
   cursor: pointer;
-  border: none;
-  background: transparent;
 }
 
 .close:hover {

--- a/packages/raystack/v1/components/dialog/dialog.tsx
+++ b/packages/raystack/v1/components/dialog/dialog.tsx
@@ -7,6 +7,7 @@ import {
   ElementRef,
   forwardRef,
 } from "react";
+import { clsx } from "clsx";
 
 import styles from "./dialog.module.css";
 
@@ -17,21 +18,34 @@ export interface DialogContentProps
     VariantProps<typeof dialogContent> {
   ariaLabel?: string;
   ariaDescription?: string;
+  overlayBlur?: boolean;
+  overlayClassName?: string;
+  width?: string | number;
 }
 
 const DialogContent = forwardRef<
   ElementRef<typeof DialogPrimitive.Content>,
   DialogContentProps
->(({ className, children, ariaLabel, ariaDescription, ...props }, ref) => (
+>(({ 
+  className, 
+  children, 
+  ariaLabel, 
+  ariaDescription, 
+  overlayBlur = false, 
+  overlayClassName,
+  width,
+  ...props 
+}, ref) => (
   <DialogPrimitive.Portal>
     <DialogPrimitive.Overlay 
-      className={styles.dialogOverlay}
+      className={clsx(styles.dialogOverlay, overlayClassName, overlayBlur && styles.overlayBlur )}
       aria-hidden="true"
       role="presentation"
     />
     <DialogPrimitive.Content
       ref={ref}
       className={dialogContent({ className })}
+      style={{ width, ...props.style }}
       aria-label={ariaLabel}
       aria-describedby={ariaDescription ? 'dialog-description' : undefined}
       {...props}
@@ -76,10 +90,16 @@ function DialogTitle({ children, ...props }: DialogTitleProps) {
   );
 }
 
-function DialogDescription({ children, ...props }: { children: React.ReactNode }) {
+interface DialogDescriptionProps extends ComponentProps<typeof DialogPrimitive.Description> {
+  children: React.ReactNode;
+  className?: string;
+}
+
+function DialogDescription({ children, className, ...props }: DialogDescriptionProps) {
   return (
     <DialogPrimitive.Description 
       {...props}
+      className={className}
       id="dialog-description"
       role="document"
     >

--- a/packages/raystack/v1/components/dialog/dialog.tsx
+++ b/packages/raystack/v1/components/dialog/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = forwardRef<
 }, ref) => (
   <DialogPrimitive.Portal>
     <DialogPrimitive.Overlay 
-      className={clsx(styles.dialogOverlay, overlayClassName, overlayBlur && styles.overlayBlur )}
+      className={clsx(styles.dialogOverlay, overlayBlur && styles.overlayBlur, overlayClassName)}
       aria-hidden="true"
       role="presentation"
     />
@@ -51,6 +51,7 @@ const DialogContent = forwardRef<
       {...props}
     >
       {children}
+      <CloseButton />
     </DialogPrimitive.Content>
   </DialogPrimitive.Portal>
 ));

--- a/packages/raystack/v1/components/dialog/dialog.tsx
+++ b/packages/raystack/v1/components/dialog/dialog.tsx
@@ -21,6 +21,7 @@ export interface DialogContentProps
   overlayBlur?: boolean;
   overlayClassName?: string;
   width?: string | number;
+  close?: boolean;
 }
 
 const DialogContent = forwardRef<
@@ -34,11 +35,12 @@ const DialogContent = forwardRef<
   overlayBlur = false, 
   overlayClassName,
   width,
+  close,
   ...props 
 }, ref) => (
   <DialogPrimitive.Portal>
     <DialogPrimitive.Overlay 
-      className={clsx(styles.dialogOverlay, overlayBlur && styles.overlayBlur, overlayClassName)}
+      className={clsx(styles.dialogOverlay, overlayClassName, overlayBlur && styles.overlayBlur )}
       aria-hidden="true"
       role="presentation"
     />
@@ -51,7 +53,7 @@ const DialogContent = forwardRef<
       {...props}
     >
       {children}
-      <CloseButton />
+      {close && <CloseButton />}
     </DialogPrimitive.Content>
   </DialogPrimitive.Portal>
 ));

--- a/packages/raystack/v1/components/dialog/dialog.tsx
+++ b/packages/raystack/v1/components/dialog/dialog.tsx
@@ -20,6 +20,7 @@ export interface DialogContentProps
   ariaDescription?: string;
   overlayBlur?: boolean;
   overlayClassName?: string;
+  overlayStyle?: React.CSSProperties;
   width?: string | number;
   close?: boolean;
 }
@@ -34,6 +35,7 @@ const DialogContent = forwardRef<
   ariaDescription, 
   overlayBlur = false, 
   overlayClassName,
+  overlayStyle,
   width,
   close,
   ...props 
@@ -41,6 +43,7 @@ const DialogContent = forwardRef<
   <DialogPrimitive.Portal>
     <DialogPrimitive.Overlay 
       className={clsx(styles.dialogOverlay, overlayClassName, overlayBlur && styles.overlayBlur )}
+      style={overlayStyle}
       aria-hidden="true"
       role="presentation"
     />


### PR DESCRIPTION
## Description

- Feat: Add overlay customisation (`overlayBlur`, `overlayClassName`, `overlayStyle`)
- Feat: Add width prop to _Dialog.Content_ for direct width control
- Feat: Add `close` prop to control close button visibility
- Feat: Add `className` support for _Dialog.Description_
- Style: Match close button css with legacy styling until we have the new designs for v1.
- Chore: Add usage in Assets.tsx
- Docs: Update docs
- Chore: Button fixed height (Squeeze in this PR only)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [x] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [x] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (.mdx files)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

[Add screenshots here]

## Related Issues

[Link any related issues here using #issue-number]
