### PR TITLE
fix: Tabs active content alignment issue

### DIFF
--- a/packages/raystack/v1/components/tabs/tabs.module.css
+++ b/packages/raystack/v1/components/tabs/tabs.module.css
@@ -70,8 +70,10 @@
 
 .content {
   outline: none;
+	flex: 1;
 }
 
 .content[data-state='inactive'] {
   display: none;
-} 
+	flex: 0;
+}


### PR DESCRIPTION
## Description

Fixes active tab style break (active tab width not taking 100% of the available area)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

Tested locally with devtools

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (.mdx files)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
