### PR TITLE
fix: fix font difference

### DIFF
--- a/packages/raystack/v1/styles/typography.css
+++ b/packages/raystack/v1/styles/typography.css
@@ -54,6 +54,15 @@
   --rs-letter-spacing-t2: 0;
   --rs-letter-spacing-t3: 0;
   --rs-letter-spacing-t4: 0;
+  
+  /* Font Smoothing */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body, p, h1, h2, h3, h4, h5, h6, span, div, label {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 [data-style="modern"] {


### PR DESCRIPTION
## Description

Note: This is not a sure shot fix and only makes the font closer to what is shown in Figma. I am currently researching on a tool called Capsize (or similar as it's deprecated) for this.

This PR addresses font rendering, but has some considerations:

**Font Smoothing Effects:**
- `-webkit-font-smoothing: antialiased` and `-moz-osx-font-smoothing: grayscale` make fonts appear thinner and smoother.
- These properties affect how the font is rendered (the crispness and weight) but don't address spacing issues.

`font-smooth: never` - Not using this.
- This is not a standard CSS property and has limited browser support
- It attempts to disable font smoothing entirely, which can make text appear more pixelated

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (.mdx files)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

