### PR TITLE
Feat/custom timezone support 4723

### DIFF
--- a/apps/www/src/app/examples/page.tsx
+++ b/apps/www/src/app/examples/page.tsx
@@ -126,10 +126,61 @@ const Page = () => {
             onClear={() => setSearch1("")}
           />
           
-          <RangePicker
-               />
+          <Text size="large" weight="medium" style={{ marginTop: "24px", marginBottom: "16px" }}>
+            Date Pickers with Timezone
+          </Text>
 
-          <DatePicker />
+          <Text weight="medium">Default (Local Timezone)</Text>
+          <DatePicker onSelect={(date) => console.log('Default DatePicker - Selected:', date)} />
+
+          <Text weight="medium" style={{ marginTop: "16px" }}>Tokyo Timezone</Text>
+          <DatePicker 
+            timezone="Asia/Tokyo" 
+            onSelect={(date) => console.log('Tokyo DatePicker - Selected:', date)}
+          />
+
+          <Text weight="medium" style={{ marginTop: "16px" }}>New York Timezone</Text>
+          <DatePicker 
+            timezone="America/New_York" 
+            onSelect={(date) => console.log('NY DatePicker - Selected:', date)}
+          />
+
+          <Text weight="medium" style={{ marginTop: "24px" }}>Range Picker Examples</Text>
+
+          <Text weight="medium">Default (Local Timezone)</Text>
+          <RangePicker 
+            onSelect={(range) => console.log('Default RangePicker - Selected:', range)}
+          />
+
+          <Text weight="medium" style={{ marginTop: "16px" }}>Berlin Timezone</Text>
+          <RangePicker
+            timezone="Europe/Berlin"
+            placeholders={{
+              startDate: "Start (Berlin time)",
+              endDate: "End (Berlin time)"
+            }}
+            onSelect={(range) => console.log('Berlin RangePicker - Selected:', range)}
+          />
+
+          <Text weight="medium" style={{ marginTop: "16px" }}>New York Timezone</Text>
+          <RangePicker 
+            timezone="America/New_York"
+            placeholders={{
+              startDate: "Start (NY time)",
+              endDate: "End (NY time)"
+            }}
+            onSelect={(range) => console.log('NY RangePicker - Selected:', range)}
+          />
+
+          <Text weight="medium" style={{ marginTop: "16px" }}>Singapore Timezone</Text>
+          <RangePicker 
+            timezone="Asia/Singapore"
+            placeholders={{
+              startDate: "Start (Singapore time)",
+              endDate: "End (Singapore time)"
+            }}
+            onSelect={(range) => console.log('Singapore RangePicker - Selected:', range)}
+          />
 
           <Search
             placeholder="Default small search"

--- a/apps/www/src/app/examples/page.tsx
+++ b/apps/www/src/app/examples/page.tsx
@@ -7,6 +7,9 @@ import {
   IconButton,
   Search,
   TextArea,
+  RangePicker,
+  Callout,
+  DatePicker,
 } from "@raystack/apsara/v1";
 import React, { useState } from "react";
 import {
@@ -122,6 +125,11 @@ const Page = () => {
             }
             onClear={() => setSearch1("")}
           />
+          
+          <RangePicker
+               />
+
+          <DatePicker />
 
           <Search
             placeholder="Default small search"

--- a/apps/www/src/content/docs/components/calendar/props.ts
+++ b/apps/www/src/content/docs/components/calendar/props.ts
@@ -42,9 +42,27 @@ export interface RangePickerProps {
    * @defaultValue true
    */
   showCalendarIcon?: boolean;
+
+  /**
+   * Timezone string (e.g., "America/New_York", "Asia/Tokyo")
+   * If not provided, dates will be displayed in the local timezone
+   */
+  timezone?: string;
 }
 
 export interface DatePickerProps {
+  /** Format for displaying the date (e.g., "DD/MM/YYYY") */
+  dateFormat?: string;
+
+  /** Callback function when date is selected */
+  onSelect?: (date: Date) => void;
+
+  /** Initial date value */
+  value?: Date;
+
+  /** Props for customizing the calendar */
+  calendarProps?: CalendarProps;
+
   /** Props for customizing the text field */
   textFieldProps?: Record<string, unknown>;
 
@@ -56,4 +74,10 @@ export interface DatePickerProps {
    * @defaultValue true
    */
   showCalendarIcon?: boolean;
+
+  /**
+   * Timezone string (e.g., "America/New_York", "Asia/Tokyo")
+   * If not provided, dates will be displayed in the local timezone
+   */
+  timezone?: string;
 }

--- a/packages/raystack/v1/components/calendar/calendar.module.css
+++ b/packages/raystack/v1/components/calendar/calendar.module.css
@@ -1,14 +1,13 @@
 .calendarRoot {
-  padding: var(--rs-space-5);
+  padding: var(--rs-space-3);
   border-radius: var(--rs-radius-4);
-  border: 1px solid var(--rs-color-border-base-primary);
   background: var(--rs-color-background-base-primary);
   width: fit-content;
   font-family: var(--rs-font-body);
 }
 
 .caption_label,
-.dropdowns > span,
+.dropdowns>span,
 .dropdown_trigger .dropdown_item_text {
   font-family: var(--rs-font-body);
   font-weight: var(--rs-font-weight-medium);
@@ -50,7 +49,7 @@
 
 .months {
   display: flex;
-  gap: var(--rs-space-3);
+  gap: var(--rs-space-4);
   position: relative;
 }
 
@@ -110,6 +109,7 @@
 .range_middle {
   border-radius: 0;
   background-color: var(--rs-color-background-base-primary-hover);
+
   button {
     color: var(--rs-color-foreground-base-primary);
   }
@@ -186,8 +186,9 @@
 }
 
 .calendarPopover {
-  padding: 0 !important;
-  border: none !important;
+  padding: var(--rs-space-3) !important;
+  /* border: none !important; */
+  border: 1px solid var(--rs-color-border-base-primary) !important;
   min-width: max-content;
   width: fit-content;
   max-width: none !important;
@@ -217,7 +218,7 @@
 
 .dropdown_content {
   max-height: 400px;
-  border: 1px solid var(--rs-color-border-base-primary);
+  /* border: 1px solid var(--rs-color-border-base-primary); */
 }
 
 .disabled {
@@ -262,4 +263,13 @@
 
 .datePickerInput {
   text-align: left;
+  outline: 0.5px solid var(--rs-color-border-base-tertiary) !important;
+}
+
+.calendarFooter {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--rs-space-3);
+  margin-top: var(--rs-space-2);
 }

--- a/packages/raystack/v1/components/calendar/date-picker.tsx
+++ b/packages/raystack/v1/components/calendar/date-picker.tsx
@@ -1,6 +1,8 @@
 import { CalendarIcon } from "@radix-ui/react-icons";
 import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { PropsBase, PropsSingleRequired } from "react-day-picker";
 
@@ -11,6 +13,8 @@ import { Calendar } from "./calendar";
 import styles from "./calendar.module.css";
 
 dayjs.extend(customParseFormat);
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 interface DatePickerProps {
   side?: "top" | "right" | "bottom" | "left";
@@ -24,6 +28,7 @@ interface DatePickerProps {
     | React.ReactNode
     | ((props: { selectedDate: string }) => React.ReactNode);
   showCalendarIcon?: boolean;
+  timezone?: string;
 }
 
 export function DatePicker({
@@ -36,13 +41,14 @@ export function DatePicker({
   onSelect = () => {},
   children,
   showCalendarIcon = true,
+  timezone = dayjs.tz.guess(),
 }: DatePickerProps) {
   const [showCalendar, setShowCalendar] = useState(false);
   const [selectedDate, setSelectedDate] = useState(value);
   const [inputState, setInputState] =
     useState<Partial<React.ComponentProps<typeof TextField>["state"]>>();
 
-  const formattedDate = dayjs(selectedDate).format(dateFormat);
+  const formattedDate = dayjs(selectedDate).tz(timezone).format(dateFormat);
 
   const isDropdownOpenRef = useRef(false);
   const textFieldRef = useRef<HTMLInputElement | null>(null);
@@ -76,7 +82,7 @@ export function DatePicker({
     isInputFieldFocused.current = false;
     setShowCalendar(false);
 
-    const updatedVal = dayjs(selectedDateRef.current).format(dateFormat);
+    const updatedVal = dayjs(selectedDateRef.current).tz(timezone).format(dateFormat);
 
     if (textFieldRef.current) textFieldRef.current.value = updatedVal;
     if (inputState === undefined && !skipUpdate)
@@ -142,7 +148,7 @@ export function DatePicker({
         return `${day.padStart(2, "0")}/${month.padStart(2, "0")}/${year}`; // Replaces [8/8/2024] to [08/08/2024]
       }),
       format
-    );
+    ).tz(timezone);
 
     const isValidDate = date.isValid();
 

--- a/packages/raystack/v1/components/calendar/range-picker.tsx
+++ b/packages/raystack/v1/components/calendar/range-picker.tsx
@@ -1,5 +1,7 @@
 import { CalendarIcon } from "@radix-ui/react-icons";
 import dayjs from "dayjs";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
 import { useState } from "react";
 import { DateRange, PropsBase, PropsRangeRequired } from "react-day-picker";
 
@@ -9,6 +11,9 @@ import { TextField } from "../textfield";
 import { TextfieldProps } from "../textfield/textfield";
 import { Calendar } from "./calendar";
 import styles from "./calendar.module.css";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 interface RangePickerProps {
   side?: "top" | "right" | "bottom" | "left";
@@ -22,6 +27,7 @@ interface RangePickerProps {
   children?: React.ReactNode | ((props: { startDate: string; endDate: string }) => React.ReactNode);
   showCalendarIcon?: boolean;
   footer?: React.ReactNode;
+  timezone?: string;
 }
 
 type RangeFields = keyof DateRange;
@@ -41,13 +47,18 @@ export function RangePicker({
   children,
   showCalendarIcon = true,
   footer,
+  timezone = dayjs.tz.guess(),
 }: RangePickerProps) {
   const [showCalendar, setShowCalendar] = useState(false);
   const [currentRangeField, setCurrentRangeField] = useState<RangeFields>("from");
   const [selectedRange, setSelectedRange] = useState(value);
 
-  const startDate = selectedRange.from ? dayjs(selectedRange.from).format(dateFormat) : '';
-  const endDate = selectedRange.to ? dayjs(selectedRange.to).format(dateFormat) : '';
+  const startDate = selectedRange.from 
+    ? dayjs(selectedRange.from).tz(timezone).format(dateFormat)
+    : '';
+  const endDate = selectedRange.to 
+    ? dayjs(selectedRange.to).tz(timezone).format(dateFormat)
+    : '';
 
   // 1st click will select the start date.
   // 2nd click will select the end date.

--- a/packages/raystack/v1/components/calendar/range-picker.tsx
+++ b/packages/raystack/v1/components/calendar/range-picker.tsx
@@ -21,6 +21,7 @@ interface RangePickerProps {
   value?: DateRange;
   children?: React.ReactNode | ((props: { startDate: string; endDate: string }) => React.ReactNode);
   showCalendarIcon?: boolean;
+  footer?: React.ReactNode;
 }
 
 type RangeFields = keyof DateRange;
@@ -39,6 +40,7 @@ export function RangePicker({
   pickerGroupClassName,
   children,
   showCalendarIcon = true,
+  footer,
 }: RangePickerProps) {
   const [showCalendar, setShowCalendar] = useState(false);
   const [currentRangeField, setCurrentRangeField] = useState<RangeFields>("from");
@@ -113,6 +115,11 @@ export function RangePicker({
           selected={selectedRange}
           onSelect={handleSelect}
         />
+        {footer && (
+          <div className={styles.calendarFooter}>
+            {footer}
+          </div>
+        )}
       </Popover.Content>
     </Popover>
   );


### PR DESCRIPTION
## Description

 **Feat: Add custom timezone support for Range-picker and Date-picker.**

- Range-picker and Date-picker should show the timezone passed by the user. All UI interactions should be in passed timezone including the selected date in the trigger.
- Default timezone will be the user local timezone i.e. if no timezone is passed.
- Component should output the value as { selected: …, local: …. } where selected in the date in the current set timezone and local is the date in user's local timezone. 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

Manual

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (.mdx files)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

[Add screenshots here]

## Related Issues

[Link any related issues here using #issue-number]
