### PR TITLE
Feat/same date click 5738

### DIFF
--- a/apps/www/src/app/examples/page.tsx
+++ b/apps/www/src/app/examples/page.tsx
@@ -7,6 +7,7 @@ import {
   IconButton,
   Search,
   TextArea,
+  RangePicker,
 } from "@raystack/apsara/v1";
 import React, { useState } from "react";
 import {
@@ -191,6 +192,17 @@ const Page = () => {
             label="Disabled"
             value="This is disabled"
             disabled
+          />
+
+          <Text size="large" weight="medium" style={{ marginTop: "24px", marginBottom: "16px" }}>
+            Date Range Picker
+          </Text>
+
+          <RangePicker
+            onSelect={(range) => console.log('Selected date range:', range)}
+            textFieldProps={{
+              label: "Select Date Range"
+            }}
           />
         </Flex>
 

--- a/apps/www/src/content/docs/components/calendar/index.mdx
+++ b/apps/www/src/content/docs/components/calendar/index.mdx
@@ -66,7 +66,29 @@ Choose between different variants to convey different meanings or importance lev
 
 ### Range Picker
 
-The Badge component supports three sizes to accommodate various layout requirements. Default size is `small`.
+The Range Picker component allows selecting a date range with the following behaviors:
+
+1. When selecting two different dates:
+   - The start date (`from`) will be the first selected date
+   - The end date (`to`) will be one day after the second selected date
+   ```tsx
+   // Example: If user selects April 1st and April 10th, 2025
+   {
+     "from": "2025-04-01T18:30:00.000Z",
+     "to": "2025-04-11T18:30:00.000Z"  // One day after selected end date
+   }
+   ```
+
+2. When clicking the same date twice:
+   - The start date (`from`) will be the selected date
+   - The end date (`to`) will be one day after the selected date
+   ```tsx
+   // Example: If user clicks April 1st, 2025 twice
+   {
+     "from": "2025-04-01T18:30:00.000Z",
+     "to": "2025-04-02T18:30:00.000Z"  // One day after selected end date
+   }
+   ```
 
 <Demo data={rangePickerDemo} />
 

--- a/apps/www/src/content/docs/components/calendar/index.mdx
+++ b/apps/www/src/content/docs/components/calendar/index.mdx
@@ -69,10 +69,12 @@ Choose between different variants to convey different meanings or importance lev
 The Range Picker component allows selecting a date range with the following behaviors:
 
 1. When selecting two different dates:
-   - The start date (`from`) will be the first selected date
-   - The end date (`to`) will be one day after the second selected date
+   - The UI will show the exact selected dates
+   - The callback will return the start date as selected and end date as one day after
    ```tsx
    // Example: If user selects April 1st and April 10th, 2025
+   // UI will show: April 1st, 2025 - April 10th, 2025
+   // Callback will return:
    {
      "from": "2025-04-01T18:30:00.000Z",
      "to": "2025-04-11T18:30:00.000Z"  // One day after selected end date
@@ -80,13 +82,15 @@ The Range Picker component allows selecting a date range with the following beha
    ```
 
 2. When clicking the same date twice:
-   - The start date (`from`) will be the selected date
-   - The end date (`to`) will be one day after the selected date
+   - The UI will show the same date for both start and end
+   - The callback will return the start date as selected and end date as one day after
    ```tsx
    // Example: If user clicks April 1st, 2025 twice
+   // UI will show: April 1st, 2025 - April 1st, 2025
+   // Callback will return:
    {
      "from": "2025-04-01T18:30:00.000Z",
-     "to": "2025-04-02T18:30:00.000Z"  // One day after selected end date
+     "to": "2025-04-02T18:30:00.000Z"  // One day after selected date
    }
    ```
 

--- a/packages/raystack/v1/components/calendar/range-picker.tsx
+++ b/packages/raystack/v1/components/calendar/range-picker.tsx
@@ -54,12 +54,23 @@ export function RangePicker({
     const from = selectedRange?.from || range?.from;
     let newRange: DateRange;
     
-    if (currentRangeField === "to" && dayjs(selectedDay).isAfter(dayjs(from))) {
-      // update the end date
-      newRange = { from, to: selectedDay };
+    if (currentRangeField === "to") {
+      if (dayjs(selectedDay).isSame(dayjs(from), 'day')) {
+        // If same date is clicked twice, set end date to the same date
+        newRange = {
+          from,
+          to: selectedDay
+        };
+      } else if (dayjs(selectedDay).isAfter(dayjs(from))) {
+        // If different date is selected and it's after start date
+        newRange = { from, to: selectedDay };
+      } else {
+        // If selected date is before start date, reset and select start day
+        newRange = { from: selectedDay };
+      }
       setCurrentRangeField("from");
     } else {
-      // reset the range and select start day
+      // Reset the range and select start day
       newRange = { from: selectedDay };
       setCurrentRangeField("to");
     }

--- a/packages/raystack/v1/components/calendar/range-picker.tsx
+++ b/packages/raystack/v1/components/calendar/range-picker.tsx
@@ -56,14 +56,17 @@ export function RangePicker({
     
     if (currentRangeField === "to") {
       if (dayjs(selectedDay).isSame(dayjs(from), 'day')) {
-        // If same date is clicked twice, set end date to the same date
+        // If same date is clicked twice, set end date to next day
         newRange = {
           from,
-          to: selectedDay
+          to: dayjs(selectedDay).add(1, 'day').toDate()
         };
       } else if (dayjs(selectedDay).isAfter(dayjs(from))) {
-        // If different date is selected and it's after start date
-        newRange = { from, to: selectedDay };
+        // If different date is selected and it's after start date, add one day to end date
+        newRange = { 
+          from, 
+          to: dayjs(selectedDay).add(1, 'day').toDate() 
+        };
       } else {
         // If selected date is before start date, reset and select start day
         newRange = { from: selectedDay };

--- a/packages/raystack/v1/components/calendar/range-picker.tsx
+++ b/packages/raystack/v1/components/calendar/range-picker.tsx
@@ -56,17 +56,14 @@ export function RangePicker({
     
     if (currentRangeField === "to") {
       if (dayjs(selectedDay).isSame(dayjs(from), 'day')) {
-        // If same date is clicked twice, set end date to next day
+        // If same date is clicked twice, set end date to the same date for UI
         newRange = {
           from,
-          to: dayjs(selectedDay).add(1, 'day').toDate()
+          to: selectedDay
         };
       } else if (dayjs(selectedDay).isAfter(dayjs(from))) {
-        // If different date is selected and it's after start date, add one day to end date
-        newRange = { 
-          from, 
-          to: dayjs(selectedDay).add(1, 'day').toDate() 
-        };
+        // If different date is selected and it's after start date
+        newRange = { from, to: selectedDay };
       } else {
         // If selected date is before start date, reset and select start day
         newRange = { from: selectedDay };
@@ -79,7 +76,13 @@ export function RangePicker({
     }
     
     setSelectedRange(newRange);
-    onSelect(newRange);
+    
+    // Return the range with +1 day for the end date in the callback
+    const callbackRange = {
+      from: newRange.from,
+      to: newRange.to ? dayjs(newRange.to).add(1, 'day').toDate() : undefined
+    };
+    onSelect(callbackRange);
   };
 
   function onOpenChange(open?: boolean) {


### PR DESCRIPTION
## Description

## BREAKING CHANGE

- Feat: Add support for the same date click on range-picker.
- Docs: Update docs
- Feat: Make to date exclusive:

If user clicks on same date twice (example clicked twice on 1 Apr, 2025), below should be the date object value:
```
{
  "from": "2025-04-01T18:30:00.000Z",
  "to": "2025-05-02T18:30:00.000Z"
}
```
Similarly, if user clicks on two separate dates in range-picker (eg: from: 1st April, 2025 and to: 10 April, 2025), below should be the date object value:

```
{
  "from": "2025-04-01T18:30:00.000Z",
  "to": "2025-04-011T18:30:00.000Z"
}
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

[Describe the tests that you ran to verify your changes]

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (.mdx files)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

[Add screenshots here]

## Related Issues

[Link any related issues here using #issue-number]
