### PR TITLE
chore: Merge old styles for Text and Headline backwards compatibility

### DIFF
--- a/packages/raystack/v1/components/headline/headline.module.css
+++ b/packages/raystack/v1/components/headline/headline.module.css
@@ -29,6 +29,20 @@
   letter-spacing: var(--rs-letter-spacing-t4);
 }
 
+/* Deprecated Headline Size */
+.headline-small {
+  font-size: 24px;
+  line-height: 32px;
+}
+.headline-medium {
+  font-size: 28px;
+  line-height: 36px;
+}
+.headline-large {
+  font-size: 32px;
+  line-height: 40px;
+}
+
 .headline-align-left {
   text-align: left;
 }

--- a/packages/raystack/v1/components/headline/headline.tsx
+++ b/packages/raystack/v1/components/headline/headline.tsx
@@ -10,6 +10,9 @@ const headline = cva(styles.headline, {
       t2: styles["headline-t2"],
       t3: styles["headline-t3"],
       t4: styles["headline-t4"],
+      small: styles["headline-small"],
+      medium: styles["headline-medium"],
+      large: styles["headline-large"],
     },
     align: {
       left: styles["headline-align-left"],
@@ -21,13 +24,18 @@ const headline = cva(styles.headline, {
     },
   },
   defaultVariants: {
-    size: "t1",
+    size: "t2",
     align: "left",
     truncate: false,
   },
 });
 
-export type HeadlineBaseProps = VariantProps<typeof headline>;
+export type HeadlineBaseProps = VariantProps<typeof headline> & {
+  /**
+   * @remarks Use "t1" | "t2" | "t3" | "t4"
+   */
+  size?: "t1" | "t2" | "t3" | "t4" | "small" | "medium" | "large";
+};
 
 type HeadlineProps = HeadlineBaseProps &
   HTMLAttributes<HTMLHeadingElement> & {

--- a/packages/raystack/v1/components/text/text.module.css
+++ b/packages/raystack/v1/components/text/text.module.css
@@ -95,51 +95,39 @@
 .text-weight-bold {
   font-weight: bold;
 }
-
 .text-weight-bolder {
   font-weight: bolder;
 }
-
 .text-weight-normal {
   font-weight: normal;
 }
-
 .text-weight-lighter {
   font-weight: lighter;
 }
-
 .text-weight-100 {
   font-weight: 100;
 }
-
 .text-weight-200 {
   font-weight: 200;
 }
-
 .text-weight-300 {
   font-weight: 300;
 }
-
 .text-weight-400 {
   font-weight: var(--rs-font-weight-regular);
 }
-
 .text-weight-500 {
   font-weight: var(--rs-font-weight-medium);
 }
-
 .text-weight-600 {
   font-weight: 600;
 }
-
 .text-weight-700 {
   font-weight: 700;
 }
-
 .text-weight-800 {
   font-weight: 800;
 }
-
 .text-weight-900 {
   font-weight: 900;
 }

--- a/packages/raystack/v1/components/text/text.module.css
+++ b/packages/raystack/v1/components/text/text.module.css
@@ -31,12 +31,117 @@
   letter-spacing: var(--rs-letter-spacing-large);
 }
 
+/* @deprecated Text Size */
+.text-1 {
+  font-size: var(--rs-font-size-mini);
+  line-height: var(--rs-line-height-mini);
+  letter-spacing: var(--rs-letter-spacing-mini);
+}
+.text-2 {
+  font-size: var(--rs-font-size-small);
+  line-height: var(--rs-line-height-small);
+  letter-spacing: var(--rs-letter-spacing-small);
+}
+.text-3 {
+  font-size: 13px;
+  line-height: var(--rs-line-height-mini);
+  letter-spacing: var(--rs-letter-spacing-small);
+}
+.text-4 {
+  font-size: var(--rs-font-size-regular);
+  line-height: var(--rs-line-height-regular);
+  letter-spacing: var(--rs-letter-spacing-regular);
+}
+.text-5 {
+  font-size: var(--rs-font-size-large);
+  line-height: var(--rs-line-height-large);
+  letter-spacing: var(--rs-letter-spacing-large);
+}
+.text-6 {
+  font-size: 18px;
+  line-height: var(--rs-line-height-regular);
+  letter-spacing: var(--rs-letter-spacing-regular);
+}
+.text-7 {
+  font-size: 20px;
+  line-height: var(--rs-line-height-large);
+  letter-spacing: var(--rs-letter-spacing-large);
+}
+.text-8 {
+  font-size: 22px;
+  line-height: 28px;
+  letter-spacing: var(--rs-letter-spacing-large);
+}
+.text-9 {
+  font-size: 24px;
+  line-height: 32px;
+  letter-spacing: var(--rs-letter-spacing-large);
+}
+.text-10 {
+  font-size: 28px;
+  line-height: 36px;
+  letter-spacing: var(--rs-letter-spacing-large);
+}
+
 /* Text Weight */
 .text-weight-regular {
   font-weight: var(--rs-font-weight-regular);
 }
 .text-weight-medium {
   font-weight: var(--rs-font-weight-medium);
+}
+
+/* @deprecated Text Weight */
+.text-weight-bold {
+  font-weight: bold;
+}
+
+.text-weight-bolder {
+  font-weight: bolder;
+}
+
+.text-weight-normal {
+  font-weight: normal;
+}
+
+.text-weight-lighter {
+  font-weight: lighter;
+}
+
+.text-weight-100 {
+  font-weight: 100;
+}
+
+.text-weight-200 {
+  font-weight: 200;
+}
+
+.text-weight-300 {
+  font-weight: 300;
+}
+
+.text-weight-400 {
+  font-weight: var(--rs-font-weight-regular);
+}
+
+.text-weight-500 {
+  font-weight: var(--rs-font-weight-medium);
+}
+
+.text-weight-600 {
+  font-weight: 600;
+}
+
+.text-weight-700 {
+  font-weight: 700;
+}
+
+.text-weight-800 {
+  font-weight: 800;
+}
+
+.text-weight-900 {
+  font-weight: 900;
 }
 
 /* Text Variant */

--- a/packages/raystack/v1/components/text/text.tsx
+++ b/packages/raystack/v1/components/text/text.tsx
@@ -21,10 +21,33 @@ export const textVariants = cva(styles.text, {
       small: styles["text-small"],
       regular: styles["text-regular"],
       large: styles["text-large"],
+      1: styles["text-1"],
+      2: styles["text-2"],
+      3: styles["text-3"],
+      4: styles["text-4"],
+      5: styles["text-5"],
+      6: styles["text-6"],
+      7: styles["text-7"],
+      8: styles["text-8"],
+      9: styles["text-9"],
+      10: styles["text-10"],
     },
     weight: {
       regular: styles["text-weight-regular"],
       medium: styles["text-weight-medium"],
+      bold: styles["text-weight-bold"],
+      bolder: styles["text-weight-bolder"],
+      normal: styles["text-weight-normal"],
+      lighter: styles["text-weight-lighter"],
+      100: styles["text-weight-100"],
+      200: styles["text-weight-200"],
+      300: styles["text-weight-300"],
+      400: styles["text-weight-400"],
+      500: styles["text-weight-500"],
+      600: styles["text-weight-600"],
+      700: styles["text-weight-700"],
+      800: styles["text-weight-800"],
+      900: styles["text-weight-900"],
     },
     transform: {
       capitalize: styles["text-transform-capitalize"],
@@ -56,7 +79,7 @@ export const textVariants = cva(styles.text, {
   },
   defaultVariants: {
     variant: "primary",
-    size: "regular",
+    size: "small",
     weight: "regular",
   },
   compoundVariants: [
@@ -68,7 +91,46 @@ export const textVariants = cva(styles.text, {
   ],
 });
 
-export type TextBaseProps = VariantProps<typeof textVariants>;
+export type TextBaseProps = VariantProps<typeof textVariants> & {
+  /**
+   * @remarks Use "micro", "mini", "small", "regular", "large"
+   */
+  size?:
+    | 1
+    | 2
+    | 3
+    | 4
+    | 5
+    | 6
+    | 7
+    | 8
+    | 9
+    | 10
+    | "micro"
+    | "mini"
+    | "small"
+    | "regular"
+    | "large";
+  /**
+   * @remarks Use "regular", "medium"
+   */
+  weight?:
+    | "regular"
+    | "medium"
+    | "bold"
+    | "bolder"
+    | "normal"
+    | "lighter"
+    | 100
+    | 200
+    | 300
+    | 400
+    | 500
+    | 600
+    | 700
+    | 800
+    | 900;
+};
 
 type TextSpanProps = { as?: "span" } & ComponentPropsWithoutRef<"span">;
 type TextDivProps = { as: "div" } & ComponentPropsWithoutRef<"div">;

--- a/packages/raystack/v1/components/text/text.tsx
+++ b/packages/raystack/v1/components/text/text.tsx
@@ -93,7 +93,7 @@ export const textVariants = cva(styles.text, {
 
 export type TextBaseProps = VariantProps<typeof textVariants> & {
   /**
-   * @remarks Use "micro", "mini", "small", "regular", "large"
+   * @remarks Use "micro" | "mini" | "small" | "regular" | "large"
    */
   size?:
     | 1
@@ -112,7 +112,7 @@ export type TextBaseProps = VariantProps<typeof textVariants> & {
     | "regular"
     | "large";
   /**
-   * @remarks Use "regular", "medium"
+   * @remarks Use "regular" | "medium"
    */
   weight?:
     | "regular"


### PR DESCRIPTION
## Description

This PR adds the old styles back for backwards compatibility for the following components
- Text
- Headline

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [x] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

Manual

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (.mdx files)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works