### PR TITLE
fix: add max-width to empty state

### DIFF
--- a/apps/www/src/app/examples/page.tsx
+++ b/apps/www/src/app/examples/page.tsx
@@ -379,8 +379,8 @@ const Page = () => {
 
           <EmptyState
             icon={<FilterIcon />}
-            heading="KYC required for image orders KYC required for image orders KYC required for image orders"
-            subHeading="Please contact your organization owner to complete the KYC process for the image orders. You can also contact support@raystack.io for assistance. Please contact your organization owner to complete the KYC process for the image orders."
+            heading="KYC required for image orders"
+            subHeading="Please contact your organization owner to complete the KYC process for the image orders. You can also contact support@raystack.io for assistance."
             primaryAction={<Button variant="outline" color="neutral">Add Data</Button>}
             variant="empty1"
           />

--- a/apps/www/src/app/examples/page.tsx
+++ b/apps/www/src/app/examples/page.tsx
@@ -13,6 +13,15 @@ import {
   DatePicker,
   Spinner,
   DropdownMenu,
+  Dialog,
+  Avatar,
+  AvatarGroup,
+  Tooltip,
+  InputField,
+  Popover,
+  Indicator,
+  Sheet,
+  EmptyState,
 } from "@raystack/apsara/v1";
 import React, { useState } from "react";
 import {
@@ -128,7 +137,6 @@ const Page = () => {
             size={4}
             aria-label={sidebarOpen ? "Collapse sidebar" : "Expand sidebar"}
             onClick={() => setSidebarOpen(!sidebarOpen)}
-            variant="ghost"
             style={{ marginBottom: "16px" }}>
             <SidebarIcon />
           </IconButton>
@@ -369,6 +377,14 @@ const Page = () => {
             Select Examples
           </Text>
 
+          <EmptyState
+            icon={<FilterIcon />}
+            heading="KYC required for image orders KYC required for image orders KYC required for image orders"
+            subHeading="Please contact your organization owner to complete the KYC process for the image orders. You can also contact support@raystack.io for assistance. Please contact your organization owner to complete the KYC process for the image orders."
+            primaryAction={<Button variant="outline" color="neutral">Add Data</Button>}
+            variant="empty1"
+          />
+
           <TextArea label="Read Only" value="This is a read only text area" />
 
           <Flex direction="column" gap={4} style={{ maxWidth: "150px" }}>
@@ -394,7 +410,7 @@ const Page = () => {
               </Select>
 
               <Select value={selectValue} onValueChange={setSelectValue}>
-                <Select.Trigger size="small" variant="filter">
+                <Select.Trigger size="small" variant="text">
                   <Select.Value placeholder="Choose an options option option" />
                 </Select.Trigger>
                 <Select.Content>
@@ -502,7 +518,7 @@ const Page = () => {
               </Select>
             </Flex>
 
-            <Flex direction="column" gap="2">
+            <Flex direction="column" gap={2}>
               <Text size="small">Test Normal size:</Text>
               <Select
                 value={selectValue}

--- a/packages/raystack/v1/components/empty-state/empty-state.module.css
+++ b/packages/raystack/v1/components/empty-state/empty-state.module.css
@@ -53,6 +53,8 @@
   font-weight: var(--rs-font-weight-medium);
   line-height: var(--rs-line-height-large);
   letter-spacing: var(--rs-letter-spacing-large);
+  text-wrap: wrap;
+  max-width: 360px;
 }
 
 .subHeaderText {
@@ -63,16 +65,9 @@
   font-weight: var(--rs-font-weight-regular);
   line-height: var(--rs-line-height-regular);
   letter-spacing: var(--rs-letter-spacing-regular);
-}
-
-.headerText {
+  text-wrap: wrap;
   max-width: 360px;
 }
-
-.subHeaderText {
-  max-width: 288px;
-}
-
 
 /* Empty2 */
 
@@ -88,8 +83,6 @@
 .emptyStateContent .subHeaderText {
   max-width: 366px;
 }
-
-
 
 .emptyStateLeft {
   padding: var(--rs-space-9) var(--rs-space-5);


### PR DESCRIPTION
## Description

Fix: Add `text-wrap: wrap;` and `max-width: 360px;` to header and subHeader texts in EmptyState.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (.mdx files)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
<img width="524" alt="Screenshot 2025-04-15 at 2 00 31 PM" src="https://github.com/user-attachments/assets/11a340f0-560f-49be-8d94-9e43458bf2d8" />


