### PR TITLE
Fix: Avatar overflow style mismatch

### DIFF
--- a/apps/www/src/app/examples/page.tsx
+++ b/apps/www/src/app/examples/page.tsx
@@ -976,6 +976,36 @@ const Page = () => {
             </Flex>
           </Flex>
 
+          <Text
+            size="large"
+            weight="medium"
+            style={{ marginTop: "32px", marginBottom: "16px" }}>
+            Avatar Examples
+          </Text>
+
+          <Flex direction="column" gap={6}>
+            <Flex direction="column" gap={3}>
+                <AvatarGroup max={4}>
+                    <Tooltip message="JD">
+                      <Avatar radius="small" size={7} fallback="JD" color="indigo" />
+                    </Tooltip>
+                    <Tooltip message="AS">
+                      <Avatar radius="small" size={7} fallback="AS" color="mint" />
+                    </Tooltip>
+                    <Tooltip message="RK">
+                      <Avatar radius="small" size={7} fallback="RK" color="sky" />
+                    </Tooltip>
+                    <Tooltip message="PL">
+                      <Avatar radius="small" size={7} fallback="PL" color="purple" />
+                    </Tooltip>
+                    <Tooltip message="MN">
+                      <Avatar radius="small" size={7} fallback="MN" color="pink" />
+                    </Tooltip>
+                </AvatarGroup>
+              </Flex>
+            </Flex>
+
+
           <Flex justify="center" style={{ marginTop: 40 }}>
             <Button type="submit">Submit button</Button>
           </Flex>

--- a/packages/raystack/v1/components/avatar/avatar.tsx
+++ b/packages/raystack/v1/components/avatar/avatar.tsx
@@ -2,14 +2,13 @@ import {
   ComponentPropsWithoutRef,
   ElementRef,
   forwardRef,
-  ReactNode,
-  isValidElement
+  ReactNode
 } from "react";
 import * as AvatarPrimitive from "@radix-ui/react-avatar";
 import { cva, VariantProps } from "class-variance-authority";
 import { clsx } from 'clsx';
 
-import {AVATAR_COLORS} from './utils'
+import {AVATAR_COLORS, getAvatarProps} from './utils'
 import { Box } from "../box";
 import styles from "./avatar.module.css";
 
@@ -148,20 +147,6 @@ export const AvatarGroup = forwardRef<HTMLDivElement, AvatarGroupProps>(
     const avatars = max ? children.slice(0, max) : children;
     const count = max && children.length > max ? children.length - max : 0;
 
-    // This function is used to recursively get the avatar props even if it's wrapped in another component like Tooltip, Flex, etc.
-    const getAvatarProps = (element: React.ReactElement): AvatarProps => {
-      if (element.type === Avatar) {
-        return element.props;
-      }
-      
-      if (element.props.children) {
-        if (isValidElement(element.props.children)) {
-          return getAvatarProps(element.props.children);
-        }
-      }
-      return {};
-    };
-
     // Overflow avatar matches the first avatar styling
     const firstAvatarProps = getAvatarProps(avatars[0]);
 
@@ -183,7 +168,7 @@ export const AvatarGroup = forwardRef<HTMLDivElement, AvatarGroupProps>(
               radius={firstAvatarProps.radius}
               variant={firstAvatarProps.variant}
               color='neutral'
-              fallback={<span>+{count}</span>}
+              fallback={`+${count}`}
             />
           </div>
         )}

--- a/packages/raystack/v1/components/avatar/avatar.tsx
+++ b/packages/raystack/v1/components/avatar/avatar.tsx
@@ -1,16 +1,17 @@
-import * as AvatarPrimitive from "@radix-ui/react-avatar";
-import { cva, VariantProps } from "class-variance-authority";
-import { clsx } from 'clsx';
 import {
   ComponentPropsWithoutRef,
   ElementRef,
   forwardRef,
   ReactNode,
+  isValidElement
 } from "react";
+import * as AvatarPrimitive from "@radix-ui/react-avatar";
+import { cva, VariantProps } from "class-variance-authority";
+import { clsx } from 'clsx';
 
+import {AVATAR_COLORS} from './utils'
 import { Box } from "../box";
 import styles from "./avatar.module.css";
-import {AVATAR_COLORS} from './utils'
 
 const avatar = cva(styles.avatar, {
   variants: {
@@ -147,6 +148,23 @@ export const AvatarGroup = forwardRef<HTMLDivElement, AvatarGroupProps>(
     const avatars = max ? children.slice(0, max) : children;
     const count = max && children.length > max ? children.length - max : 0;
 
+    // This function is used to recursively get the avatar props even if it's wrapped in another component like Tooltip, Flex, etc.
+    const getAvatarProps = (element: React.ReactElement): AvatarProps => {
+      if (element.type === Avatar) {
+        return element.props;
+      }
+      
+      if (element.props.children) {
+        if (isValidElement(element.props.children)) {
+          return getAvatarProps(element.props.children);
+        }
+      }
+      return {};
+    };
+
+    // Overflow avatar matches the first avatar styling
+    const firstAvatarProps = getAvatarProps(avatars[0]);
+
     return (
       <div
         ref={ref}
@@ -161,9 +179,9 @@ export const AvatarGroup = forwardRef<HTMLDivElement, AvatarGroupProps>(
         {count > 0 && (
           <div className={styles.avatarWrapper}>
             <Avatar
-              size={avatars[0].props.size}
-              radius={avatars[0].props.radius}
-              variant={avatars[0].props.variant}
+              size={firstAvatarProps.size}
+              radius={firstAvatarProps.radius}
+              variant={firstAvatarProps.variant}
               color='neutral'
               fallback={<span>+{count}</span>}
             />

--- a/packages/raystack/v1/components/avatar/utils.test.ts
+++ b/packages/raystack/v1/components/avatar/utils.test.ts
@@ -1,4 +1,7 @@
-import { getAvatarColor } from "./utils";
+import { getAvatarColor, getAvatarProps } from "./utils";
+import { Avatar } from "./avatar";
+import React from "react";
+
 describe("getAvatarColor", () => {
   it("should return same color for the same name", () => {
     const color = getAvatarColor("John Doe");
@@ -21,5 +24,49 @@ describe("getAvatarColor", () => {
     const id = "John_Doe!@#$%^&";
     const color = getAvatarColor(id);
     expect(color).toBe("grass");
+  });
+});
+
+describe("getAvatarProps", () => {
+  it("should return props directly from Avatar component", () => {
+    const props = {
+      size: 5 as const,
+      color: "indigo" as const,
+      fallback: "GS",
+    };
+    const element = React.createElement(Avatar, props);
+    const result = getAvatarProps(element);
+    expect(result).toEqual(props);
+  });
+
+  it("should return props from Avatar wrapped in another component", () => {
+    const avatarProps = {
+      size: 5 as const,
+      color: "mint" as const,
+      fallback: "GS",
+    };
+    const avatar = React.createElement(Avatar, avatarProps);
+    const wrapper = React.createElement('div', {}, avatar);
+    const result = getAvatarProps(wrapper);
+    expect(result).toEqual(avatarProps);
+  });
+
+  it("should return props from deeply nested Avatar", () => {
+    const avatarProps = {
+      size: 7 as const,
+      color: "sky" as const,
+      fallback: "GS",
+    };
+    const avatar = React.createElement(Avatar, avatarProps);
+    const innerWrapper = React.createElement('div', {}, avatar);
+    const outerWrapper = React.createElement('div', {}, innerWrapper);
+    const result = getAvatarProps(outerWrapper);
+    expect(result).toEqual(avatarProps);
+  });
+
+  it("should return empty object when children is not a valid element", () => {
+    const element = React.createElement('div', {}, 'text content');
+    const result = getAvatarProps(element);
+    expect(result).toEqual({});
   });
 });

--- a/packages/raystack/v1/components/avatar/utils.tsx
+++ b/packages/raystack/v1/components/avatar/utils.tsx
@@ -1,3 +1,8 @@
+import { isValidElement } from "react";
+import { Avatar } from "./avatar";
+
+import { AvatarProps } from "./avatar";
+
 export const COLORS = [
   "indigo",
   "orange",
@@ -21,3 +26,20 @@ export function getAvatarColor(str: string): AVATAR_COLORS {
   const index = hash % COLORS.length;
   return COLORS[index];
 }
+
+/*
+ * @desc This function is used to recursively get the avatar props 
+ * even if it's wrapped in another component like Tooltip, Flex, etc.
+ */ 
+export const getAvatarProps = (element: React.ReactElement): AvatarProps => {
+  if (element.type === Avatar) {
+    return element.props;
+  }
+  
+  if (element.props.children) {
+    if (isValidElement(element.props.children)) {
+      return getAvatarProps(element.props.children);
+    }
+  }
+  return {};
+};

--- a/packages/raystack/v1/components/avatar/utils.tsx
+++ b/packages/raystack/v1/components/avatar/utils.tsx
@@ -28,8 +28,8 @@ export function getAvatarColor(str: string): AVATAR_COLORS {
 }
 
 /*
- * @desc This function is used to recursively get the avatar props 
- * even if it's wrapped in another component like Tooltip, Flex, etc.
+ * @desc Recursively get the avatar props even if it's
+ * wrapped in another component like Tooltip, Flex, etc.
  */ 
 export const getAvatarProps = (element: React.ReactElement): AvatarProps => {
   if (element.type === Avatar) {

--- a/packages/raystack/v1/components/avatar/utils.tsx
+++ b/packages/raystack/v1/components/avatar/utils.tsx
@@ -32,13 +32,15 @@ export function getAvatarColor(str: string): AVATAR_COLORS {
  * wrapped in another component like Tooltip, Flex, etc.
  */ 
 export const getAvatarProps = (element: ReactElement): AvatarProps => {
+  const { props } = element;
+
   if (element.type === Avatar) {
-    return element.props;
+    return props;
   }
   
-  if (element.props.children) {
-    if (isValidElement(element.props.children)) {
-      return getAvatarProps(element.props.children);
+  if (props.children) {
+    if (isValidElement(props.children)) {
+      return getAvatarProps(props.children);
     }
   }
   return {};

--- a/packages/raystack/v1/components/avatar/utils.tsx
+++ b/packages/raystack/v1/components/avatar/utils.tsx
@@ -1,4 +1,4 @@
-import { isValidElement } from "react";
+import { isValidElement, ReactElement } from "react";
 import { Avatar } from "./avatar";
 
 import { AvatarProps } from "./avatar";
@@ -31,7 +31,7 @@ export function getAvatarColor(str: string): AVATAR_COLORS {
  * @desc Recursively get the avatar props even if it's
  * wrapped in another component like Tooltip, Flex, etc.
  */ 
-export const getAvatarProps = (element: React.ReactElement): AvatarProps => {
+export const getAvatarProps = (element: ReactElement): AvatarProps => {
   if (element.type === Avatar) {
     return element.props;
   }


### PR DESCRIPTION
## Description
The overflow Avatar picks the props of the first Avatar inside the AvatarGroup. If Avatar is enclosed inside another element like div, Flex, Tooltip, etc. overflow Avatar is no longer able to access Avatar props from the first level thus the styling of the overflow Avatar doesn't match other Avatars.

**Solution:**
Add a helper function which recursively checks if Avatar is enclosed inside other component and fetches the Avatar props and returns it. We match the props for overflow Avatar to the first Avatar.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [x] Test (adding missing tests or correcting existing tests)
- [ ] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

Manual and unit test for thegetAvatarProps function

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (.mdx files)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
**Before:**
<img width="191" alt="Screenshot 2025-04-23 at 11 48 27 AM" src="https://github.com/user-attachments/assets/7d95f6e8-2d69-4c24-90bf-59900be99d3c" />

**After:**
<img width="199" alt="Screenshot 2025-04-23 at 11 47 55 AM" src="https://github.com/user-attachments/assets/915e6ad8-a90b-4623-8f23-7d3b14d93ec9" />

