### PR TITLE
chore: deprecate old components

### DIFF
--- a/apps/www/src/content/docs/components/checkbox/index.mdx
+++ b/apps/www/src/content/docs/components/checkbox/index.mdx
@@ -12,7 +12,7 @@ import { playground, statesExamples } from "./demo.ts";
 You can control the checkbox state using the `checked` and `onCheckedChange` props:
 
 ```tsx
-import { Checkbox } from "@raystack/apsara";
+import { Checkbox } from "@raystack/apsara/v1";
 
 const [checked, setChecked] = useState(false);
 

--- a/apps/www/src/content/docs/components/command/index.mdx
+++ b/apps/www/src/content/docs/components/command/index.mdx
@@ -12,7 +12,7 @@ import { preview } from "./demo.ts";
 Import all parts and piece them together.
 
 ```tsx
-import { Command } from "@raystack/apsara";
+import { Command } from "@raystack/apsara/v1";
 
 <Command>
   <Command.Input placeholder="Type a command or search..." />

--- a/packages/raystack/errorstate/errorstate.tsx
+++ b/packages/raystack/errorstate/errorstate.tsx
@@ -72,6 +72,9 @@ type ErrorStateProps = PropsWithChildren<VariantProps<typeof errorstate>> &
     message?: string;
   };
 
+/**
+ * @deprecated Use EmptyState from '@raystack/apsara/v1' instead.
+ */
 export function ErrorState({
   children,
   className,

--- a/packages/raystack/textfield/textfield.tsx
+++ b/packages/raystack/textfield/textfield.tsx
@@ -28,7 +28,7 @@ const textfield = cva(styles.textfield, {
 });
 
 /**
- * @deprecated Use TextFieldProps from '@raystack/apsara/v1' instead.
+ * @deprecated Use InputFieldProps from '@raystack/apsara/v1' instead.
  */
 export type TextfieldProps = Omit<
   InputHTMLAttributes<HTMLInputElement>,

--- a/packages/raystack/textfield/textfield.tsx
+++ b/packages/raystack/textfield/textfield.tsx
@@ -27,6 +27,9 @@ const textfield = cva(styles.textfield, {
   },
 });
 
+/**
+ * @deprecated Use TextFieldProps from '@raystack/apsara/v1' instead.
+ */
 export type TextfieldProps = Omit<
   InputHTMLAttributes<HTMLInputElement>,
   "size"
@@ -37,6 +40,9 @@ export type TextfieldProps = Omit<
     iconClass?: { leadingIcon?: string; trailingIcon?: string };
   };
 
+/**
+ * @deprecated Use InputField from '@raystack/apsara/v1' instead.
+ */
 export const TextField = forwardRef<HTMLInputElement, TextfieldProps>(
   (
     {


### PR DESCRIPTION
## Description

- Deprecate old textField and ErrorState.
- Typo in doc

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (.mdx files)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

