### PR TITLE
Fix (Calendar): Set fixed height to prevent UI shift

### DIFF
--- a/apps/www/src/app/examples/page.tsx
+++ b/apps/www/src/app/examples/page.tsx
@@ -161,11 +161,11 @@ const Page = () => {
               onClear={() => setSearch1("")}
             />
 
+            <RangePicker footer={<Callout width="100%" type="success">Some important message in the footer</Callout>} />
+
             <RangePicker />
 
             <DatePicker />
-
-            <RangePicker />
 
             <Text
               size="large"

--- a/apps/www/src/content/docs/components/calendar/demo.ts
+++ b/apps/www/src/content/docs/components/calendar/demo.ts
@@ -40,11 +40,11 @@ export const rangePickerDemo = {
   tabs: [
     {
       name: "Basic",
-      code: `<RangePicker inputFieldsProps={{ startDate: { size: "large" } }} />`,
+      code: `<RangePicker />`,
     },
     {
       name: "Without Calendar Icon",
-      code: `<RangePicker showCalendarIcon={false} inputFieldsProps={{ startDate: { size: "large" } }} />`,
+      code: `<RangePicker showCalendarIcon={false} />`,
     },
     {
       name: "Custom Trigger",

--- a/packages/raystack/v1/components/calendar/calendar.module.css
+++ b/packages/raystack/v1/components/calendar/calendar.module.css
@@ -4,6 +4,7 @@
   background: var(--rs-color-background-base-primary);
   width: fit-content;
   font-family: var(--rs-font-body);
+  min-height: 324px;
 }
 
 .caption_label,


### PR DESCRIPTION
## Description

Fix: Prevent UI shift while changing month in date-picker and range-picker.
Docs: Update props for range-picker to appropriate context.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (.mdx files)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screen recording (if appropriate):

https://github.com/user-attachments/assets/fd31632d-5c44-491e-8a6e-7e755a8cede6

