### PR TITLE
fix: accommodate calendar height change due to new select

### DIFF
--- a/packages/raystack/v1/components/calendar/calendar.module.css
+++ b/packages/raystack/v1/components/calendar/calendar.module.css
@@ -4,7 +4,7 @@
   background: var(--rs-color-background-base-primary);
   width: fit-content;
   font-family: var(--rs-font-body);
-  min-height: 324px;
+  min-height: 334px;
 }
 
 .caption_label,


### PR DESCRIPTION
## Description

Fix: New select is causing the calendar popover height to increase.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [x] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

Manual in range-picker and date-picker.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (.mdx files)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works