### PR TITLE
feat: breadcrumb `as` support

### DIFF
--- a/apps/www/src/content/docs/components/breadcrumb/index.mdx
+++ b/apps/www/src/content/docs/components/breadcrumb/index.mdx
@@ -18,6 +18,10 @@ import {
 
 <auto-type-table path="./props.ts" name="BreadcrumbProps" />
 
+### BreadcrumbItem Props
+
+<auto-type-table path="./props.ts" name="BreadcrumbItem" />
+
 ## Examples
 
 ### Size

--- a/apps/www/src/content/docs/components/breadcrumb/props.ts
+++ b/apps/www/src/content/docs/components/breadcrumb/props.ts
@@ -1,28 +1,42 @@
+import { ReactElement } from 'react';
+
+export interface BreadcrumbItem {
+  /** Text to display for the item */
+  label: string;
+  /** URL for the item link */
+  href?: string;
+  /** Optional icon element to display */
+  icon?: React.ReactNode;
+  /** Optional array of dropdown items */
+  dropdownItems?: {
+    /** Text to display for the dropdown item */
+    label: string;
+    /** URL for the dropdown item link */
+    href?: string;
+  }[];
+  /**
+   * Custom element used to render the Item.
+   *
+   * All props are merged.
+   *
+   * @default "<a />"
+   */
+  as?: ReactElement;
+}
+
 export interface BreadcrumbProps {
   /**
    * Array of breadcrumb items.
+   *
+   * You can pass custom element to render using `as`
    */
-  items: {
-    /** Text to display for the item */
-    label: string;
-    /** URL for the item link */
-    href: string;
-    /** Optional icon element to display */
-    icon?: React.ReactNode;
-    /** Optional array of dropdown items */
-    dropdownItems?: {
-      /** Text to display for the dropdown item */
-      label: string;
-      /** URL for the dropdown item link */
-      href: string;
-    }[];
-  }[];
+  items: BreadcrumbItem[];
 
   /**
    * Size variant of the breadcrumb
    * @defaultValue "medium"
    */
-  size?: "small" | "medium";
+  size?: 'small' | 'medium';
 
   /** Maximum number of items to display before showing ellipsis */
   maxVisibleItems?: number;
@@ -34,7 +48,7 @@ export interface BreadcrumbProps {
   separator?: React.ReactNode;
 
   /** Callback function when an item is clicked */
-  onItemClick?: (item: { label: string; href: string }) => void;
+  onItemClick?: (item: { label: string; href?: string }) => void;
 
   /** Custom CSS class names */
   className?: string;

--- a/packages/raystack/v1/components/breadcrumb/breadcrumb.tsx
+++ b/packages/raystack/v1/components/breadcrumb/breadcrumb.tsx
@@ -1,7 +1,12 @@
 import { ChevronDownIcon, DotsHorizontalIcon } from '@radix-ui/react-icons';
-import { type VariantProps, cva } from 'class-variance-authority';
-import React, { forwardRef, PropsWithChildren } from 'react';
-
+import { type VariantProps, cva, cx } from 'class-variance-authority';
+import {
+  MouseEvent,
+  ReactElement,
+  cloneElement,
+  forwardRef,
+  useMemo
+} from 'react';
 import { DropdownMenu } from '../dropdown-menu';
 import styles from './breadcrumb.module.css';
 
@@ -10,9 +15,73 @@ interface BreadcrumbItem {
   href: string;
   icon?: React.ReactNode;
   dropdownItems?: Array<{ label: string; href: string }>;
+  as?: ReactElement;
 }
 
-const breadcrumb = cva(styles['breadcrumb'], {
+interface BreadcrumbItemProps extends BreadcrumbItem {
+  isActive: boolean;
+  onItemClick?: (item: BreadcrumbItem) => void;
+}
+
+const BreadcrumbItem = ({
+  as = <a />,
+  onItemClick,
+  ...props
+}: BreadcrumbItemProps) => {
+  const { label, href, icon, dropdownItems, isActive } = props;
+
+  if (label === 'ellipsis') {
+    return (
+      <span className={styles['breadcrumb-ellipsis']}>
+        <DotsHorizontalIcon />
+      </span>
+    );
+  }
+  if (dropdownItems) {
+    return (
+      <DropdownMenu>
+        <DropdownMenu.Trigger className={styles['breadcrumb-dropdown-trigger']}>
+          {icon && <span className={styles['breadcrumb-icon']}>{icon}</span>}
+          <span>{label}</span>
+          <ChevronDownIcon className={styles['breadcrumb-dropdown-icon']} />
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content className={styles['breadcrumb-dropdown-content']}>
+          {dropdownItems.map((dropdownItem, dropdownIndex) => (
+            <DropdownMenu.Item
+              key={dropdownIndex}
+              className={styles['breadcrumb-dropdown-item']}
+              onSelect={() => onItemClick?.(dropdownItem)}
+            >
+              {dropdownItem.label}
+            </DropdownMenu.Item>
+          ))}
+        </DropdownMenu.Content>
+      </DropdownMenu>
+    );
+  }
+  return cloneElement(
+    as,
+    {
+      className: cx(
+        styles['breadcrumb-link'],
+        isActive && styles['breadcrumb-link-active']
+      ),
+      onClick: (e: MouseEvent) => {
+        if (onItemClick && href !== '#') {
+          e.preventDefault();
+          onItemClick(props);
+        }
+      },
+      href
+    },
+    <>
+      {icon && <span className={styles['breadcrumb-icon']}>{icon}</span>}
+      <span>{label}</span>
+    </>
+  );
+};
+
+const breadcrumbVariants = cva(styles['breadcrumb'], {
   variants: {
     size: {
       small: styles['breadcrumb-small'],
@@ -24,9 +93,7 @@ const breadcrumb = cva(styles['breadcrumb'], {
   }
 });
 
-type BreadcrumbProps = PropsWithChildren<
-  Omit<VariantProps<typeof breadcrumb>, 'size'>
-> & {
+type BreadcrumbProps = VariantProps<typeof breadcrumbVariants> & {
   items: BreadcrumbItem[];
   maxVisibleItems?: number;
   separator?: React.ReactNode;
@@ -48,89 +115,41 @@ export const Breadcrumb = forwardRef<HTMLDivElement, BreadcrumbProps>(
     },
     ref
   ) => {
-    const visibleItems =
-      maxVisibleItems && items.length > maxVisibleItems
-        ? [
-            ...items.slice(0, 1),
-            { label: 'ellipsis', href: '#' },
-            ...items.slice(-Math.min(maxVisibleItems - 1, items.length - 1))
-          ]
-        : items;
-
-    const renderItem = (
-      item: BreadcrumbItem,
-      index: number,
-      isLast: boolean
-    ) => (
-      <li key={index} className={styles['breadcrumb-item']}>
-        {item.label === 'ellipsis' ? (
-          <span className={styles['breadcrumb-ellipsis']}>
-            <DotsHorizontalIcon />
-          </span>
-        ) : item?.dropdownItems ? (
-          <DropdownMenu>
-            <DropdownMenu.Trigger
-              className={styles['breadcrumb-dropdown-trigger']}
-            >
-              {item.icon && (
-                <span className={styles['breadcrumb-icon']}>{item.icon}</span>
-              )}
-              <span>{item.label}</span>
-              <ChevronDownIcon className={styles['breadcrumb-dropdown-icon']} />
-            </DropdownMenu.Trigger>
-            <DropdownMenu.Content
-              className={styles['breadcrumb-dropdown-content']}
-            >
-              {item.dropdownItems.map((dropdownItem, dropdownIndex) => (
-                <DropdownMenu.Item
-                  key={dropdownIndex}
-                  className={styles['breadcrumb-dropdown-item']}
-                  onClick={() =>
-                    onItemClick &&
-                    onItemClick({
-                      label: dropdownItem.label,
-                      href: dropdownItem.href
-                    })
-                  }
-                >
-                  {dropdownItem.label}
-                </DropdownMenu.Item>
-              ))}
-            </DropdownMenu.Content>
-          </DropdownMenu>
-        ) : (
-          <a
-            href={item.href}
-            className={`${styles['breadcrumb-link']} ${isLast ? styles['breadcrumb-link-active'] : ''}`}
-            onClick={e => {
-              if (onItemClick && item.href !== '#') {
-                e.preventDefault();
-                onItemClick(item);
-              }
-            }}
-          >
-            {item.icon && (
-              <span className={styles['breadcrumb-icon']}>{item.icon}</span>
-            )}
-            <span>{item.label}</span>
-          </a>
-        )}
-        {!isLast && (
-          <span className={styles['breadcrumb-separator']}>{separator}</span>
-        )}
-      </li>
-    );
+    const visibleItems = useMemo(() => {
+      if (maxVisibleItems && items.length > maxVisibleItems) {
+        return [
+          ...items.slice(0, 1),
+          { label: 'ellipsis', href: '#' },
+          ...items.slice(-Math.min(maxVisibleItems - 1, items.length - 1))
+        ];
+      }
+      return items;
+    }, [maxVisibleItems, items]);
 
     return (
       <nav
-        className={breadcrumb({ size: size as 'small' | 'medium', className })}
+        className={breadcrumbVariants({ size, className })}
         ref={ref}
         {...props}
       >
         <ol className={styles['breadcrumb-list']}>
-          {visibleItems.map((item, index) =>
-            renderItem(item, index, index === visibleItems.length - 1)
-          )}
+          {visibleItems.map((item, index) => {
+            const isLast = index === visibleItems.length - 1;
+            return (
+              <li className={styles['breadcrumb-item']} key={index}>
+                <BreadcrumbItem
+                  {...item}
+                  isActive={isLast}
+                  onItemClick={onItemClick}
+                />
+                {!isLast && (
+                  <span className={styles['breadcrumb-separator']}>
+                    {separator}
+                  </span>
+                )}
+              </li>
+            );
+          })}
         </ol>
       </nav>
     );

--- a/packages/raystack/v1/components/breadcrumb/breadcrumb.tsx
+++ b/packages/raystack/v1/components/breadcrumb/breadcrumb.tsx
@@ -10,11 +10,13 @@ import {
 import { DropdownMenu } from '../dropdown-menu';
 import styles from './breadcrumb.module.css';
 
-interface BreadcrumbItem {
+interface BreadcrumbItemBase {
   label: string;
-  href: string;
+  href?: string;
+}
+interface BreadcrumbItem extends BreadcrumbItemBase {
   icon?: React.ReactNode;
-  dropdownItems?: Array<{ label: string; href: string }>;
+  dropdownItems?: BreadcrumbItemBase[];
   as?: ReactElement;
 }
 
@@ -72,7 +74,8 @@ const BreadcrumbItem = ({
           onItemClick(props);
         }
       },
-      href
+      href,
+      ...as.props
     },
     <>
       {icon && <span className={styles['breadcrumb-icon']}>{icon}</span>}


### PR DESCRIPTION
## Description

This PR adds `as` support for Breadcrumb items, allowing to render the item as custom elements

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

Manual
