### PR TITLE
fix (input-field): set font-family

### DIFF
--- a/packages/raystack/v1/components/input-field/input-field.module.css
+++ b/packages/raystack/v1/components/input-field/input-field.module.css
@@ -92,6 +92,7 @@
 }
 
 .input-field {
+  font-family: var(--rs-font-body);
   width: 100%;
   padding: 0 var(--rs-space-3);
   padding-left: var(--rs-space-3);
@@ -99,7 +100,6 @@
   margin: 0;
   border: none;
   background: transparent;
-  font-family: inherit;
   font-weight: var(--rs-font-weight-regular);
   font-size: var(--rs-font-size-small);
   line-height: 32px;


### PR DESCRIPTION
## Description

Currently set to inherit which makes the font-family a bit un predictable. Setting it to the font-family defined in the root.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

Manual

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (.mdx files)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

[Add screenshots here]

## Related Issues

[Link any related issues here using #issue-number]
