### PR TITLE
feat: add fallback and rename icon prop

### DIFF
--- a/packages/raystack/components/sidebar/sidebar.module.css
+++ b/packages/raystack/components/sidebar/sidebar.module.css
@@ -2,8 +2,8 @@
   display: flex;
   width: 220px;
   height: 100%;
-  padding: var(--rs-space-1) var(--rs-space-3) var(--rs-space-5)
-    var(--rs-space-3);
+  padding: var(--rs-space-1) var(--rs-space-4) var(--rs-space-5)
+    var(--rs-space-4);
   flex-direction: column;
   justify-content: flex-start;
   align-items: flex-start;
@@ -27,12 +27,10 @@
 }
 
 .root[data-state="collapsed"] {
-  width: 48px;
+  width: 56px;
 }
 
 .header {
-  display: flex;
-  align-items: center;
   gap: var(--rs-space-3);
   padding: var(--rs-space-6) var(--rs-space-2);
   align-self: stretch;
@@ -65,16 +63,17 @@
 
 .main {
   flex: 1;
-  display: flex;
-  flex-direction: column;
   overflow-y: auto;
   width: 100%;
   gap: var(--rs-space-2);
+  align-items: flex-start;
+}
+
+.root[data-state="collapsed"] .main {
+  align-items: center;
 }
 
 .footer {
-  display: flex;
-  flex-direction: column;
   width: 100%;
   gap: var(--rs-space-2);
 }
@@ -119,7 +118,7 @@
   pointer-events: none;
 }
 
-.nav-icon {
+.nav-leading-icon {
   display: flex;
   align-items: center;
   gap: var(--rs-space-3);
@@ -199,6 +198,17 @@
   display: none;
 }
 
+.nav-group {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+}
+
+.root[data-state="collapsed"] .nav-group {
+  align-items: center;
+}
+
 .nav-group-header {
   display: flex;
   align-items: center;
@@ -226,6 +236,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--rs-space-2);
+  width: 100%;
 }
 
 .root[data-state="collapsed"] .nav-group-name {

--- a/packages/raystack/components/sidebar/sidebar.tsx
+++ b/packages/raystack/components/sidebar/sidebar.tsx
@@ -10,6 +10,8 @@ import {
   forwardRef,
   useContext
 } from 'react';
+import { Avatar, getAvatarColor } from '../avatar';
+import { Flex } from '../flex';
 import { Tooltip, TooltipProvider } from '../tooltip';
 import styles from './sidebar.module.css';
 
@@ -38,13 +40,13 @@ interface SidebarHeaderProps extends ComponentPropsWithoutRef<'div'> {
 }
 
 interface SidebarItemProps extends ComponentPropsWithoutRef<'a'> {
-  icon?: ReactNode;
+  leadingIcon?: ReactNode;
   active?: boolean;
   disabled?: boolean;
   as?: ReactElement;
   classNames?: {
     root?: string;
-    icon?: string;
+    leadingIcon?: string;
     text?: string;
   };
 }
@@ -53,7 +55,7 @@ interface SidebarFooterProps extends ComponentPropsWithoutRef<'div'> {}
 
 interface SidebarNavigationGroupProps extends ComponentPropsWithoutRef<'div'> {
   name: string;
-  icon?: ReactNode;
+  leadingIcon?: ReactNode;
 }
 
 const SidebarRoot = forwardRef<
@@ -125,7 +127,13 @@ const SidebarRoot = forwardRef<
 
 const SidebarHeader = forwardRef<HTMLDivElement, SidebarHeaderProps>(
   ({ className, logo, title, onLogoClick, ...props }, ref) => (
-    <div ref={ref} className={styles.header} role='banner' {...props}>
+    <Flex
+      align='center'
+      ref={ref}
+      className={styles.header}
+      role='banner'
+      {...props}
+    >
       <div
         className={styles.logo}
         onClick={onLogoClick}
@@ -144,41 +152,51 @@ const SidebarHeader = forwardRef<HTMLDivElement, SidebarHeaderProps>(
       <div className={styles.title} role='heading' aria-level={1}>
         {title}
       </div>
-    </div>
+    </Flex>
   )
 );
 
 const SidebarMain = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<'div'>>(
   ({ className, children, ...props }, ref) => (
-    <div
+    <Flex
       ref={ref}
       className={styles.main}
+      direction='column'
       role='group'
       aria-label='Main navigation'
       {...props}
     >
       {children}
-    </div>
+    </Flex>
   )
 );
 
 const SidebarFooter = forwardRef<HTMLDivElement, SidebarFooterProps>(
   ({ className, children, ...props }, ref) => (
-    <div
+    <Flex
       ref={ref}
       className={styles.footer}
+      direction='column'
       role='group'
       aria-label='Footer navigation'
       {...props}
     >
       {children}
-    </div>
+    </Flex>
   )
 );
 
 const SidebarItem = forwardRef<HTMLAnchorElement, SidebarItemProps>(
   (
-    { classNames, icon, children, active, disabled, as = <a />, ...props },
+    {
+      classNames,
+      leadingIcon,
+      children,
+      active,
+      disabled,
+      as = <a />,
+      ...props
+    },
     ref
   ) => {
     const { isCollapsed, hideCollapsedItemTooltip } =
@@ -198,10 +216,19 @@ const SidebarItem = forwardRef<HTMLAnchorElement, SidebarItemProps>(
       },
       <>
         <span
-          className={cx(styles['nav-icon'], classNames?.icon)}
+          className={cx(styles['nav-leading-icon'], classNames?.leadingIcon)}
           aria-hidden='true'
         >
-          {icon}
+          {leadingIcon ||
+            (typeof children === 'string' && children.length > 0 ? (
+              <Avatar
+                size={1}
+                variant='soft'
+                color={getAvatarColor(children)}
+                fallback={children[0].toUpperCase()}
+                style={{ cursor: 'pointer' }}
+              />
+            ) : null)}
         </span>
         {!isCollapsed && <span className={styles['nav-text']}>{children}</span>}
       </>
@@ -222,10 +249,17 @@ const SidebarItem = forwardRef<HTMLAnchorElement, SidebarItemProps>(
 const SidebarNavigationGroup = forwardRef<
   HTMLElement,
   SidebarNavigationGroupProps
->(({ className, name, icon, children, ...props }, ref) => (
-  <section ref={ref} className={className} aria-label={name} {...props}>
+>(({ className, name, leadingIcon, children, ...props }, ref) => (
+  <section
+    ref={ref}
+    className={cx(styles['nav-group'], className)}
+    aria-label={name}
+    {...props}
+  >
     <div className={styles['nav-group-header']}>
-      {icon && <span className={styles['nav-icon']}>{icon}</span>}
+      {leadingIcon && (
+        <span className={styles['nav-leading-icon']}>{leadingIcon}</span>
+      )}
       <span className={styles['nav-group-name']}>{name}</span>
     </div>
     <div className={styles['nav-group-items']} role='list'>


### PR DESCRIPTION
## Description

- Avatar as fallback if not leadingIcon prop is passed.
- Rename icon to leadingIcon.
- Refactor Sidebar.Header tag.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

[Describe the tests that you ran to verify your changes]

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (.mdx files)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

[Add screenshots here]

## Related Issues

[Link any related issues here using #issue-number]
