### PR TITLE
fix: dropdown focus fix when used inside dialog

### DIFF
--- a/packages/raystack/components/dropdown-menu/dropdown-menu-content.tsx
+++ b/packages/raystack/components/dropdown-menu/dropdown-menu-content.tsx
@@ -3,8 +3,8 @@
 import { Menu, MenuProps, useMenuContext } from '@ariakit/react';
 import { Combobox, ComboboxList } from '@ariakit/react';
 import { cx } from 'class-variance-authority';
-import { Slot } from 'radix-ui';
-import { ElementRef, forwardRef, useRef } from 'react';
+import { Slot, VisuallyHidden } from 'radix-ui';
+import { ElementRef, forwardRef, useEffect, useRef, useState } from 'react';
 import { useDropdownContext } from './dropdown-menu-root';
 import styles from './dropdown-menu.module.css';
 import { WithAsChild } from './types';
@@ -25,45 +25,65 @@ export const DropdownMenuContent = forwardRef<
     const { autocomplete } = useDropdownContext();
     const isSubMenu = !!menu?.parent;
     const comboboxRef = useRef<HTMLInputElement>(null);
+    const visuallyHiddenRef = useRef<HTMLDivElement>(null);
+    const [isInsideRadixDialog, setIsInsideRadixDialog] = useState(false);
+
+    /*
+     * This is a workaround to fix focus lock issue when the dropdown menu is inside a Radix Dialog.
+     * TODO: Use Radix.Popover for the dropdown popover
+     */
+    useEffect(() => {
+      setIsInsideRadixDialog(
+        !!visuallyHiddenRef.current?.closest("[role='dialog']")
+      );
+    }, []);
 
     return (
-      <Menu
-        ref={ref}
-        modal
-        portal
-        portalElement={
-          typeof window === 'undefined' ? null : window?.document?.body
-        }
-        unmountOnHide
-        gutter={isSubMenu ? 2 : 4}
-        className={cx(
-          styles.content,
-          autocomplete && styles.comboboxContainer,
-          className
-        )}
-        render={asChild ? <Slot.Root /> : undefined}
-        {...props}
-      >
-        {autocomplete ? (
-          <>
-            <Combobox
-              ref={comboboxRef}
-              placeholder={searchPlaceholder}
-              className={styles.comboboxInput}
-              autoSelect
-              onPointerEnter={e => {
-                if (document && document.activeElement !== comboboxRef.current)
-                  comboboxRef.current?.focus();
-              }}
-            />
-            <ComboboxList className={styles.comboboxContent}>
-              {children}
-            </ComboboxList>
-          </>
-        ) : (
-          children
-        )}
-      </Menu>
+      <>
+        <VisuallyHidden.Root ref={visuallyHiddenRef} aria-hidden='true' />
+        <Menu
+          ref={ref}
+          modal={!isInsideRadixDialog}
+          portal={!isInsideRadixDialog}
+          portalElement={
+            typeof window === 'undefined' || isInsideRadixDialog
+              ? null
+              : window?.document?.body
+          }
+          unmountOnHide
+          gutter={isSubMenu ? 2 : 4}
+          className={cx(
+            styles.content,
+            autocomplete && styles.comboboxContainer,
+            className
+          )}
+          render={asChild ? <Slot.Root /> : undefined}
+          {...props}
+        >
+          {autocomplete ? (
+            <>
+              <Combobox
+                ref={comboboxRef}
+                placeholder={searchPlaceholder}
+                className={styles.comboboxInput}
+                autoSelect
+                onPointerEnter={e => {
+                  if (
+                    document &&
+                    document.activeElement !== comboboxRef.current
+                  )
+                    comboboxRef.current?.focus();
+                }}
+              />
+              <ComboboxList className={styles.comboboxContent}>
+                {children}
+              </ComboboxList>
+            </>
+          ) : (
+            children
+          )}
+        </Menu>
+      </>
     );
   }
 );


### PR DESCRIPTION
## Description

This PR fixes a focus lock issue when dropdown was used inside dialog

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

Manual