### PR TITLE
feat: migrate tabs to Base UI

### DIFF
--- a/apps/www/src/components/mdx/mdx-components.tsx
+++ b/apps/www/src/components/mdx/mdx-components.tsx
@@ -40,9 +40,9 @@ function Table(props: TableHTMLAttributes<HTMLTableElement>) {
 }
 
 const mdxComponents = {
-  CodeBlockTabsTrigger: (
-    props: ComponentPropsWithoutRef<typeof Tabs.Trigger>
-  ) => <Tabs.Trigger {...props} />,
+  CodeBlockTabsTrigger: (props: ComponentPropsWithoutRef<typeof Tabs.Tab>) => (
+    <Tabs.Tab {...props} />
+  ),
   CodeBlockTabs: (props: HTMLAttributes<HTMLDivElement>) => (
     <Tabs defaultValue='npm' className={props.className}>
       {props.children}

--- a/apps/www/src/components/mdx/pre-context.tsx
+++ b/apps/www/src/components/mdx/pre-context.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ReactNode, createContext, useContext } from 'react';
+import { createContext, ReactNode, useContext } from 'react';
 
 const PreContext = createContext<{
   hasPreParent: boolean;
@@ -11,7 +11,10 @@ const PreContext = createContext<{
 export const PreContextProvider = ({
   children,
   hasPreParent
-}: { children: ReactNode; hasPreParent: boolean }) => {
+}: {
+  children: ReactNode;
+  hasPreParent: boolean;
+}) => {
   return (
     <PreContext.Provider value={{ hasPreParent }}>
       {children}

--- a/apps/www/src/components/playground/tabs-examples.tsx
+++ b/apps/www/src/components/playground/tabs-examples.tsx
@@ -11,11 +11,11 @@ export function TabsExamples() {
         <Flex gap='large' direction='column'>
           <Tabs defaultValue='tab1'>
             <Tabs.List>
-              <Tabs.Trigger value='tab1'>Account</Tabs.Trigger>
-              <Tabs.Trigger value='tab2' disabled>
+              <Tabs.Tab value='tab1'>Account</Tabs.Tab>
+              <Tabs.Tab value='tab2' disabled>
                 Password
-              </Tabs.Trigger>
-              <Tabs.Trigger value='tab3'>Settings</Tabs.Trigger>
+              </Tabs.Tab>
+              <Tabs.Tab value='tab3'>Settings</Tabs.Tab>
             </Tabs.List>
             <Tabs.Content value='tab1'>Account settings</Tabs.Content>
             <Tabs.Content value='tab2'>Password settings</Tabs.Content>
@@ -25,8 +25,8 @@ export function TabsExamples() {
         <Flex gap='large' direction='column'>
           <Tabs defaultValue='tab1'>
             <Tabs.List>
-              <Tabs.Trigger value='tab1'>Home</Tabs.Trigger>
-              <Tabs.Trigger value='tab2' icon={<Info />} />
+              <Tabs.Tab value='tab1'>Home</Tabs.Tab>
+              <Tabs.Tab value='tab2' leadingIcon={<Info />} />
             </Tabs.List>
             <Tabs.Content value='tab1'>Home</Tabs.Content>
             <Tabs.Content value='tab2'>Info</Tabs.Content>

--- a/apps/www/src/components/theme-customiser/theme-customiser.tsx
+++ b/apps/www/src/components/theme-customiser/theme-customiser.tsx
@@ -1,6 +1,6 @@
 'use client';
-import { getPropsString } from '@/lib/utils';
 import { Button, Radio, Tabs } from '@raystack/apsara';
+import { getPropsString } from '@/lib/utils';
 import { ThemeOptions, useTheme } from '../theme';
 import styles from './theme-customiser.module.css';
 
@@ -44,8 +44,8 @@ export default function ThemeCustomizer() {
           }
         >
           <Tabs.List>
-            <Tabs.Trigger value='modern'>Modern</Tabs.Trigger>
-            <Tabs.Trigger value='traditional'>Traditional</Tabs.Trigger>
+            <Tabs.Tab value='modern'>Modern</Tabs.Tab>
+            <Tabs.Tab value='traditional'>Traditional</Tabs.Tab>
           </Tabs.List>
         </Tabs>
       </div>
@@ -58,8 +58,8 @@ export default function ThemeCustomizer() {
           }
         >
           <Tabs.List>
-            <Tabs.Trigger value='light'>Light</Tabs.Trigger>
-            <Tabs.Trigger value='dark'>Dark</Tabs.Trigger>
+            <Tabs.Tab value='light'>Light</Tabs.Tab>
+            <Tabs.Tab value='dark'>Dark</Tabs.Tab>
           </Tabs.List>
         </Tabs>
       </div>

--- a/apps/www/src/content/docs/components/tabs/demo.ts
+++ b/apps/www/src/content/docs/components/tabs/demo.ts
@@ -6,11 +6,11 @@ export const preview = {
   <Flex direction="row" gap="large" style={{ width: "100%", fontSize: "12px" }}>
     <Tabs defaultValue="tab-one">
       <Tabs.List>
-        <Tabs.Trigger value="tab-one" icon={<Info />}>Hoisting</Tabs.Trigger>
-        <Tabs.Trigger value="tab-two">Hosting</Tabs.Trigger>
-        <Tabs.Trigger value="tab-three" icon={<Info />}>Editor</Tabs.Trigger>
-        <Tabs.Trigger value="tab-four">Billing</Tabs.Trigger>
-        <Tabs.Trigger value="tab-five">SEO</Tabs.Trigger>
+        <Tabs.Tab value="tab-one" leadingIcon={<Info />}>Hoisting</Tabs.Tab>
+        <Tabs.Tab value="tab-two">Hosting</Tabs.Tab>
+        <Tabs.Tab value="tab-three" leadingIcon={<Info />}>Editor</Tabs.Tab>
+        <Tabs.Tab value="tab-four">Billing</Tabs.Tab>
+        <Tabs.Tab value="tab-five">SEO</Tabs.Tab>
       </Tabs.List>
       <Tabs.Content value="tab-one">
         <Text>General settings content</Text>
@@ -37,9 +37,9 @@ export const basicDemo = {
   <div style={{ width: "400px" }}>
   <Tabs defaultValue="tab1">
   <Tabs.List>
-    <Tabs.Trigger value="tab1">Account</Tabs.Trigger>
-    <Tabs.Trigger value="tab2">Password</Tabs.Trigger>
-    <Tabs.Trigger value="tab3">Settings</Tabs.Trigger>
+    <Tabs.Tab value="tab1">Account</Tabs.Tab>
+    <Tabs.Tab value="tab2">Password</Tabs.Tab>
+    <Tabs.Tab value="tab3">Settings</Tabs.Tab>
   </Tabs.List>
   <Tabs.Content value="tab1">Account settings</Tabs.Content>
   <Tabs.Content value="tab2">Password settings</Tabs.Content>
@@ -54,11 +54,11 @@ export const iconsDemo = {
   <div style={{ width: "400px" }}>
   <Tabs defaultValue="tab1">
     <Tabs.List>
-      <Tabs.Trigger value="tab1">Home</Tabs.Trigger>
-      <Tabs.Trigger value="tab2" icon={<Info />} />
+      <Tabs.Tab value="tab1">Home</Tabs.Tab>
+      <Tabs.Tab value="tab2" leadingIcon={<Info />}>Info</Tabs.Tab>
     </Tabs.List>
-    <Tabs.Content value="tab1">Home</Tabs.Content>
-    <Tabs.Content value="tab2">Info</Tabs.Content>
+    <Tabs.Content value="tab1">Home content</Tabs.Content>
+    <Tabs.Content value="tab2">Info content</Tabs.Content>
   </Tabs>
   </div>`
 };
@@ -69,8 +69,8 @@ export const disabledDemo = {
   <div style={{ width: "400px" }}>
   <Tabs defaultValue="tab1">
   <Tabs.List>
-    <Tabs.Trigger value="tab1">Active</Tabs.Trigger>
-    <Tabs.Trigger value="tab2" disabled>Disabled</Tabs.Trigger>
+    <Tabs.Tab value="tab1">Active</Tabs.Tab>
+    <Tabs.Tab value="tab2" disabled>Disabled</Tabs.Tab>
   </Tabs.List>
   <Tabs.Content value="tab1">Active tab content</Tabs.Content>
   <Tabs.Content value="tab2">Disabled tab content</Tabs.Content>

--- a/apps/www/src/content/docs/components/tabs/index.mdx
+++ b/apps/www/src/content/docs/components/tabs/index.mdx
@@ -22,9 +22,9 @@ import { Tabs } from "@raystack/apsara";
 
 <auto-type-table path="./props.ts" name="TabsListProps" />
 
-### Tabs.Trigger Props
+### Tabs.Tab Props
 
-<auto-type-table path="./props.ts" name="TabsTriggerProps" />
+<auto-type-table path="./props.ts" name="TabsTabProps" />
 
 ### Tabs.Content Props
 
@@ -36,18 +36,10 @@ import { Tabs } from "@raystack/apsara";
 
 <Demo data={basicDemo} />
 
-### With Icons
+### With Leading Icons
 
 <Demo data={iconsDemo} />
 
 ### Disabled Tab
 
 <Demo data={disabledDemo} />
-
-## Accessibility
-
-Tabs follow the [WAI-ARIA Tabs Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/). They include the following accessibility features:
-
-- Keyboard navigation between tabs using arrow keys
-- Proper ARIA roles, states, and properties
-- Focus management for tab panels

--- a/apps/www/src/content/docs/components/tabs/props.ts
+++ b/apps/www/src/content/docs/components/tabs/props.ts
@@ -1,12 +1,15 @@
 export interface TabsRootProps {
-  /** The initial active tab value. If not provided, no tab will be selected by default. */
-  defaultValue?: string;
+  /** The initial active tab value. */
+  defaultValue?: any;
 
   /** The controlled active tab value. */
-  value?: string;
+  value?: any;
 
   /** Callback function triggered when the active tab changes. */
-  onValueChange?: (value: string) => void;
+  onValueChange?: (value: any) => void;
+
+  /** The orientation of the tabs. */
+  orientation?: 'horizontal' | 'vertical';
 
   /** Additional CSS class names. */
   className?: string;
@@ -17,12 +20,12 @@ export interface TabsListProps {
   className?: string;
 }
 
-export interface TabsTriggerProps {
+export interface TabsTabProps {
   /** Unique identifier for the tab. */
-  value: string;
+  value: any;
 
-  /** Optional icon element to display. */
-  icon?: React.ReactNode;
+  /** Optional icon element to display before the label. */
+  leadingIcon?: React.ReactNode;
 
   /** Whether the tab is disabled. */
   disabled?: boolean;
@@ -33,7 +36,10 @@ export interface TabsTriggerProps {
 
 export interface TabsContentProps {
   /** Matching identifier for the tab. */
-  value: string;
+  value: any;
+
+  /** Whether to keep the panel in the DOM while hidden. */
+  keepMounted?: boolean;
 
   /** Additional CSS class names. */
   className?: string;

--- a/packages/raystack/components/tabs/index.tsx
+++ b/packages/raystack/components/tabs/index.tsx
@@ -1,1 +1,1 @@
-export { Tabs } from "./tabs"; 
+export { Tabs } from './tabs';

--- a/packages/raystack/components/tabs/tabs.module.css
+++ b/packages/raystack/components/tabs/tabs.module.css
@@ -5,6 +5,7 @@
 }
 
 .list {
+  position: relative;
   display: flex;
   align-items: center;
   gap: var(--rs-space-2);
@@ -27,7 +28,7 @@
   color: var(--rs-color-foreground-base-secondary);
   cursor: pointer;
   border-radius: var(--rs-radius-2);
-  transition: all 0.2s ease;
+  transition: color 0.2s ease;
   flex: 1;
   text-align: center;
   text-overflow: ellipsis;
@@ -37,18 +38,17 @@
   line-height: var(--rs-line-height-small);
   letter-spacing: var(--rs-letter-spacing-small);
   box-sizing: border-box;
+  position: relative;
+  z-index: 1;
 }
 
 .trigger:hover:not([data-disabled]) {
   color: var(--rs-color-foreground-base-primary);
 }
 
-.trigger[data-state="active"] {
-  background-color: var(--rs-color-background-base-primary);
+/* Active tab - transparent background so indicator shows through */
+.trigger[data-active] {
   color: var(--rs-color-foreground-base-primary);
-  box-shadow: var(--rs-shadow-feather);
-  font-size: var(--rs-font-size-small);
-  font-weight: var(--rs-font-weight-medium);
 }
 
 .trigger[data-disabled] {
@@ -68,10 +68,28 @@
   flex-shrink: 0;
 }
 
+.indicator {
+  position: absolute;
+  background-color: var(--rs-color-background-base-primary);
+  border-radius: var(--rs-radius-2);
+  box-shadow: var(--rs-shadow-feather);
+  transition:
+    top 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+    left 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+    width 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+    height 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  top: var(--active-tab-top, 0);
+  left: var(--active-tab-left, 0);
+  width: var(--active-tab-width, 0);
+  height: var(--active-tab-height, 0);
+  z-index: 0;
+}
+
 .content {
   outline: none;
 }
 
-.content[data-state="inactive"] {
+/* Base UI uses hidden attribute for inactive panels */
+.content[hidden] {
   display: none;
 }

--- a/packages/raystack/components/tabs/tabs.tsx
+++ b/packages/raystack/components/tabs/tabs.tsx
@@ -1,91 +1,67 @@
-import { type VariantProps, cva } from 'class-variance-authority';
-import { Tabs as TabsPrimitive } from 'radix-ui';
-import {
-  ComponentPropsWithoutRef,
-  ElementRef,
-  ReactNode,
-  forwardRef
-} from 'react';
-
+import { Tabs as TabsPrimitive } from '@base-ui/react';
+import { cx } from 'class-variance-authority';
+import { ComponentPropsWithoutRef, forwardRef, ReactNode } from 'react';
 import styles from './tabs.module.css';
 
-const root = cva(styles.root);
-const list = cva(styles.list);
-const trigger = cva(styles.trigger);
-const content = cva(styles.content);
+const TabsRoot = forwardRef<HTMLDivElement, TabsPrimitive.Root.Props>(
+  ({ className, ...props }, ref) => (
+    <TabsPrimitive.Root
+      ref={ref}
+      className={cx(styles.root, className)}
+      {...props}
+    />
+  )
+);
+TabsRoot.displayName = 'Tabs.Root';
 
-export interface TabsRootProps
-  extends ComponentPropsWithoutRef<typeof TabsPrimitive.Root>,
-    VariantProps<typeof root> {
-  defaultValue?: string;
-  'aria-label'?: string;
+const TabsList = forwardRef<HTMLDivElement, TabsPrimitive.List.Props>(
+  ({ className, children, ...props }, ref) => (
+    <TabsPrimitive.List
+      ref={ref}
+      className={cx(styles.list, className)}
+      {...props}
+    >
+      {children}
+      <TabsPrimitive.Indicator className={styles.indicator} />
+    </TabsPrimitive.List>
+  )
+);
+TabsList.displayName = 'Tabs.List';
+
+interface TabsTabProps
+  extends ComponentPropsWithoutRef<typeof TabsPrimitive.Tab> {
+  leadingIcon?: ReactNode;
 }
 
-interface TabsTriggerProps
-  extends ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger> {
-  icon?: ReactNode;
-  disabled?: boolean;
-}
+const TabsTab = forwardRef<HTMLButtonElement, TabsTabProps>(
+  ({ className, leadingIcon, children, ...props }, ref) => (
+    <TabsPrimitive.Tab
+      ref={ref}
+      className={cx(styles.trigger, className)}
+      {...props}
+    >
+      {leadingIcon && (
+        <span className={styles['trigger-icon']}>{leadingIcon}</span>
+      )}
+      {children}
+    </TabsPrimitive.Tab>
+  )
+);
+TabsTab.displayName = 'Tabs.Tab';
 
-const TabsRoot = forwardRef<
-  ElementRef<typeof TabsPrimitive.Root>,
-  TabsRootProps
->(({ className, 'aria-label': ariaLabel, ...props }, ref) => (
-  <TabsPrimitive.Root
-    ref={ref}
-    className={root({ className })}
-    aria-label={ariaLabel || 'Tabs'}
-    {...props}
-  />
-));
-
-const TabsList = forwardRef<
-  ElementRef<typeof TabsPrimitive.List>,
-  ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.List
-    ref={ref}
-    role='tablist'
-    className={list({ className })}
-    {...props}
-  />
-));
-
-const TabsTrigger = forwardRef<
-  ElementRef<typeof TabsPrimitive.Trigger>,
-  TabsTriggerProps
->(({ className, icon, children, disabled, ...props }, ref) => (
-  <TabsPrimitive.Trigger
-    ref={ref}
-    className={trigger({ className })}
-    disabled={disabled}
-    aria-disabled={disabled}
-    {...props}
-  >
-    {icon && <span className={styles['trigger-icon']}>{icon}</span>}
-    {children}
-  </TabsPrimitive.Trigger>
-));
-
-const TabsContent = forwardRef<
-  ElementRef<typeof TabsPrimitive.Content>,
-  ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Content
-    ref={ref}
-    role='tabpanel'
-    className={content({ className })}
-    {...props}
-  />
-));
-
-TabsRoot.displayName = TabsPrimitive.Root.displayName;
-TabsList.displayName = TabsPrimitive.List.displayName;
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
-TabsContent.displayName = TabsPrimitive.Content.displayName;
+const TabsContent = forwardRef<HTMLDivElement, TabsPrimitive.Panel.Props>(
+  ({ className, ...props }, ref) => (
+    <TabsPrimitive.Panel
+      ref={ref}
+      className={cx(styles.content, className)}
+      {...props}
+    />
+  )
+);
+TabsContent.displayName = 'Tabs.Content';
 
 export const Tabs = Object.assign(TabsRoot, {
   List: TabsList,
-  Trigger: TabsTrigger,
+  Tab: TabsTab,
   Content: TabsContent
 });


### PR DESCRIPTION
## Description

**Breaking Changes**

- `Tabs.Trigger` renamed to `Tabs.Tab` - update all usages
- `icon` prop renamed to `leadingIcon`
- `onValueChange` callback now receives `(value, details)` instead of just `value`

**Changes**

- Migrated from Radix UI to Base UI (`@base-ui/react`)
- Separate active tab indicator usaage within `Tabs.List`
- Enhanced indicator animations using CSS custom properties
- Added `orientation` prop for horizontal/vertical orientations

**Docs & Tests**

- Updated all documentation examples to use `Tabs.Tab` and `leadingIcon`
- Updated props documentation: `TabsTabProps` replaces `TabsTriggerProps`
- Test updates: added indicator rendering test, updated assertions for new attributes, updated `onValueChange` tests
- Updated playground examples