### PR TITLE
feat: add FilterCard component

### DIFF
--- a/apps/www/src/components/playground/filter-card-examples.tsx
+++ b/apps/www/src/components/playground/filter-card-examples.tsx
@@ -44,11 +44,11 @@ export function FilterCardExamples() {
         <FilterCard.Section title='Display Properties'>
           <Text size={1}>Name, Creator, Project</Text>
         </FilterCard.Section>
-        <FilterCard.Section align='end'>
+        <FilterCard.Footer>
           <Button variant='ghost' size='small'>
             Reset to default
           </Button>
-        </FilterCard.Section>
+        </FilterCard.Footer>
       </FilterCard>
     </PlaygroundLayout>
   );

--- a/apps/www/src/components/playground/filter-card-examples.tsx
+++ b/apps/www/src/components/playground/filter-card-examples.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { Button, FilterCard, Select, Text } from '@raystack/apsara';
+import PlaygroundLayout from './playground-layout';
+
+export function FilterCardExamples() {
+  return (
+    <PlaygroundLayout title='FilterCard'>
+      <FilterCard>
+        <FilterCard.Section>
+          <FilterCard.Item label='Ordering'>
+            <Select defaultValue='auto'>
+              <Select.Trigger
+                size='small'
+                variant='filter'
+                style={{ width: '100%' }}
+              >
+                <Select.Value />
+              </Select.Trigger>
+              <Select.Content>
+                <Select.Item value='auto'>Auto</Select.Item>
+                <Select.Item value='name'>Name</Select.Item>
+                <Select.Item value='date'>Date</Select.Item>
+              </Select.Content>
+            </Select>
+          </FilterCard.Item>
+          <FilterCard.Item label='Grouping'>
+            <Select defaultValue='none'>
+              <Select.Trigger
+                size='small'
+                variant='filter'
+                style={{ width: '100%' }}
+              >
+                <Select.Value />
+              </Select.Trigger>
+              <Select.Content>
+                <Select.Item value='none'>No grouping</Select.Item>
+                <Select.Item value='status'>Status</Select.Item>
+                <Select.Item value='type'>Type</Select.Item>
+              </Select.Content>
+            </Select>
+          </FilterCard.Item>
+        </FilterCard.Section>
+        <FilterCard.Section title='Display Properties'>
+          <Text size={1}>Name, Creator, Project</Text>
+        </FilterCard.Section>
+        <FilterCard.Section align='end'>
+          <Button variant='ghost' size='small'>
+            Reset to default
+          </Button>
+        </FilterCard.Section>
+      </FilterCard>
+    </PlaygroundLayout>
+  );
+}

--- a/apps/www/src/components/playground/filter-card-examples.tsx
+++ b/apps/www/src/components/playground/filter-card-examples.tsx
@@ -12,7 +12,7 @@ export function FilterCardExamples() {
             <Select defaultValue='auto'>
               <Select.Trigger
                 size='small'
-                variant='filter'
+                variant='outline'
                 style={{ width: '100%' }}
               >
                 <Select.Value />
@@ -28,7 +28,7 @@ export function FilterCardExamples() {
             <Select defaultValue='none'>
               <Select.Trigger
                 size='small'
-                variant='filter'
+                variant='outline'
                 style={{ width: '100%' }}
               >
                 <Select.Value />
@@ -45,7 +45,7 @@ export function FilterCardExamples() {
           <Text size={1}>Name, Creator, Project</Text>
         </FilterCard.Section>
         <FilterCard.Footer>
-          <Button variant='ghost' size='small'>
+          <Button variant='text' size='small' color='neutral'>
             Reset to default
           </Button>
         </FilterCard.Footer>

--- a/apps/www/src/components/playground/index.ts
+++ b/apps/www/src/components/playground/index.ts
@@ -16,6 +16,7 @@ export * from './data-table-examples';
 export * from './dialog-examples';
 export * from './dropdown-menu-examples';
 export * from './empty-state-examples';
+export * from './filter-card-examples';
 export * from './filter-chip-examples';
 export * from './flex-examples';
 export * from './headline-examples';

--- a/apps/www/src/content/docs/components/filter-card/demo.ts
+++ b/apps/www/src/content/docs/components/filter-card/demo.ts
@@ -31,7 +31,7 @@ export const sectionsDemo = {
     <FilterCard.Section>
       <FilterCard.Item label="Ordering">
         <Select defaultValue="auto">
-          <Select.Trigger size="small" variant="filter" style={{ width: "100%" }}>
+          <Select.Trigger size="small" variant="outline" style={{ width: "100%" }}>
             <Select.Value />
           </Select.Trigger>
           <Select.Content>
@@ -43,7 +43,7 @@ export const sectionsDemo = {
       </FilterCard.Item>
       <FilterCard.Item label="Grouping">
         <Select defaultValue="none">
-          <Select.Trigger size="small" variant="filter" style={{ width: "100%" }}>
+          <Select.Trigger size="small" variant="outline" style={{ width: "100%" }}>
             <Select.Value />
           </Select.Trigger>
           <Select.Content>
@@ -58,7 +58,7 @@ export const sectionsDemo = {
       <Text size={1}>Name, Creator, Project</Text>
     </FilterCard.Section>
     <FilterCard.Footer>
-      <Button variant="ghost" size="small">Reset to default</Button>
+      <Button variant="text" size="small" color="neutral">Reset to default</Button>
     </FilterCard.Footer>
   </FilterCard>`
 };

--- a/apps/www/src/content/docs/components/filter-card/demo.ts
+++ b/apps/www/src/content/docs/components/filter-card/demo.ts
@@ -1,0 +1,74 @@
+'use client';
+
+import { getPropsString } from '@/lib/utils';
+
+export const getCode = (props: any) => {
+  const { children, ...rest } = props;
+  return `<FilterCard>
+  <FilterCard.Section${getPropsString(rest)}>${children}</FilterCard.Section>
+</FilterCard>`;
+};
+
+export const playground = {
+  type: 'playground',
+  controls: {
+    title: {
+      type: 'text',
+      initialValue: 'Display Properties'
+    },
+    children: {
+      type: 'text',
+      initialValue: 'Section content goes here'
+    }
+  },
+  getCode
+};
+
+export const sectionsDemo = {
+  type: 'code',
+  code: `
+  <FilterCard>
+    <FilterCard.Section>
+      <FilterCard.Item label="Ordering">
+        <Select defaultValue="auto">
+          <Select.Trigger size="small" variant="filter" style={{ width: "100%" }}>
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Content>
+            <Select.Item value="auto">Auto</Select.Item>
+            <Select.Item value="name">Name</Select.Item>
+            <Select.Item value="date">Date</Select.Item>
+          </Select.Content>
+        </Select>
+      </FilterCard.Item>
+      <FilterCard.Item label="Grouping">
+        <Select defaultValue="none">
+          <Select.Trigger size="small" variant="filter" style={{ width: "100%" }}>
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Content>
+            <Select.Item value="none">No grouping</Select.Item>
+            <Select.Item value="status">Status</Select.Item>
+            <Select.Item value="type">Type</Select.Item>
+          </Select.Content>
+        </Select>
+      </FilterCard.Item>
+    </FilterCard.Section>
+    <FilterCard.Section title="Display Properties">
+      <Text size={1}>Name, Creator, Project</Text>
+    </FilterCard.Section>
+    <FilterCard.Section align="end">
+      <Button variant="ghost" size="small">Reset to default</Button>
+    </FilterCard.Section>
+  </FilterCard>`
+};
+
+export const withoutTitleDemo = {
+  type: 'code',
+  code: `
+  <FilterCard>
+    <FilterCard.Section>
+      <Text size={1}>Section without a title</Text>
+    </FilterCard.Section>
+  </FilterCard>`
+};

--- a/apps/www/src/content/docs/components/filter-card/demo.ts
+++ b/apps/www/src/content/docs/components/filter-card/demo.ts
@@ -57,9 +57,9 @@ export const sectionsDemo = {
     <FilterCard.Section title="Display Properties">
       <Text size={1}>Name, Creator, Project</Text>
     </FilterCard.Section>
-    <FilterCard.Section align="end">
+    <FilterCard.Footer>
       <Button variant="ghost" size="small">Reset to default</Button>
-    </FilterCard.Section>
+    </FilterCard.Footer>
   </FilterCard>`
 };
 

--- a/apps/www/src/content/docs/components/filter-card/index.mdx
+++ b/apps/www/src/content/docs/components/filter-card/index.mdx
@@ -24,6 +24,9 @@ import { FilterCard } from '@raystack/apsara'
   <FilterCard.Section title="Section Title">
     Content
   </FilterCard.Section>
+  <FilterCard.Footer>
+    Footer content
+  </FilterCard.Footer>
 </FilterCard>
 ```
 
@@ -46,6 +49,12 @@ A section within the filter card with an optional title.
 A label-action row within a section.
 
 <auto-type-table path="./props.ts" name="FilterCardItemProps" />
+
+### FilterCard.Footer
+
+A compact footer section, right-aligned by default.
+
+<auto-type-table path="./props.ts" name="FilterCardFooterProps" />
 
 ## Examples
 

--- a/apps/www/src/content/docs/components/filter-card/index.mdx
+++ b/apps/www/src/content/docs/components/filter-card/index.mdx
@@ -1,0 +1,62 @@
+---
+title: FilterCard
+description: A sectioned card component for grouping filter controls and configuration options.
+source: packages/raystack/components/filter-card
+---
+
+import { playground, sectionsDemo, withoutTitleDemo } from "./demo.ts";
+
+<Demo data={playground} />
+
+## Anatomy
+
+Import and assemble the component:
+
+```tsx
+import { FilterCard } from '@raystack/apsara'
+
+<FilterCard>
+  <FilterCard.Section>
+    <FilterCard.Item label="Label">
+      Action content
+    </FilterCard.Item>
+  </FilterCard.Section>
+  <FilterCard.Section title="Section Title">
+    Content
+  </FilterCard.Section>
+</FilterCard>
+```
+
+## API Reference
+
+### FilterCard
+
+The outer container for the filter card.
+
+<auto-type-table path="./props.ts" name="FilterCardProps" />
+
+### FilterCard.Section
+
+A section within the filter card with an optional title.
+
+<auto-type-table path="./props.ts" name="FilterCardSectionProps" />
+
+### FilterCard.Item
+
+A label-action row within a section.
+
+<auto-type-table path="./props.ts" name="FilterCardItemProps" />
+
+## Examples
+
+### With Sections
+
+Multiple sections separated by a divider:
+
+<Demo data={sectionsDemo} />
+
+### Without Title
+
+Sections can be rendered without a title:
+
+<Demo data={withoutTitleDemo} />

--- a/apps/www/src/content/docs/components/filter-card/props.ts
+++ b/apps/www/src/content/docs/components/filter-card/props.ts
@@ -1,0 +1,61 @@
+export interface FilterCardProps {
+  /** Content of the filter card */
+  children?: React.ReactNode;
+
+  /** Additional CSS class names */
+  className?: string;
+}
+
+export interface FilterCardSectionProps {
+  /** Optional title for the section */
+  title?: string;
+
+  /** Content of the section */
+  children?: React.ReactNode;
+
+  /** Additional CSS class names */
+  className?: string;
+
+  /**
+   * Flex direction
+   * @defaultValue "column"
+   */
+  direction?: 'row' | 'column' | 'rowReverse' | 'columnReverse';
+
+  /** Flex align items */
+  align?: 'start' | 'center' | 'end' | 'stretch' | 'baseline';
+
+  /** Flex justify content */
+  justify?: 'start' | 'center' | 'end' | 'between';
+
+  /** Flex wrap */
+  wrap?: 'noWrap' | 'wrap' | 'wrapReverse';
+
+  /** Flex gap */
+  gap?:
+    | 1
+    | 2
+    | 3
+    | 4
+    | 5
+    | 6
+    | 7
+    | 8
+    | 9
+    | 'extra-small'
+    | 'small'
+    | 'medium'
+    | 'large'
+    | 'extra-large';
+}
+
+export interface FilterCardItemProps {
+  /** Label text displayed on the left */
+  label: string;
+
+  /** Action content displayed on the right */
+  children?: React.ReactNode;
+
+  /** Additional CSS class names */
+  className?: string;
+}

--- a/apps/www/src/content/docs/components/filter-card/props.ts
+++ b/apps/www/src/content/docs/components/filter-card/props.ts
@@ -59,3 +59,17 @@ export interface FilterCardItemProps {
   /** Additional CSS class names */
   className?: string;
 }
+
+export interface FilterCardFooterProps {
+  /** Content of the footer */
+  children?: React.ReactNode;
+
+  /** Additional CSS class names */
+  className?: string;
+
+  /**
+   * Flex justify content
+   * @defaultValue "end"
+   */
+  justify?: 'start' | 'center' | 'end' | 'between';
+}

--- a/apps/www/src/content/docs/components/popover/props.ts
+++ b/apps/www/src/content/docs/components/popover/props.ts
@@ -13,6 +13,12 @@ export interface PopoverRootProps {
 }
 
 export interface PopoverContentProps {
+  /**
+   * Visual style variant
+   * @defaultValue "default"
+   */
+  variant?: 'default' | 'unstyled';
+
   /** Preferred side of the trigger to render. */
   side?: 'top' | 'right' | 'bottom' | 'left';
 

--- a/packages/raystack/components/data-table/components/display-properties.tsx
+++ b/packages/raystack/components/data-table/components/display-properties.tsx
@@ -2,7 +2,6 @@
 
 import { Chip } from '../../chip';
 import { Flex } from '../../flex';
-import { Text } from '../../text';
 import { DataTableColumn } from '../data-table.types';
 
 export function DisplayProperties<TData, TValue>({
@@ -13,21 +12,18 @@ export function DisplayProperties<TData, TValue>({
   const hidableColumns = columns?.filter(col => col.columnDef.enableHiding);
 
   return (
-    <Flex direction='column' gap={3}>
-      <Text>Display Properties</Text>
-      <Flex gap={3} wrap='wrap'>
-        {hidableColumns.map(column => (
-          <Chip
-            key={column.id}
-            variant='outline'
-            size='small'
-            color={column.getIsVisible() ? 'accent' : 'neutral'}
-            onClick={() => column.toggleVisibility()}
-          >
-            {(column.columnDef.header as string) || column.id}
-          </Chip>
-        ))}
-      </Flex>
+    <Flex gap={3} wrap='wrap'>
+      {hidableColumns.map(column => (
+        <Chip
+          key={column.id}
+          variant='outline'
+          size='small'
+          color={column.getIsVisible() ? 'accent' : 'neutral'}
+          onClick={() => column.toggleVisibility()}
+        >
+          {(column.columnDef.header as string) || column.id}
+        </Chip>
+      ))}
     </Flex>
   );
 }

--- a/packages/raystack/components/data-table/components/display-settings.tsx
+++ b/packages/raystack/components/data-table/components/display-settings.tsx
@@ -4,13 +4,12 @@ import { MixerHorizontalIcon } from '@radix-ui/react-icons';
 
 import { ReactNode } from 'react';
 import { Button } from '../../button';
-import { Flex } from '../../flex';
+import { FilterCard } from '../../filter-card';
 import { Popover } from '../../popover';
-import styles from '../data-table.module.css';
 import {
   DataTableColumn,
-  SortOrdersValues,
-  defaultGroupOption
+  defaultGroupOption,
+  SortOrdersValues
 } from '../data-table.types';
 import { useDataTable } from '../hooks/useDataTable';
 import { DisplayProperties } from './display-properties';
@@ -86,16 +85,9 @@ export function DisplaySettings<TData, TValue>({
   return (
     <Popover>
       <Popover.Trigger asChild>{trigger}</Popover.Trigger>
-      <Popover.Content
-        className={styles['display-popover-content']}
-        align='end'
-      >
-        <Flex direction='column'>
-          <Flex
-            direction='column'
-            className={styles['display-popover-properties-container']}
-            gap={5}
-          >
+      <Popover.Content variant='unstyled' align='end'>
+        <FilterCard>
+          <FilterCard.Section>
             <Ordering
               columnList={sortableColumns}
               onChange={onSortChange}
@@ -107,19 +99,16 @@ export function DisplaySettings<TData, TValue>({
               onChange={onGroupChange}
               value={tableQuery?.group_by?.[0] || defaultGroupOption.id}
             />
-          </Flex>
-          <Flex className={styles['display-popover-properties-container']}>
+          </FilterCard.Section>
+          <FilterCard.Section title='Display Properties'>
             <DisplayProperties columns={columns} />
-          </Flex>
-          <Flex
-            justify='end'
-            className={styles['display-popover-reset-container']}
-          >
+          </FilterCard.Section>
+          <FilterCard.Footer>
             <Button variant='text' onClick={onReset} color='neutral'>
               Reset to default
             </Button>
-          </Flex>
-        </Flex>
+          </FilterCard.Footer>
+        </FilterCard>
       </Popover.Content>
     </Popover>
   );

--- a/packages/raystack/components/data-table/components/grouping.tsx
+++ b/packages/raystack/components/data-table/components/grouping.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { Flex } from '../../flex';
+import { FilterCard } from '../../filter-card';
 import { Select } from '../../select';
-import { Text } from '../../text';
 import styles from '../data-table.module.css';
 import { DataTableColumn, defaultGroupOption } from '../data-table.types';
 
@@ -41,30 +40,25 @@ export function Grouping<TData, TValue>({
   };
 
   return (
-    <Flex justify='between' align='center'>
-      <Text size={2} weight={500} className={styles['flex-1']}>
-        Grouping
-      </Text>
-      <Flex className={styles['flex-1']}>
-        <Select onValueChange={handleGroupChange} value={value}>
-          <Select.Trigger
-            size='small'
-            className={styles['display-popover-properties-select']}
-          >
-            <Select.Value placeholder='Select value' />
-          </Select.Trigger>
-          <Select.Content data-variant='filter'>
-            <Select.Item value={defaultGroupOption.id}>
-              {defaultGroupOption.label}
+    <FilterCard.Item label='Grouping'>
+      <Select onValueChange={handleGroupChange} value={value}>
+        <Select.Trigger
+          size='small'
+          className={styles['display-popover-properties-select']}
+        >
+          <Select.Value placeholder='Select value' />
+        </Select.Trigger>
+        <Select.Content data-variant='filter'>
+          <Select.Item value={defaultGroupOption.id}>
+            {defaultGroupOption.label}
+          </Select.Item>
+          {columnList.map(column => (
+            <Select.Item key={column.id} value={column.id}>
+              {column.label}
             </Select.Item>
-            {columnList.map(column => (
-              <Select.Item key={column.id} value={column.id}>
-                {column.label}
-              </Select.Item>
-            ))}
-          </Select.Content>
-        </Select>
-      </Flex>
-    </Flex>
+          ))}
+        </Select.Content>
+      </Select>
+    </FilterCard.Item>
   );
 }

--- a/packages/raystack/components/data-table/components/ordering.tsx
+++ b/packages/raystack/components/data-table/components/ordering.tsx
@@ -2,10 +2,10 @@
 
 import { TextAlignBottomIcon, TextAlignTopIcon } from '@radix-ui/react-icons';
 
+import { FilterCard } from '../../filter-card';
 import { Flex } from '../../flex';
 import { IconButton } from '../../icon-button';
 import { Select } from '../../select';
-import { Text } from '../../text';
 import styles from '../data-table.module.css';
 import {
   ColumnData,
@@ -32,11 +32,8 @@ export function Ordering({ columnList, onChange, value }: OrderingProps) {
   }
 
   return (
-    <Flex justify='between' align='center'>
-      <Text size={2} weight={500} className={styles['flex-1']}>
-        Ordering
-      </Text>
-      <Flex gap='extra-small' className={styles['flex-1']}>
+    <FilterCard.Item label='Ordering'>
+      <Flex gap='extra-small'>
         <Select
           onValueChange={handleColumnChange}
           value={value.name}
@@ -71,6 +68,6 @@ export function Ordering({ columnList, onChange, value }: OrderingProps) {
           )}
         </IconButton>
       </Flex>
-    </Flex>
+    </FilterCard.Item>
   );
 }

--- a/packages/raystack/components/data-table/data-table.module.css
+++ b/packages/raystack/components/data-table/data-table.module.css
@@ -7,18 +7,8 @@
   background: var(--rs-color-background-base-primary);
 }
 
-.display-popover-content {
-  padding: 0px;
-  min-width: 300px;
-}
-
-.display-popover-properties-container {
-  --select-width: 160px;
-  padding: var(--rs-space-5);
-  border-bottom: 1px solid var(--rs-color-border-base-primary);
-}
-
 .display-popover-properties-select {
+  --select-width: 160px;
   width: var(--select-width);
 }
 .display-popover-properties-select[with-icon-button] {
@@ -30,10 +20,6 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-}
-
-.display-popover-reset-container {
-  padding: var(--rs-space-3) var(--rs-space-5);
 }
 
 .display-popover-sort-icon {

--- a/packages/raystack/components/filter-card/filter-card-footer.tsx
+++ b/packages/raystack/components/filter-card/filter-card-footer.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { cx } from 'class-variance-authority';
+import { type ComponentPropsWithoutRef, forwardRef } from 'react';
+
+import { Flex } from '../flex';
+import styles from './filter-card.module.css';
+
+export interface FilterCardFooterProps
+  extends ComponentPropsWithoutRef<typeof Flex> {}
+
+export const FilterCardFooter = forwardRef<
+  HTMLDivElement,
+  FilterCardFooterProps
+>(({ className, children, ...props }, ref) => {
+  return (
+    <Flex
+      ref={ref}
+      justify='end'
+      className={cx(styles.footer, className)}
+      {...props}
+    >
+      {children}
+    </Flex>
+  );
+});
+
+FilterCardFooter.displayName = 'FilterCard.Footer';

--- a/packages/raystack/components/filter-card/filter-card-item.tsx
+++ b/packages/raystack/components/filter-card/filter-card-item.tsx
@@ -15,7 +15,7 @@ export const FilterCardItem = forwardRef<HTMLDivElement, FilterCardItemProps>(
     return (
       <div ref={ref} className={cx(styles.item, className)} {...props}>
         <Text size={1}>{label}</Text>
-        <div>{children}</div>
+        {children}
       </div>
     );
   }

--- a/packages/raystack/components/filter-card/filter-card-item.tsx
+++ b/packages/raystack/components/filter-card/filter-card-item.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { cx } from 'class-variance-authority';
+import { forwardRef, type HTMLAttributes } from 'react';
+
+import { Text } from '../text';
+import styles from './filter-card.module.css';
+
+export interface FilterCardItemProps extends HTMLAttributes<HTMLDivElement> {
+  label: string;
+}
+
+export const FilterCardItem = forwardRef<HTMLDivElement, FilterCardItemProps>(
+  ({ className, label, children, ...props }, ref) => {
+    return (
+      <div ref={ref} className={cx(styles.item, className)} {...props}>
+        <Text size={1}>{label}</Text>
+        <div>{children}</div>
+      </div>
+    );
+  }
+);
+
+FilterCardItem.displayName = 'FilterCard.Item';

--- a/packages/raystack/components/filter-card/filter-card-root.tsx
+++ b/packages/raystack/components/filter-card/filter-card-root.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { cx } from 'class-variance-authority';
+import { forwardRef, type HTMLAttributes } from 'react';
+
+import styles from './filter-card.module.css';
+
+export interface FilterCardRootProps extends HTMLAttributes<HTMLDivElement> {}
+
+export const FilterCardRoot = forwardRef<HTMLDivElement, FilterCardRootProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <div ref={ref} className={cx(styles.filterCard, className)} {...props}>
+        {children}
+      </div>
+    );
+  }
+);
+
+FilterCardRoot.displayName = 'FilterCard';

--- a/packages/raystack/components/filter-card/filter-card-section.tsx
+++ b/packages/raystack/components/filter-card/filter-card-section.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { cx } from 'class-variance-authority';
+import { type ComponentPropsWithoutRef, forwardRef } from 'react';
+
+import { Flex } from '../flex';
+import styles from './filter-card.module.css';
+
+export interface FilterCardSectionProps
+  extends ComponentPropsWithoutRef<typeof Flex> {
+  title?: string;
+}
+
+export const FilterCardSection = forwardRef<
+  HTMLDivElement,
+  FilterCardSectionProps
+>(({ className, title, children, ...props }, ref) => {
+  return (
+    <Flex
+      ref={ref}
+      direction='column'
+      gap={5}
+      className={cx(styles.section, className)}
+      {...props}
+    >
+      {title && <div className={styles.sectionTitle}>{title}</div>}
+      {children}
+    </Flex>
+  );
+});
+
+FilterCardSection.displayName = 'FilterCard.Section';

--- a/packages/raystack/components/filter-card/filter-card.module.css
+++ b/packages/raystack/components/filter-card/filter-card.module.css
@@ -1,0 +1,31 @@
+.filterCard {
+  width: 320px;
+  background: var(--rs-color-background-base-primary);
+  border: 0.5px solid var(--rs-color-border-base-primary);
+  border-radius: var(--rs-radius-3);
+  box-shadow: var(--rs-shadow-soft);
+}
+
+.section {
+  padding: var(--rs-space-5);
+}
+
+.section:not(:last-child) {
+  border-bottom: 0.5px solid var(--rs-color-border-base-primary);
+}
+
+.sectionTitle {
+  font-family: var(--rs-font-body);
+  font-size: var(--rs-font-size-small);
+  font-weight: var(--rs-font-weight-medium);
+  line-height: var(--rs-line-height-small);
+  letter-spacing: var(--rs-letter-spacing-small);
+  color: var(--rs-color-foreground-base-primary);
+  margin-bottom: var(--rs-space-3);
+}
+
+.item {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  align-items: center;
+}

--- a/packages/raystack/components/filter-card/filter-card.module.css
+++ b/packages/raystack/components/filter-card/filter-card.module.css
@@ -14,6 +14,10 @@
   border-bottom: 0.5px solid var(--rs-color-border-base-primary);
 }
 
+.footer {
+  padding: var(--rs-space-3) var(--rs-space-5);
+}
+
 .sectionTitle {
   font-family: var(--rs-font-body);
   font-size: var(--rs-font-size-small);
@@ -21,7 +25,6 @@
   line-height: var(--rs-line-height-small);
   letter-spacing: var(--rs-letter-spacing-small);
   color: var(--rs-color-foreground-base-primary);
-  margin-bottom: var(--rs-space-3);
 }
 
 .item {

--- a/packages/raystack/components/filter-card/filter-card.tsx
+++ b/packages/raystack/components/filter-card/filter-card.tsx
@@ -1,0 +1,8 @@
+import { FilterCardItem } from './filter-card-item';
+import { FilterCardRoot } from './filter-card-root';
+import { FilterCardSection } from './filter-card-section';
+
+export const FilterCard = Object.assign(FilterCardRoot, {
+  Section: FilterCardSection,
+  Item: FilterCardItem
+});

--- a/packages/raystack/components/filter-card/filter-card.tsx
+++ b/packages/raystack/components/filter-card/filter-card.tsx
@@ -1,8 +1,10 @@
+import { FilterCardFooter } from './filter-card-footer';
 import { FilterCardItem } from './filter-card-item';
 import { FilterCardRoot } from './filter-card-root';
 import { FilterCardSection } from './filter-card-section';
 
 export const FilterCard = Object.assign(FilterCardRoot, {
   Section: FilterCardSection,
-  Item: FilterCardItem
+  Item: FilterCardItem,
+  Footer: FilterCardFooter
 });

--- a/packages/raystack/components/filter-card/index.tsx
+++ b/packages/raystack/components/filter-card/index.tsx
@@ -1,0 +1,1 @@
+export { FilterCard } from './filter-card';

--- a/packages/raystack/components/popover/popover.module.css
+++ b/packages/raystack/components/popover/popover.module.css
@@ -19,6 +19,12 @@
   animation: slideUpAndFade 400ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
+.popoverUnstyled {
+  outline: 0;
+  box-sizing: border-box;
+  animation: slideUpAndFade 400ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
 @keyframes slideUpAndFade {
   from {
     opacity: 0;

--- a/packages/raystack/components/popover/popover.tsx
+++ b/packages/raystack/components/popover/popover.tsx
@@ -1,16 +1,29 @@
 'use client';
 
 import { Popover as PopoverPrimitive } from '@base-ui/react';
-import { cx } from 'class-variance-authority';
+import { cva, VariantProps } from 'class-variance-authority';
 import { ElementRef, forwardRef } from 'react';
 import styles from './popover.module.css';
+
+const popover = cva(undefined, {
+  variants: {
+    variant: {
+      default: styles.popover,
+      unstyled: styles.popoverUnstyled
+    }
+  },
+  defaultVariants: {
+    variant: 'default'
+  }
+});
 
 export interface PopoverContentProps
   extends Omit<
       PopoverPrimitive.Positioner.Props,
       'render' | 'className' | 'style'
     >,
-    PopoverPrimitive.Popup.Props {}
+    PopoverPrimitive.Popup.Props,
+    VariantProps<typeof popover> {}
 
 const PopoverContent = forwardRef<
   ElementRef<typeof PopoverPrimitive.Popup>,
@@ -24,6 +37,7 @@ const PopoverContent = forwardRef<
       style,
       render,
       children,
+      variant,
       ...positionerProps
     },
     ref
@@ -38,7 +52,7 @@ const PopoverContent = forwardRef<
         >
           <PopoverPrimitive.Popup
             ref={ref}
-            className={cx(styles.popover, className)}
+            className={popover({ variant, className })}
             render={render}
             initialFocus={initialFocus}
             finalFocus={finalFocus}

--- a/packages/raystack/index.tsx
+++ b/packages/raystack/index.tsx
@@ -30,6 +30,7 @@ export {
 export { Dialog } from './components/dialog';
 export { DropdownMenu } from './components/dropdown-menu';
 export { EmptyState } from './components/empty-state';
+export { FilterCard } from './components/filter-card';
 export { FilterChip } from './components/filter-chip';
 export { Flex } from './components/flex';
 export { Grid } from './components/grid';


### PR DESCRIPTION
## Summary
- Add `FilterCard` component with `Section`, `Item`, and `Footer` sub-components
- Add `unstyled` variant to `Popover.Content` via CVA
- Refactor DataTable display settings to use `FilterCard`
- Clean up unused CSS classes from data-table module

## Test plan
- [ ] Verify FilterCard docs page at `/docs/components/filter-card`
- [ ] Verify DataTable display settings popover renders correctly
- [ ] Verify popover `unstyled` variant works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a composable FilterCard UI with Section, Item and Footer for building filter panels.
  * Exposed FilterCard in the public component exports.

* **Refactor**
  * Data table display/settings and grouping/ordering UIs migrated to the new FilterCard structure for a cleaner layout.
  * Display properties rendering simplified for a more compact presentation.

* **Documentation**
  * New FilterCard docs with interactive playground and demos.

* **Style**
  * Popover gains an "unstyled" variant for alternate presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->