### PR TITLE
fix: validate date value in FilterChip to prevent RangeError

### DIFF
--- a/packages/raystack/components/data-table/utils/filter-operations.tsx
+++ b/packages/raystack/components/data-table/utils/filter-operations.tsx
@@ -166,11 +166,13 @@ const handleStringBasedTypes = (
   operator?: FilterOperatorTypes | DataTableFilterOperatorTypes
 ): DataTableFilterValues => {
   switch (filterType) {
-    case FilterType.date:
+    case FilterType.date: {
+      const dateValue = dayjs(value);
       return {
         value,
-        stringValue: (value as Date).toISOString()
+        stringValue: dateValue.isValid() ? dateValue.toISOString() : ''
       };
+    }
     case FilterType.select:
       return {
         stringValue: value === EmptyFilterValue ? '' : value,

--- a/packages/raystack/components/filter-chip/filter-chip.module.css
+++ b/packages/raystack/components/filter-chip/filter-chip.module.css
@@ -197,3 +197,11 @@ button.selectValue:hover {
 .dateField [data-trailing] {
   margin-left: auto;
 }
+
+.dateFieldWrapper [class*="helper-text"] {
+  display: none;
+}
+
+.dateFieldWrapper [class*="input-error-wrapper"] {
+  border: 1px solid var(--rs-color-border-danger-primary);
+}


### PR DESCRIPTION
## Summary
- Add `dayjs.isValid()` check before calling `toISOString()` in `handleStringBasedTypes` to prevent `RangeError: Invalid time value` when an invalid date is entered
- Hide error helper text inside FilterChip date picker to prevent layout overflow
- Show red border on invalid date input for visual feedback

### Before
<img width="357" height="83" alt="Screenshot 2026-02-26 at 11 10 44 AM" src="https://github.com/user-attachments/assets/9a758770-ea34-4985-9715-1c9b806e0f60" />

### After
<img width="376" height="76" alt="Screenshot 2026-02-26 at 11 09 45 AM" src="https://github.com/user-attachments/assets/940f4b43-c058-4fff-92f4-ab1d585b58a6" />


## Test plan
- [ ] Open a DataTable with a date filter column
- [ ] Click the date filter chip and type an invalid date (e.g. `04/02/2026`)
- [ ] Verify no `RangeError` is thrown
- [ ] Verify the input shows a red border for invalid dates
- [ ] Verify valid dates still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date filter validation to properly handle invalid date entries and prevent conversion errors.
  * Enhanced error messaging display for date fields with clearer visual indicators for validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->