### PR TITLE
feat: add Collapsible component

### DIFF
--- a/apps/www/src/components/playground/collapsible-examples.tsx
+++ b/apps/www/src/components/playground/collapsible-examples.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { Collapsible, Flex, Text } from '@raystack/apsara';
+import PlaygroundLayout from './playground-layout';
+
+export function CollapsibleExamples() {
+  return (
+    <PlaygroundLayout title='Collapsible'>
+      <Flex direction='column' gap='large'>
+        <Text>Default:</Text>
+        <Collapsible>
+          <Collapsible.Trigger>Toggle content</Collapsible.Trigger>
+          <Collapsible.Panel>
+            <Text>This is the collapsible content that can be toggled.</Text>
+          </Collapsible.Panel>
+        </Collapsible>
+      </Flex>
+
+      <Flex direction='column' gap='large'>
+        <Text>Default open:</Text>
+        <Collapsible defaultOpen>
+          <Collapsible.Trigger>Toggle content</Collapsible.Trigger>
+          <Collapsible.Panel>
+            <Text>This content is visible by default.</Text>
+          </Collapsible.Panel>
+        </Collapsible>
+      </Flex>
+
+      <Flex direction='column' gap='large'>
+        <Text>Disabled:</Text>
+        <Collapsible disabled>
+          <Collapsible.Trigger>Cannot toggle (disabled)</Collapsible.Trigger>
+          <Collapsible.Panel>
+            <Text>This content cannot be toggled.</Text>
+          </Collapsible.Panel>
+        </Collapsible>
+      </Flex>
+    </PlaygroundLayout>
+  );
+}

--- a/apps/www/src/components/playground/index.ts
+++ b/apps/www/src/components/playground/index.ts
@@ -9,6 +9,7 @@ export * from './callout-examples';
 export * from './checkbox-examples';
 export * from './chip-examples';
 export * from './code-block-examples';
+export * from './collapsible-examples';
 export * from './combobox-examples';
 export * from './command-examples';
 export * from './container-examples';

--- a/apps/www/src/content/docs/components/collapsible/demo.ts
+++ b/apps/www/src/content/docs/components/collapsible/demo.ts
@@ -1,0 +1,49 @@
+'use client';
+
+export const preview = {
+  type: 'code',
+  code: `<Collapsible style={{ textAlign: 'center' }}>
+  <Collapsible.Trigger>Toggle content</Collapsible.Trigger>
+  <Collapsible.Panel>
+    <p>This is the collapsible content. It can contain any React elements.</p>
+  </Collapsible.Panel>
+</Collapsible>`
+};
+
+export const controlledDemo = {
+  type: 'code',
+  code: `function ControlledCollapsible() {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <Collapsible style={{ textAlign: 'center' }} open={open} onOpenChange={setOpen}>
+      <Collapsible.Trigger>
+        {open ? 'Hide' : 'Show'} content
+      </Collapsible.Trigger>
+      <Collapsible.Panel>
+        <p>This content is controlled by React state.</p>
+      </Collapsible.Panel>
+    </Collapsible>
+  );
+}`
+};
+
+export const defaultOpenDemo = {
+  type: 'code',
+  code: `<Collapsible defaultOpen style={{ textAlign: 'center' }}>
+  <Collapsible.Trigger>Toggle content</Collapsible.Trigger>
+  <Collapsible.Panel>
+    <p>This content is visible by default.</p>
+  </Collapsible.Panel>
+</Collapsible>`
+};
+
+export const disabledDemo = {
+  type: 'code',
+  code: `<Collapsible disabled style={{ textAlign: 'center' }}>
+  <Collapsible.Trigger>Cannot toggle (disabled)</Collapsible.Trigger>
+  <Collapsible.Panel>
+    <p>This content cannot be toggled.</p>
+  </Collapsible.Panel>
+</Collapsible>`
+};

--- a/apps/www/src/content/docs/components/collapsible/index.mdx
+++ b/apps/www/src/content/docs/components/collapsible/index.mdx
@@ -1,0 +1,74 @@
+---
+title: Collapsible
+description: An interactive component that toggles the visibility of its content panel.
+source: packages/raystack/components/collapsible
+tag: new
+---
+
+import {
+  preview,
+  controlledDemo,
+  defaultOpenDemo,
+  disabledDemo,
+} from "./demo.ts";
+
+<Demo data={preview} />
+
+## Anatomy
+
+Import and assemble the component:
+
+```tsx
+import { Collapsible } from '@raystack/apsara'
+
+<Collapsible>
+  <Collapsible.Trigger />
+  <Collapsible.Panel />
+</Collapsible>
+```
+
+## API Reference
+
+### Root
+
+Groups all parts of the collapsible.
+
+<auto-type-table path="./props.ts" name="CollapsibleProps" />
+
+### Trigger
+
+A button that toggles the visibility of the panel.
+
+<auto-type-table path="./props.ts" name="CollapsibleTriggerProps" />
+
+### Panel
+
+Contains the collapsible content.
+
+<auto-type-table path="./props.ts" name="CollapsiblePanelProps" />
+
+## Examples
+
+### Controlled
+
+You can control the collapsible state by providing `open` and `onOpenChange` props.
+
+<Demo data={controlledDemo} />
+
+### Default Open
+
+Use `defaultOpen` to have the panel initially expanded.
+
+<Demo data={defaultOpenDemo} />
+
+### Disabled
+
+The collapsible can be disabled to prevent user interaction.
+
+<Demo data={disabledDemo} />
+
+## Accessibility
+
+- The Trigger uses `aria-expanded` to indicate the open/closed state of the panel.
+- Supports keyboard interaction with Enter and Space to toggle the panel.
+- The Panel is automatically associated with the Trigger via `aria-controls`.

--- a/apps/www/src/content/docs/components/collapsible/props.ts
+++ b/apps/www/src/content/docs/components/collapsible/props.ts
@@ -1,0 +1,48 @@
+export interface CollapsibleProps {
+  /**
+   * Whether the panel is open (controlled).
+   */
+  open?: boolean;
+
+  /**
+   * Whether the panel is initially open (uncontrolled).
+   * @defaultValue false
+   */
+  defaultOpen?: boolean;
+
+  /**
+   * Event handler called when the open state changes.
+   */
+  onOpenChange?: (open: boolean) => void;
+
+  /**
+   * Whether the collapsible is disabled.
+   * @defaultValue false
+   */
+  disabled?: boolean;
+
+  /** Custom CSS class names */
+  className?: string;
+}
+
+export interface CollapsibleTriggerProps {
+  /** Custom CSS class names */
+  className?: string;
+}
+
+export interface CollapsiblePanelProps {
+  /**
+   * Whether to keep the element in the DOM while the panel is closed.
+   * @defaultValue false
+   */
+  keepMounted?: boolean;
+
+  /**
+   * Allows the browser's built-in page search to find and expand the panel contents.
+   * @defaultValue false
+   */
+  hiddenUntilFound?: boolean;
+
+  /** Custom CSS class names */
+  className?: string;
+}

--- a/packages/raystack/components/collapsible/__tests__/collapsible.test.tsx
+++ b/packages/raystack/components/collapsible/__tests__/collapsible.test.tsx
@@ -1,0 +1,202 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { Collapsible } from '../collapsible';
+import styles from '../collapsible.module.css';
+
+const TRIGGER_TEXT = 'Toggle content';
+const PANEL_TEXT = 'Collapsible panel content';
+
+const BasicCollapsible = (
+  props: Partial<Parameters<typeof Collapsible>[0]>
+) => (
+  <Collapsible {...props}>
+    <Collapsible.Trigger>{TRIGGER_TEXT}</Collapsible.Trigger>
+    <Collapsible.Panel>{PANEL_TEXT}</Collapsible.Panel>
+  </Collapsible>
+);
+
+describe('Collapsible', () => {
+  describe('Basic Rendering', () => {
+    it('renders trigger', () => {
+      render(<BasicCollapsible />);
+
+      expect(
+        screen.getByRole('button', { name: TRIGGER_TEXT })
+      ).toBeInTheDocument();
+    });
+
+    it('applies custom className to root', () => {
+      render(<BasicCollapsible className='custom-root' data-testid='root' />);
+
+      const root = screen.getByTestId('root');
+      expect(root).toHaveClass('custom-root');
+    });
+
+    it('forwards ref correctly', () => {
+      const ref = vi.fn();
+      render(
+        <Collapsible ref={ref}>
+          <Collapsible.Trigger>{TRIGGER_TEXT}</Collapsible.Trigger>
+          <Collapsible.Panel>{PANEL_TEXT}</Collapsible.Panel>
+        </Collapsible>
+      );
+      expect(ref).toHaveBeenCalled();
+    });
+  });
+
+  describe('Open/Close Behavior', () => {
+    it('expands and collapses on trigger click', () => {
+      render(<BasicCollapsible />);
+
+      const trigger = screen.getByRole('button', { name: TRIGGER_TEXT });
+
+      // Initially closed
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+      // Click to open
+      fireEvent.click(trigger);
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+      // Click to close
+      fireEvent.click(trigger);
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('starts open when defaultOpen is true', () => {
+      render(<BasicCollapsible defaultOpen />);
+
+      const trigger = screen.getByRole('button', { name: TRIGGER_TEXT });
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('supports controlled open state', () => {
+      const { rerender } = render(<BasicCollapsible open={false} />);
+
+      const trigger = screen.getByRole('button', { name: TRIGGER_TEXT });
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+      rerender(<BasicCollapsible open={true} />);
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('calls onOpenChange when toggled', () => {
+      const onOpenChange = vi.fn();
+      render(<BasicCollapsible onOpenChange={onOpenChange} />);
+
+      const trigger = screen.getByRole('button', { name: TRIGGER_TEXT });
+
+      fireEvent.click(trigger);
+      expect(onOpenChange).toHaveBeenCalledWith(true, expect.anything());
+
+      fireEvent.click(trigger);
+      expect(onOpenChange).toHaveBeenCalledWith(false, expect.anything());
+    });
+
+    it('supports keyboard toggle with Enter', async () => {
+      const user = userEvent.setup();
+      render(<BasicCollapsible />);
+
+      const trigger = screen.getByRole('button', { name: TRIGGER_TEXT });
+
+      await user.keyboard('{Tab}{Enter}');
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+      await user.keyboard('{Enter}');
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('supports keyboard toggle with Space', async () => {
+      const user = userEvent.setup();
+      render(<BasicCollapsible />);
+
+      const trigger = screen.getByRole('button', { name: TRIGGER_TEXT });
+
+      await user.keyboard('{Tab} ');
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
+
+  describe('Disabled State', () => {
+    it('does not toggle when disabled', () => {
+      render(<BasicCollapsible disabled />);
+
+      const trigger = screen.getByRole('button', { name: TRIGGER_TEXT });
+      expect(trigger).toHaveAttribute('aria-disabled', 'true');
+
+      fireEvent.click(trigger);
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+
+  describe('Trigger', () => {
+    it('applies custom className', () => {
+      render(
+        <Collapsible>
+          <Collapsible.Trigger className='custom-trigger' data-testid='trigger'>
+            {TRIGGER_TEXT}
+          </Collapsible.Trigger>
+          <Collapsible.Panel>{PANEL_TEXT}</Collapsible.Panel>
+        </Collapsible>
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      expect(trigger).toHaveClass('custom-trigger');
+      expect(trigger).toHaveClass(styles.trigger);
+    });
+
+    it('forwards ref correctly', () => {
+      const ref = vi.fn();
+      render(
+        <Collapsible>
+          <Collapsible.Trigger ref={ref}>{TRIGGER_TEXT}</Collapsible.Trigger>
+          <Collapsible.Panel>{PANEL_TEXT}</Collapsible.Panel>
+        </Collapsible>
+      );
+      expect(ref).toHaveBeenCalled();
+    });
+
+    it('handles click events', () => {
+      const handleClick = vi.fn();
+      render(
+        <Collapsible>
+          <Collapsible.Trigger onClick={handleClick}>
+            {TRIGGER_TEXT}
+          </Collapsible.Trigger>
+          <Collapsible.Panel>{PANEL_TEXT}</Collapsible.Panel>
+        </Collapsible>
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: TRIGGER_TEXT }));
+      expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Panel', () => {
+    it('applies custom className', () => {
+      render(
+        <Collapsible defaultOpen>
+          <Collapsible.Trigger>{TRIGGER_TEXT}</Collapsible.Trigger>
+          <Collapsible.Panel className='custom-panel' data-testid='panel'>
+            {PANEL_TEXT}
+          </Collapsible.Panel>
+        </Collapsible>
+      );
+
+      const panel = screen.getByTestId('panel');
+      expect(panel).toHaveClass('custom-panel');
+      expect(panel).toHaveClass(styles.panel);
+    });
+
+    it('forwards ref correctly', () => {
+      const ref = vi.fn();
+      render(
+        <Collapsible defaultOpen>
+          <Collapsible.Trigger>{TRIGGER_TEXT}</Collapsible.Trigger>
+          <Collapsible.Panel ref={ref}>{PANEL_TEXT}</Collapsible.Panel>
+        </Collapsible>
+      );
+      expect(ref).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/raystack/components/collapsible/collapsible.module.css
+++ b/packages/raystack/components/collapsible/collapsible.module.css
@@ -1,0 +1,20 @@
+.trigger {
+  cursor: pointer;
+  outline: none;
+}
+
+.trigger:disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+.panel {
+  height: var(--collapsible-panel-height);
+  overflow: hidden;
+  transition: height 150ms ease-out;
+}
+
+.panel[data-starting-style],
+.panel[data-ending-style] {
+  height: 0;
+}

--- a/packages/raystack/components/collapsible/collapsible.tsx
+++ b/packages/raystack/components/collapsible/collapsible.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { Collapsible as CollapsiblePrimitive } from '@base-ui/react';
+import { cx } from 'class-variance-authority';
+import { ElementRef, forwardRef } from 'react';
+import styles from './collapsible.module.css';
+
+const CollapsibleRoot = forwardRef<
+  ElementRef<typeof CollapsiblePrimitive.Root>,
+  CollapsiblePrimitive.Root.Props
+>((props, ref) => <CollapsiblePrimitive.Root ref={ref} {...props} />);
+
+CollapsibleRoot.displayName = 'Collapsible';
+
+const CollapsibleTrigger = forwardRef<
+  ElementRef<typeof CollapsiblePrimitive.Trigger>,
+  CollapsiblePrimitive.Trigger.Props
+>(({ className, ...props }, ref) => (
+  <CollapsiblePrimitive.Trigger
+    ref={ref}
+    className={cx(styles.trigger, className)}
+    {...props}
+  />
+));
+
+CollapsibleTrigger.displayName = 'Collapsible.Trigger';
+
+const CollapsiblePanel = forwardRef<
+  ElementRef<typeof CollapsiblePrimitive.Panel>,
+  CollapsiblePrimitive.Panel.Props
+>(({ className, ...props }, ref) => (
+  <CollapsiblePrimitive.Panel
+    ref={ref}
+    className={cx(styles.panel, className)}
+    {...props}
+  />
+));
+
+CollapsiblePanel.displayName = 'Collapsible.Panel';
+
+export const Collapsible = Object.assign(CollapsibleRoot, {
+  Trigger: CollapsibleTrigger,
+  Panel: CollapsiblePanel
+});

--- a/packages/raystack/components/collapsible/index.ts
+++ b/packages/raystack/components/collapsible/index.ts
@@ -1,0 +1,1 @@
+export { Collapsible } from './collapsible';

--- a/packages/raystack/index.tsx
+++ b/packages/raystack/index.tsx
@@ -14,6 +14,7 @@ export { Callout } from './components/callout';
 export { Checkbox } from './components/checkbox';
 export { Chip } from './components/chip';
 export { CodeBlock } from './components/code-block';
+export { Collapsible } from './components/collapsible';
 export * from './components/color-picker';
 export { Combobox } from './components/combobox';
 export { Command } from './components/command';


### PR DESCRIPTION
## Summary
- Add new Collapsible component based on Base UI with Root, Trigger, and Panel sub-components
- Include animated expand/collapse transition using `--collapsible-panel-height` CSS variable
- Add unit tests covering rendering, open/close behavior, controlled state, keyboard interaction, and disabled state
- Add documentation with preview, controlled, default open, and disabled examples
- Add playground example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new Collapsible component for expandable content sections
  * Supports controlled and default-open states with disabled variant
  * Fully keyboard accessible (Enter/Space key support)

* **Documentation**
  * Added comprehensive documentation with interactive code examples
  * Includes common implementation patterns and accessibility guidelines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->