### PR TITLE
fix: iconButton shrinks in flex container

### DIFF
--- a/packages/raystack/components/icon-button/icon-button.module.css
+++ b/packages/raystack/components/icon-button/icon-button.module.css
@@ -1,5 +1,6 @@
 .iconButton {
   display: inline-flex;
+  flex-shrink: 0;
   align-items: center;
   justify-content: center;
   background-color: transparent;
@@ -45,8 +46,8 @@
   height: var(--rs-space-7);
 }
 
-.iconButton > div,
-.iconButton > div > * {
+.iconButton>div,
+.iconButton>div>* {
   width: 100%;
   height: 100%;
 }


### PR DESCRIPTION
## Description

fix: IconButton shrinks inside a flex container.

Adding a `flex-shrink: 0;` will fix this by avoiding shrinking below its size in a flex container. `IconButton` container class already has a `display: inline-flex;`

<img width="476" height="100" alt="Screenshot 2026-03-06 at 4 23 59 PM" src="https://github.com/user-attachments/assets/016e9b32-ede3-4b2e-8f3b-398d33a41fdc" />


## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

Manual

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (.mdx files)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

[Add screenshots here]

## Related Issues

[Link any related issues here using #issue-number]
