### PR TITLE
fix(switch): replace hardcoded pixel widths with design token expressions

### DIFF
--- a/packages/raystack/components/switch/switch.module.css
+++ b/packages/raystack/components/switch/switch.module.css
@@ -12,12 +12,12 @@
 }
 
 .switch.large {
-  width: 34px;
+  width: calc(var(--rs-space-5) * 2 + var(--rs-space-1));
   height: var(--rs-space-6);
 }
 
 .switch.small {
-  width: 26px;
+  width: calc(var(--rs-space-4) * 2 + var(--rs-space-1));
   height: var(--rs-space-5);
 }
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `34px` and `26px` width values in Switch component CSS with `calc()` expressions using existing `--rs-*` spacing tokens
- Large switch: `calc(var(--rs-space-5) * 2 + var(--rs-space-1))` (= 34px)
- Small switch: `calc(var(--rs-space-4) * 2 + var(--rs-space-1))` (= 26px)

## Test plan
- [x] All 1619 existing tests pass
- [x] Visual output unchanged (values are mathematically equivalent)
- [ ] Verify Switch renders correctly in browser at both sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)