### PR TITLE
refactor: replace `as` prop with `render` prop in Text and Headline

### DIFF
--- a/apps/www/src/components/playground/headline-examples.tsx
+++ b/apps/www/src/components/playground/headline-examples.tsx
@@ -8,13 +8,13 @@ export function HeadlineExamples() {
     <PlaygroundLayout title='Headline'>
       <Flex direction='column' gap='large'>
         <Flex direction='column' gap='large'>
-          <Headline size='large' as='h1'>
+          <Headline size='large' render={<h1 />}>
             Large Headline
           </Headline>
 
           <Headline size='medium'>Medium Headline</Headline>
 
-          <Headline size='small' as='h3'>
+          <Headline size='small' render={<h3 />}>
             Small Headline
           </Headline>
         </Flex>

--- a/apps/www/src/content/docs/components/headline/demo.ts
+++ b/apps/www/src/content/docs/components/headline/demo.ts
@@ -22,8 +22,8 @@ export const playground = {
     },
     render: {
       type: 'select',
-      options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
-      defaultValue: 'h2'
+      options: ['<h1 />', '<h2 />', '<h3 />', '<h4 />', '<h5 />', '<h6 />'],
+      defaultValue: '<h2 />'
     },
     align: {
       type: 'select',

--- a/apps/www/src/content/docs/components/headline/demo.ts
+++ b/apps/www/src/content/docs/components/headline/demo.ts
@@ -20,7 +20,7 @@ export const playground = {
       options: ['regular', 'medium'],
       defaultValue: 'medium'
     },
-    as: {
+    render: {
       type: 'select',
       options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
       defaultValue: 'h2'

--- a/apps/www/src/content/docs/components/headline/index.mdx
+++ b/apps/www/src/content/docs/components/headline/index.mdx
@@ -20,7 +20,7 @@ import { Headline } from '@raystack/apsara'
 
 ## API Reference
 
-Renders a heading element with configurable size and weight.
+Renders a heading element with configurable size and weight. Use the `render` prop to change the heading level or provide a custom render function.
 
 <auto-type-table path="./props.ts" name="HeadlineProps" />
 

--- a/apps/www/src/content/docs/components/headline/props.ts
+++ b/apps/www/src/content/docs/components/headline/props.ts
@@ -12,10 +12,13 @@ export interface HeadlineProps {
   weight?: 'regular' | 'medium';
 
   /**
-   * HTML heading element to render.
+   * Custom render element or function. Accepts a JSX element (e.g. `<h1 />`)
+   * or a render function for full control.
    * @default "h2"
    */
-  as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  render?:
+    | React.ReactElement
+    | ((props: React.ComponentPropsWithRef<'h2'>) => React.ReactElement);
 
   /**
    * Text alignment.

--- a/apps/www/src/content/docs/components/text/demo.ts
+++ b/apps/www/src/content/docs/components/text/demo.ts
@@ -25,8 +25,8 @@ export const playground = {
     },
     render: {
       type: 'select',
-      options: ['span', 'p', 'div', 'label', 'a'],
-      defaultValue: 'span'
+      options: ['<span />', '<p />', '<div />', '<label />', '<a />'],
+      defaultValue: '<span />'
     },
     size: {
       type: 'select',

--- a/apps/www/src/content/docs/components/text/demo.ts
+++ b/apps/www/src/content/docs/components/text/demo.ts
@@ -23,7 +23,7 @@ export const playground = {
       ],
       defaultValue: 'primary'
     },
-    as: {
+    render: {
       type: 'select',
       options: ['span', 'p', 'div', 'label', 'a'],
       defaultValue: 'span'

--- a/apps/www/src/content/docs/components/text/index.mdx
+++ b/apps/www/src/content/docs/components/text/index.mdx
@@ -29,7 +29,7 @@ import { Text } from '@raystack/apsara'
 
 ## API Reference
 
-According to the element rendered using `as`, Text will extend over the default HTML Attributes
+Use the `render` prop to change the rendered element or provide a custom render function.
 
 <auto-type-table path="./props.ts" name="TextProps" />
 

--- a/apps/www/src/content/docs/components/text/props.ts
+++ b/apps/www/src/content/docs/components/text/props.ts
@@ -1,9 +1,12 @@
 export interface TextProps {
   /**
-   * Text element to render as.
+   * Custom render element or function. Accepts a JSX element (e.g. `<p />`)
+   * or a render function for full control.
    * @default "span"
    */
-  as?: 'span' | 'p' | 'div' | 'label' | 'a';
+  render?:
+    | React.ReactElement
+    | ((props: React.ComponentPropsWithRef<'span'>) => React.ReactElement);
 
   /**
    * The visual style variant.

--- a/docs/V1-migration.md
+++ b/docs/V1-migration.md
@@ -32,6 +32,7 @@ This guide covers all breaking changes when upgrading from the last stable Radix
       - [New Features](#new-features-2)
     - [Flex](#flex)
     - [Grid](#grid)
+    - [Headline](#headline)
     - [InputField](#inputfield)
     - [Popover](#popover)
       - [New Features](#new-features-3)
@@ -49,6 +50,7 @@ This guide covers all breaking changes when upgrading from the last stable Radix
     - [Switch](#switch)
     - [Tabs](#tabs)
       - [New Features](#new-features-8)
+    - [Text](#text)
     - [TextArea](#textarea)
     - [Toast](#toast)
       - [New Features](#new-features-9)
@@ -109,6 +111,8 @@ Radix's `asChild` composition pattern is gone. Use the `render` prop instead. No
 ```
 
 Affected components: Button, Grid, Grid.Item, Popover.Trigger, Menu.Trigger, Drawer.Trigger, Dialog.Trigger, Dialog.Close, AlertDialog.Trigger, Breadcrumb.Item, Tooltip.Trigger.
+
+> **Note:** Text and Headline also replace their `as` prop with `render`, but using a different pattern. Instead of `asChild` (which forwarded all props to a child element), `as` was a simple string tag name. The new `render` prop accepts a JSX element or a render function, matching the Base UI convention. See [Text](#text) and [Headline](#headline) for details.
 
 ### Callback Signatures
 
@@ -767,6 +771,35 @@ Type changed to `useRender.ComponentProps<'div'>` -- may cause TypeScript errors
 
 ---
 
+### Headline
+
+**`as` prop replaced by `render`:**
+
+The `as` prop accepted a string tag name (`'h1'` through `'h6'`). The new `render` prop accepts a JSX element or a render function, consistent with the Base UI pattern used across the library. The default element remains `<h2>`.
+
+```tsx
+// Before
+<Headline as="h1" size="large">Page Title</Headline>
+<Headline as="h3" size="small">Section Title</Headline>
+<Headline>Default h2</Headline>
+
+// After
+<Headline render={<h1 />} size="large">Page Title</Headline>
+<Headline render={<h3 />} size="small">Section Title</Headline>
+<Headline>Default h2</Headline>
+```
+
+The `render` prop also supports render functions for full control:
+
+```tsx
+// Render function for custom element
+<Headline render={props => <h1 {...props} />}>Page Title</Headline>
+```
+
+**TypeScript:** The type changed from `HeadlineBaseProps & ComponentProps<'h1'> & { as?: 'h1' | ... | 'h6' }` to `HeadlineBaseProps & useRender.ComponentProps<'h2'>`. If you explicitly typed Headline props, update to `HeadlineProps` (now exported).
+
+---
+
 ### InputField
 
 **Label, helper text, error, and optional indicator moved to `Field` wrapper.** InputField is now a pure input control — wrap it with the new `Field` component for labels, descriptions, and error messages.
@@ -1283,6 +1316,49 @@ Key changes:
 
 ---
 
+### Text
+
+**`as` prop replaced by `render`:**
+
+The `as` prop accepted a string tag name (`'span'`, `'p'`, `'div'`, `'label'`, `'a'`). The new `render` prop accepts a JSX element or a render function, consistent with the Base UI pattern used across the library. The default element remains `<span>`.
+
+```tsx
+// Before
+<Text as="label">Username</Text>
+<Text as="p">Paragraph text</Text>
+<Text as="a" href="/link">Click here</Text>
+<Text>Default span</Text>
+
+// After
+<Text render={<label />}>Username</Text>
+<Text render={<p />}>Paragraph text</Text>
+<Text render={<a href="/link" />}>Click here</Text>
+<Text>Default span</Text>
+```
+
+Note that HTML attributes specific to the rendered element (like `href` for anchors, `htmlFor` for labels) now go on the JSX element inside `render`, not on `Text` itself:
+
+```tsx
+// Before
+<Text as="label" htmlFor="email-input">Email</Text>
+<Text as="a" href="#section" target="_blank">Link</Text>
+
+// After
+<Text render={<label htmlFor="email-input" />}>Email</Text>
+<Text render={<a href="#section" target="_blank" />}>Link</Text>
+```
+
+The `render` prop also supports render functions for full control:
+
+```tsx
+// Render function for any element
+<Text render={props => <section {...props} />}>Custom element</Text>
+```
+
+**TypeScript:** The type changed from a discriminated union (`TextSpanProps | TextDivProps | TextLabelProps | TextPProps | TextAProps`) to `TextBaseProps & useRender.ComponentProps<'span'>`. The `render` prop now accepts any element, so you are no longer limited to the five original tag names. The `// @ts-expect-error` that was needed internally for polymorphic refs is also gone.
+
+---
+
 ### TextArea
 
 **Label, helper text, error, and optional indicator moved to `Field` wrapper.** TextArea is now a pure textarea control — wrap it with the new `Field` component for labels, descriptions, and error messages.
@@ -1596,6 +1672,8 @@ These are purely additive -- no migration needed.
 - [ ] Upgrade to React 19
 - [ ] Update CSS import order (`normalize.css` before `style.css`)
 - [ ] Global find-and-replace: `asChild` -> `render` prop pattern
+- [ ] Replace `Text as="..."` with `Text render={<element />}` (see [Text](#text))
+- [ ] Replace `Headline as="..."` with `Headline render={<element />}` (see [Headline](#headline))
 - [ ] Update callback signatures where TypeScript complains
 - [ ] Replace `DropdownMenu` imports with `Menu`
 - [ ] Replace `Sheet` imports with `Drawer`

--- a/packages/raystack/components/headline/__tests__/headline.test.tsx
+++ b/packages/raystack/components/headline/__tests__/headline.test.tsx
@@ -30,19 +30,47 @@ describe('Headline', () => {
     });
   });
 
-  describe('As Prop', () => {
-    const headingLevels = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const;
-
-    it.each(headingLevels)('renders as %s element', level => {
-      render(<Headline as={level}>Heading</Headline>);
+  describe('Render Prop', () => {
+    it('renders as h1 via render prop', () => {
+      render(<Headline render={<h1 />}>Heading</Headline>);
       const heading = screen.getByText('Heading');
-      expect(heading.tagName).toBe(level.toUpperCase());
+      expect(heading.tagName).toBe('H1');
+    });
+
+    it('renders as h3 via render prop', () => {
+      render(<Headline render={<h3 />}>Heading</Headline>);
+      const heading = screen.getByText('Heading');
+      expect(heading.tagName).toBe('H3');
+    });
+
+    it('renders as h4 via render prop', () => {
+      render(<Headline render={<h4 />}>Heading</Headline>);
+      const heading = screen.getByText('Heading');
+      expect(heading.tagName).toBe('H4');
+    });
+
+    it('renders as h5 via render prop', () => {
+      render(<Headline render={<h5 />}>Heading</Headline>);
+      const heading = screen.getByText('Heading');
+      expect(heading.tagName).toBe('H5');
+    });
+
+    it('renders as h6 via render prop', () => {
+      render(<Headline render={<h6 />}>Heading</Headline>);
+      const heading = screen.getByText('Heading');
+      expect(heading.tagName).toBe('H6');
     });
 
     it('renders as h2 by default', () => {
       render(<Headline>Heading</Headline>);
       const heading = screen.getByText('Heading');
       expect(heading.tagName).toBe('H2');
+    });
+
+    it('supports render function', () => {
+      render(<Headline render={props => <h1 {...props} />}>Heading</Headline>);
+      const heading = screen.getByText('Heading');
+      expect(heading.tagName).toBe('H1');
     });
   });
 

--- a/packages/raystack/components/headline/headline.tsx
+++ b/packages/raystack/components/headline/headline.tsx
@@ -1,5 +1,5 @@
+import { mergeProps, useRender } from '@base-ui/react';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { ComponentProps } from 'react';
 import styles from './headline.module.css';
 
 const headline = cva(styles.headline, {
@@ -41,10 +41,7 @@ export type HeadlineBaseProps = VariantProps<typeof headline> & {
   size?: 't1' | 't2' | 't3' | 't4' | 'small' | 'medium' | 'large';
 };
 
-type HeadlineProps = HeadlineBaseProps &
-  ComponentProps<'h1'> & {
-    as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
-  };
+export type HeadlineProps = HeadlineBaseProps & useRender.ComponentProps<'h2'>;
 
 export function Headline({
   className,
@@ -52,15 +49,21 @@ export function Headline({
   weight,
   align,
   truncate,
-  as: Component = 'h2',
+  render,
+  ref,
   ...props
 }: HeadlineProps) {
-  return (
-    <Component
-      className={headline({ size, weight, align, truncate, className })}
-      {...props}
-    />
-  );
+  const element = useRender({
+    defaultTagName: 'h2',
+    ref,
+    render,
+    props: mergeProps<'h2'>(
+      { className: headline({ size, weight, align, truncate, className }) },
+      props
+    )
+  });
+
+  return element;
 }
 
 Headline.displayName = 'Headline';

--- a/packages/raystack/components/link/link.tsx
+++ b/packages/raystack/components/link/link.tsx
@@ -42,7 +42,7 @@ export function Link({
       {...externalProps}
       {...downloadProps}
       {...props}
-      as='a'
+      render={<a />}
     >
       {children}
     </Text>

--- a/packages/raystack/components/text/__tests__/text.test.tsx
+++ b/packages/raystack/components/text/__tests__/text.test.tsx
@@ -206,49 +206,59 @@ describe('Text', () => {
     });
   });
 
-  describe('As Rendering', () => {
-    it('renders as div when specified', () => {
-      render(<Text as='div'>Div text</Text>);
+  describe('Render Prop', () => {
+    it('renders as div via render prop', () => {
+      render(<Text render={<div />}>Div text</Text>);
 
       const div = screen.getByText('Div text');
       expect(div.tagName.toLowerCase()).toBe('div');
     });
 
-    it('renders as paragraph when specified', () => {
-      render(<Text as='p'>Paragraph text</Text>);
+    it('renders as paragraph via render prop', () => {
+      render(<Text render={<p />}>Paragraph text</Text>);
 
       const p = screen.getByText('Paragraph text');
       expect(p.tagName.toLowerCase()).toBe('p');
     });
 
-    it('renders as label when specified', () => {
-      render(<Text as='label'>Label text</Text>);
+    it('renders as label via render prop', () => {
+      render(<Text render={<label />}>Label text</Text>);
 
       const label = screen.getByText('Label text');
       expect(label.tagName.toLowerCase()).toBe('label');
     });
 
-    it('renders as anchor when specified', () => {
-      render(
-        <Text as='a' href='#test'>
-          Link text
-        </Text>
-      );
+    it('renders as anchor via render prop', () => {
+      render(<Text render={<a href='#test' />}>Link text</Text>);
 
       const a = screen.getByText('Link text');
       expect(a.tagName.toLowerCase()).toBe('a');
       expect(a).toHaveAttribute('href', '#test');
     });
 
-    it('forwards props to the correct element type', () => {
+    it('renders as h1 via render prop', () => {
+      render(<Text render={<h1 />}>Heading text</Text>);
+
+      const h1 = screen.getByText('Heading text');
+      expect(h1.tagName.toLowerCase()).toBe('h1');
+    });
+
+    it('forwards props to the rendered element', () => {
       render(
-        <Text as='label' htmlFor='test-input'>
-          Label for input
-        </Text>
+        <Text render={<label htmlFor='test-input' />}>Label for input</Text>
       );
 
       const label = screen.getByText('Label for input');
       expect(label).toHaveAttribute('for', 'test-input');
+    });
+
+    it('supports render function', () => {
+      render(
+        <Text render={props => <section {...props} />}>Section text</Text>
+      );
+
+      const section = screen.getByText('Section text');
+      expect(section.tagName.toLowerCase()).toBe('section');
     });
   });
 

--- a/packages/raystack/components/text/text.tsx
+++ b/packages/raystack/components/text/text.tsx
@@ -1,5 +1,5 @@
+import { mergeProps, useRender } from '@base-ui/react';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { ComponentProps } from 'react';
 import styles from './text.module.css';
 
 export const textVariants = cva(styles.text, {
@@ -131,13 +131,7 @@ export type TextBaseProps = VariantProps<typeof textVariants> & {
     | 900;
 };
 
-type TextSpanProps = { as?: 'span' } & ComponentProps<'span'>;
-type TextDivProps = { as: 'div' } & ComponentProps<'div'>;
-type TextLabelProps = { as: 'label' } & ComponentProps<'label'>;
-type TextPProps = { as: 'p' } & ComponentProps<'p'>;
-type TextAProps = { as: 'a' } & ComponentProps<'a'>;
-export type TextProps = TextBaseProps &
-  (TextSpanProps | TextDivProps | TextLabelProps | TextPProps | TextAProps);
+export type TextProps = TextBaseProps & useRender.ComponentProps<'span'>;
 
 export function Text({
   className,
@@ -150,9 +144,9 @@ export function Text({
   underline,
   strikeThrough,
   italic,
-  as: Component = 'span',
-  children,
-  ...rest
+  render,
+  ref,
+  ...props
 }: TextProps) {
   const textClassName = textVariants({
     size,
@@ -167,12 +161,14 @@ export function Text({
     italic
   });
 
-  return (
-    // @ts-expect-error polymorphic ref
-    <Component className={textClassName} {...rest}>
-      {children}
-    </Component>
-  );
+  const element = useRender({
+    defaultTagName: 'span',
+    ref,
+    render,
+    props: mergeProps<'span'>({ className: textClassName }, props)
+  });
+
+  return element;
 }
 
 Text.displayName = 'Text';


### PR DESCRIPTION
## Summary
- Replace the `as` polymorphic prop with Base UI's `render` prop + `useRender` hook in the **Text** and **Headline** components, matching the existing pattern used by the `Flex` component.
- Remove brittle per-element type unions (`TextSpanProps`, `TextDivProps`, etc.) and the `@ts-expect-error` suppression, using `useRender.ComponentProps<'span'>` / `useRender.ComponentProps<'h2'>` instead.
- Update the **Link** component (which used `as='a'` on Text) to use `render={<a />}`.
- Update all tests, docs, playground controls, and example files to use the `render` prop.

## Test plan
- [x] All Text tests pass (89 tests including 7 new render prop tests)
- [x] All Headline tests pass (33 tests including 7 new render prop tests)
- [x] All Link tests pass (12 tests)
- [x] TypeScript compiles cleanly for text, headline, and link components (`npx tsc --noEmit`)
- [x] Verify default tag rendering (`<span>` for Text, `<h2>` for Headline)
- [x] Verify render prop with JSX element (e.g., `<Text render={<h1 />}>`)
- [x] Verify render function (e.g., `<Text render={(props) => <section {...props} />}>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)