### PR TITLE
feat(checkbox): accessibility features, size variants, and custom icons

### DIFF
--- a/apps/www/src/content/docs/components/checkbox/demo.ts
+++ b/apps/www/src/content/docs/components/checkbox/demo.ts
@@ -25,6 +25,11 @@ export const playground = {
     disabled: {
       type: 'checkbox',
       defaultValue: false
+    },
+    size: {
+      type: 'select',
+      options: ['large', 'small'],
+      defaultValue: 'large'
     }
   },
   getCode
@@ -52,6 +57,20 @@ export const statesExamples = {
   ]
 };
 
+export const sizeExamples = {
+  type: 'code',
+  tabs: [
+    {
+      name: 'Large (default)',
+      code: `<Checkbox size="large" />`
+    },
+    {
+      name: 'Small',
+      code: `<Checkbox size="small" />`
+    }
+  ]
+};
+
 export const groupDemo = {
   type: 'code',
   code: `
@@ -69,6 +88,25 @@ export const groupDemo = {
       <Checkbox name="cherry" id="cg-cherry" />
       <label htmlFor="cg-cherry">Cherry</label>
     </Flex>
+  </Flex>
+</Checkbox.Group>`
+};
+
+export const groupHorizontalDemo = {
+  type: 'code',
+  code: `
+<Checkbox.Group defaultValue={["banana"]} orientation="horizontal">
+  <Flex gap="small" align="center">
+    <Checkbox name="apple" id="ch-apple" />
+    <label htmlFor="ch-apple">Apple</label>
+  </Flex>
+  <Flex gap="small" align="center">
+    <Checkbox name="banana" id="ch-banana" />
+    <label htmlFor="ch-banana">Banana</label>
+  </Flex>
+  <Flex gap="small" align="center">
+    <Checkbox name="cherry" id="ch-cherry" />
+    <label htmlFor="ch-cherry">Cherry</label>
   </Flex>
 </Checkbox.Group>`
 };

--- a/apps/www/src/content/docs/components/checkbox/index.mdx
+++ b/apps/www/src/content/docs/components/checkbox/index.mdx
@@ -4,7 +4,7 @@ description: Checkbox is a user interface control that enables users to toggle b
 source: packages/raystack/components/checkbox
 ---
 
-import { playground, statesExamples, groupDemo, groupDisabledDemo, parentDemo } from "./demo.ts";
+import { playground, statesExamples, sizeExamples, groupDemo, groupHorizontalDemo, groupDisabledDemo, parentDemo } from "./demo.ts";
 
 <Demo data={playground} />
 
@@ -55,11 +55,23 @@ The Checkbox component supports multiple states to represent different selection
 
 <Demo data={statesExamples} />
 
+### Size Variants
+
+The Checkbox component comes in two sizes: `large` (default) and `small`.
+
+<Demo data={sizeExamples} />
+
 ### Group
 
 Use `Checkbox.Group` to coordinate multiple checkboxes with shared state.
 
 <Demo data={groupDemo} />
+
+### Horizontal Group
+
+Use the `orientation` prop to lay out checkboxes in a horizontal row.
+
+<Demo data={groupHorizontalDemo} />
 
 ### Disabled Group
 
@@ -80,3 +92,6 @@ Use a parent checkbox with `allValues` to toggle all items at once.
 - Uses `aria-checked` to indicate state (checked, unchecked, indeterminate)
 - Associates with labels via `id` and `htmlFor` attributes
 - Wrap `Checkbox.Group` with `aria-label` or `aria-labelledby` for an accessible group name
+- **Disabled state** preserves the visual checked/indeterminate appearance while preventing interaction
+- **Read-only state** reduces opacity and changes cursor to indicate non-editable content
+- **Invalid state** displays a danger border (or danger background when checked/indeterminate) for form validation feedback

--- a/apps/www/src/content/docs/components/checkbox/props.ts
+++ b/apps/www/src/content/docs/components/checkbox/props.ts
@@ -42,14 +42,12 @@ export interface CheckboxProps {
   size?: 'small' | 'large';
 
   /**
-   * Custom indicator content. Can be a ReactNode or a function receiving `{ checked, indeterminate }` state.
+   * Custom render function for the indicator. Receives `(props, state)` where state includes `checked` and `indeterminate`.
    */
-  children?:
-    | React.ReactNode
-    | ((state: {
-        checked: boolean;
-        indeterminate: boolean;
-      }) => React.ReactNode);
+  render?: (
+    props: React.HTMLAttributes<HTMLSpanElement>,
+    state: { checked: boolean; indeterminate: boolean }
+  ) => React.ReactNode;
 
   /** Additional CSS class name. */
   className?: string;

--- a/apps/www/src/content/docs/components/checkbox/props.ts
+++ b/apps/www/src/content/docs/components/checkbox/props.ts
@@ -42,19 +42,14 @@ export interface CheckboxProps {
   size?: 'small' | 'large';
 
   /**
-   * Custom icon to render when the checkbox is checked.
+   * Custom indicator content. Can be a ReactNode or a function receiving `{ checked, indeterminate }` state.
    */
-  checkedIcon?: React.ReactNode;
-
-  /**
-   * Custom icon to render when the checkbox is in the indeterminate state.
-   */
-  indeterminateIcon?: React.ReactNode;
-
-  /**
-   * Ref to the hidden `<input>` element for form integration.
-   */
-  inputRef?: React.Ref<HTMLInputElement>;
+  children?:
+    | React.ReactNode
+    | ((state: {
+        checked: boolean;
+        indeterminate: boolean;
+      }) => React.ReactNode);
 
   /** Additional CSS class name. */
   className?: string;

--- a/apps/www/src/content/docs/components/checkbox/props.ts
+++ b/apps/www/src/content/docs/components/checkbox/props.ts
@@ -35,6 +35,27 @@ export interface CheckboxProps {
    */
   parent?: boolean;
 
+  /**
+   * The size of the checkbox.
+   * @defaultValue 'large'
+   */
+  size?: 'small' | 'large';
+
+  /**
+   * Custom icon to render when the checkbox is checked.
+   */
+  checkedIcon?: React.ReactNode;
+
+  /**
+   * Custom icon to render when the checkbox is in the indeterminate state.
+   */
+  indeterminateIcon?: React.ReactNode;
+
+  /**
+   * Ref to the hidden `<input>` element for form integration.
+   */
+  inputRef?: React.Ref<HTMLInputElement>;
+
   /** Additional CSS class name. */
   className?: string;
 }
@@ -59,6 +80,12 @@ export interface CheckboxGroupProps {
    * @defaultValue false
    */
   disabled?: boolean;
+
+  /**
+   * Layout direction of the checkbox group.
+   * @defaultValue 'vertical'
+   */
+  orientation?: 'vertical' | 'horizontal';
 
   /** Additional CSS class name. */
   className?: string;

--- a/apps/www/src/content/docs/components/checkbox/props.ts
+++ b/apps/www/src/content/docs/components/checkbox/props.ts
@@ -20,9 +20,23 @@ export interface CheckboxProps {
   indeterminate?: boolean;
 
   /**
-   * When true, prevents the user from interacting with the checkbox
+   * When true, prevents the user from interacting with the checkbox.
+   * @defaultValue false
    */
   disabled?: boolean;
+
+  /**
+   * When true, the checkbox is displayed in a read-only state.
+   * The user cannot change the value but it is still focusable.
+   * @defaultValue false
+   */
+  readOnly?: boolean;
+
+  /**
+   * When true, the user must tick the checkbox before submitting a form.
+   * @defaultValue false
+   */
+  required?: boolean;
 
   /**
    * Identifies the checkbox within a `Checkbox.Group`. The group uses this value in its `value` array.

--- a/docs/V1-migration.md
+++ b/docs/V1-migration.md
@@ -23,37 +23,38 @@ This guide covers all breaking changes when upgrading from the last stable Radix
     - [Button](#button)
     - [Checkbox](#checkbox)
       - [New: `Checkbox.Group`](#new-checkboxgroup)
-    - [Combobox](#combobox)
       - [New Features](#new-features)
+    - [Combobox](#combobox)
+      - [New Features](#new-features-1)
     - [Data Table](#data-table)
     - [Dialog](#dialog)
-      - [New Features](#new-features-1)
-    - [DropdownMenu -\> Menu](#dropdownmenu---menu)
       - [New Features](#new-features-2)
+    - [DropdownMenu -\> Menu](#dropdownmenu---menu)
+      - [New Features](#new-features-3)
     - [Flex](#flex)
     - [Grid](#grid)
     - [InputField](#inputfield)
     - [Popover](#popover)
-      - [New Features](#new-features-3)
+      - [New Features](#new-features-4)
     - [Radio](#radio)
     - [ScrollArea](#scrollarea)
     - [Select](#select)
-      - [New Features](#new-features-4)
+      - [New Features](#new-features-5)
     - [Separator](#separator)
     - [Sheet -\> Drawer](#sheet---drawer)
-      - [New Features](#new-features-5)
-    - [Sidebar](#sidebar)
       - [New Features](#new-features-6)
-    - [Slider](#slider)
+    - [Sidebar](#sidebar)
       - [New Features](#new-features-7)
+    - [Slider](#slider)
+      - [New Features](#new-features-8)
     - [Switch](#switch)
     - [Tabs](#tabs)
-      - [New Features](#new-features-8)
+      - [New Features](#new-features-9)
     - [TextArea](#textarea)
     - [Toast](#toast)
-      - [New Features](#new-features-9)
-    - [Tooltip](#tooltip)
       - [New Features](#new-features-10)
+    - [Tooltip](#tooltip)
+      - [New Features](#new-features-11)
   - [New Components](#new-components)
   - [Removed Exports](#removed-exports)
   - [| `RadioItem` | `Radio` | See Radio |](#-radioitem--radio--see-radio-)
@@ -452,6 +453,38 @@ Unchanged: `size`, `radius`, `variant`, `color`, `fallback`, `src`, `alt`, `clas
 
 ```tsx
 <Checkbox.Group defaultValue={['apple']} onValueChange={setSelected}>
+  <Checkbox name="apple" />
+  <Checkbox name="banana" />
+</Checkbox.Group>
+```
+
+#### New Features
+
+- `size` prop (`'small' | 'large'`, default `'large'`) for controlling checkbox dimensions
+- `render` prop for custom indicator rendering — receives `(props, state)` where state includes `checked` and `indeterminate`
+- `readOnly` prop for non-editable display with reduced opacity
+- `orientation` prop on `Checkbox.Group` (`'vertical' | 'horizontal'`, default `'vertical'`)
+- Enhanced disabled state preserves checked/indeterminate visual appearance
+- Invalid state styling with danger border (and danger background when checked/indeterminate)
+
+```tsx
+// Size variants
+<Checkbox size="small" />
+<Checkbox size="large" /> {/* default */}
+
+// Custom indicator
+<Checkbox
+  checked
+  render={(props, state) => (
+    <span {...props}>{state.checked ? '✓' : ''}</span>
+  )}
+/>
+
+// Read-only checkbox
+<Checkbox checked readOnly />
+
+// Horizontal group layout
+<Checkbox.Group defaultValue={['apple']} orientation="horizontal">
   <Checkbox name="apple" />
   <Checkbox name="banana" />
 </Checkbox.Group>

--- a/packages/raystack/components/checkbox/__tests__/checkbox-group.test.tsx
+++ b/packages/raystack/components/checkbox/__tests__/checkbox-group.test.tsx
@@ -63,6 +63,44 @@ describe('Checkbox.Group', () => {
     });
   });
 
+  describe('Orientation', () => {
+    it('renders vertical by default', () => {
+      render(
+        <Checkbox.Group data-testid='group'>
+          <Checkbox name='apple' />
+          <Checkbox name='banana' />
+        </Checkbox.Group>
+      );
+      const group = screen.getByTestId('group');
+      expect(group).toHaveClass(styles.group);
+      expect(group).not.toHaveClass(styles['group-horizontal']);
+    });
+
+    it('renders vertical when orientation="vertical"', () => {
+      render(
+        <Checkbox.Group orientation='vertical' data-testid='group'>
+          <Checkbox name='apple' />
+          <Checkbox name='banana' />
+        </Checkbox.Group>
+      );
+      const group = screen.getByTestId('group');
+      expect(group).toHaveClass(styles.group);
+      expect(group).not.toHaveClass(styles['group-horizontal']);
+    });
+
+    it('renders horizontal when orientation="horizontal"', () => {
+      render(
+        <Checkbox.Group orientation='horizontal' data-testid='group'>
+          <Checkbox name='apple' />
+          <Checkbox name='banana' />
+        </Checkbox.Group>
+      );
+      const group = screen.getByTestId('group');
+      expect(group).toHaveClass(styles.group);
+      expect(group).toHaveClass(styles['group-horizontal']);
+    });
+  });
+
   describe('Selection Behavior', () => {
     it('works with defaultValue', () => {
       render(

--- a/packages/raystack/components/checkbox/__tests__/checkbox.test.tsx
+++ b/packages/raystack/components/checkbox/__tests__/checkbox.test.tsx
@@ -31,6 +31,23 @@ describe('Checkbox', () => {
     });
   });
 
+  describe('Sizes', () => {
+    const sizes = ['small', 'large'] as const;
+    sizes.forEach(size => {
+      it(`renders ${size} size`, () => {
+        render(<Checkbox size={size} />);
+        const checkbox = screen.getByRole('checkbox');
+        expect(checkbox).toHaveClass(styles[size]);
+      });
+    });
+
+    it('renders large size by default', () => {
+      render(<Checkbox />);
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toHaveClass(styles.large);
+    });
+  });
+
   describe('Checked State', () => {
     it('renders unchecked by default', () => {
       render(<Checkbox />);
@@ -133,6 +150,44 @@ describe('Checkbox', () => {
     });
   });
 
+  describe('Custom Icons', () => {
+    it('renders custom checked icon when provided', () => {
+      render(
+        <Checkbox
+          checked
+          checkedIcon={<span data-testid='custom-check'>custom</span>}
+        />
+      );
+      expect(screen.getByTestId('custom-check')).toBeInTheDocument();
+    });
+
+    it('renders custom indeterminate icon when provided', () => {
+      render(
+        <Checkbox
+          indeterminate
+          indeterminateIcon={
+            <span data-testid='custom-indeterminate'>custom</span>
+          }
+        />
+      );
+      expect(screen.getByTestId('custom-indeterminate')).toBeInTheDocument();
+    });
+
+    it('renders default check icon when no custom icon is provided', () => {
+      const { container } = render(<Checkbox checked />);
+      const indicator = container.querySelector(`.${styles.indicator}`);
+      const svg = indicator?.querySelector('svg');
+      expect(svg).toBeInTheDocument();
+    });
+
+    it('renders default indeterminate icon when no custom icon is provided', () => {
+      const { container } = render(<Checkbox indeterminate />);
+      const indicator = container.querySelector(`.${styles.indicator}`);
+      const svg = indicator?.querySelector('svg');
+      expect(svg).toBeInTheDocument();
+    });
+  });
+
   describe('Event Handling', () => {
     it('calls onCheckedChange when clicked', () => {
       const handleChange = vi.fn();
@@ -231,6 +286,12 @@ describe('Checkbox', () => {
       render(<Checkbox aria-invalid='true' />);
       const checkbox = screen.getByRole('checkbox');
       expect(checkbox).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('supports required prop', () => {
+      render(<Checkbox required />);
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toHaveAttribute('data-required');
     });
   });
 });

--- a/packages/raystack/components/checkbox/__tests__/checkbox.test.tsx
+++ b/packages/raystack/components/checkbox/__tests__/checkbox.test.tsx
@@ -150,37 +150,50 @@ describe('Checkbox', () => {
     });
   });
 
-  describe('Custom Icons', () => {
-    it('renders custom checked icon when provided', () => {
+  describe('Children (Custom Icons)', () => {
+    it('renders children as ReactNode when provided', () => {
       render(
-        <Checkbox
-          checked
-          checkedIcon={<span data-testid='custom-check'>custom</span>}
-        />
+        <Checkbox checked>
+          <span data-testid='custom-icon'>custom</span>
+        </Checkbox>
       );
-      expect(screen.getByTestId('custom-check')).toBeInTheDocument();
+      expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
     });
 
-    it('renders custom indeterminate icon when provided', () => {
+    it('renders children as render function with state', () => {
       render(
-        <Checkbox
-          indeterminate
-          indeterminateIcon={
-            <span data-testid='custom-indeterminate'>custom</span>
-          }
-        />
+        <Checkbox checked>
+          {({ checked, indeterminate }) => (
+            <span data-testid='render-fn'>
+              {checked ? 'yes' : 'no'}-{indeterminate ? 'mixed' : 'clear'}
+            </span>
+          )}
+        </Checkbox>
       );
-      expect(screen.getByTestId('custom-indeterminate')).toBeInTheDocument();
+      expect(screen.getByTestId('render-fn')).toHaveTextContent('yes-clear');
     });
 
-    it('renders default check icon when no custom icon is provided', () => {
+    it('renders render function with indeterminate state', () => {
+      render(
+        <Checkbox indeterminate>
+          {({ indeterminate }) => (
+            <span data-testid='render-fn'>
+              {indeterminate ? 'mixed' : 'clear'}
+            </span>
+          )}
+        </Checkbox>
+      );
+      expect(screen.getByTestId('render-fn')).toHaveTextContent('mixed');
+    });
+
+    it('renders default check icon when no children provided', () => {
       const { container } = render(<Checkbox checked />);
       const indicator = container.querySelector(`.${styles.indicator}`);
       const svg = indicator?.querySelector('svg');
       expect(svg).toBeInTheDocument();
     });
 
-    it('renders default indeterminate icon when no custom icon is provided', () => {
+    it('renders default indeterminate icon when no children provided', () => {
       const { container } = render(<Checkbox indeterminate />);
       const indicator = container.querySelector(`.${styles.indicator}`);
       const svg = indicator?.querySelector('svg');

--- a/packages/raystack/components/checkbox/__tests__/checkbox.test.tsx
+++ b/packages/raystack/components/checkbox/__tests__/checkbox.test.tsx
@@ -150,50 +150,45 @@ describe('Checkbox', () => {
     });
   });
 
-  describe('Children (Custom Icons)', () => {
-    it('renders children as ReactNode when provided', () => {
+  describe('Custom Indicator (render prop)', () => {
+    it('renders custom indicator via render prop', () => {
       render(
-        <Checkbox checked>
-          <span data-testid='custom-icon'>custom</span>
-        </Checkbox>
-      );
-      expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
-    });
-
-    it('renders children as render function with state', () => {
-      render(
-        <Checkbox checked>
-          {({ checked, indeterminate }) => (
-            <span data-testid='render-fn'>
-              {checked ? 'yes' : 'no'}-{indeterminate ? 'mixed' : 'clear'}
+        <Checkbox
+          checked
+          render={(props, state) => (
+            <span {...props} data-testid='custom-indicator'>
+              {state.checked ? 'checked' : 'unchecked'}
             </span>
           )}
-        </Checkbox>
+        />
       );
-      expect(screen.getByTestId('render-fn')).toHaveTextContent('yes-clear');
+      expect(screen.getByTestId('custom-indicator')).toHaveTextContent(
+        'checked'
+      );
     });
 
-    it('renders render function with indeterminate state', () => {
+    it('receives indeterminate state in render prop', () => {
       render(
-        <Checkbox indeterminate>
-          {({ indeterminate }) => (
-            <span data-testid='render-fn'>
-              {indeterminate ? 'mixed' : 'clear'}
+        <Checkbox
+          indeterminate
+          render={(props, state) => (
+            <span {...props} data-testid='custom-indicator'>
+              {state.indeterminate ? 'mixed' : 'clear'}
             </span>
           )}
-        </Checkbox>
+        />
       );
-      expect(screen.getByTestId('render-fn')).toHaveTextContent('mixed');
+      expect(screen.getByTestId('custom-indicator')).toHaveTextContent('mixed');
     });
 
-    it('renders default check icon when no children provided', () => {
+    it('renders default check icon when no render prop provided', () => {
       const { container } = render(<Checkbox checked />);
       const indicator = container.querySelector(`.${styles.indicator}`);
       const svg = indicator?.querySelector('svg');
       expect(svg).toBeInTheDocument();
     });
 
-    it('renders default indeterminate icon when no children provided', () => {
+    it('renders default indeterminate icon when no render prop provided', () => {
       const { container } = render(<Checkbox indeterminate />);
       const indicator = container.querySelector(`.${styles.indicator}`);
       const svg = indicator?.querySelector('svg');

--- a/packages/raystack/components/checkbox/checkbox.module.css
+++ b/packages/raystack/components/checkbox/checkbox.module.css
@@ -4,21 +4,43 @@
   gap: var(--rs-space-3);
 }
 
+.group-horizontal {
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
 .checkbox {
   all: unset;
   box-sizing: border-box;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: var(--rs-space-5);
-  height: var(--rs-space-5);
-  min-width: var(--rs-space-5);
-  min-height: var(--rs-space-5);
   border-radius: var(--rs-radius-1);
   background: var(--rs-color-background-base-primary);
   border: 1px solid var(--rs-color-border-base-secondary);
   cursor: pointer;
   flex-shrink: 0;
+}
+
+/* Size variants */
+.large {
+  width: var(--rs-space-5);
+  height: var(--rs-space-5);
+  min-width: var(--rs-space-5);
+  min-height: var(--rs-space-5);
+}
+
+.small {
+  width: var(--rs-space-4);
+  height: var(--rs-space-4);
+  min-width: var(--rs-space-4);
+  min-height: var(--rs-space-4);
+}
+
+/* A1: Focus-visible ring for keyboard navigation (WCAG 2.4.7) */
+.checkbox:focus-visible {
+  outline: 2px solid var(--rs-color-border-accent-emphasis);
+  outline-offset: 2px;
 }
 
 .checkbox:hover {
@@ -41,18 +63,48 @@
   border: none;
 }
 
+/* A5: Indeterminate hover visual feedback */
 .checkbox[data-indeterminate]:hover {
-  background: var(--rs-color-background-neutral-tertiary);
+  background: var(--rs-color-background-neutral-secondary);
   border: none;
 }
 
-.checkbox[data-disabled] {
-  opacity: 0.5;
+/* A2: Read-only styling */
+.checkbox[data-readonly] {
+  cursor: default;
+  opacity: 0.7;
 }
 
-.checkbox[data-disabled]:hover {
-  background: var(--rs-color-background-base-primary);
-  border-color: var(--rs-color-border-base-primary);
+/* A3: Invalid state — red border for validation errors */
+.checkbox[data-invalid] {
+  border-color: var(--rs-color-border-danger-primary);
+}
+
+.checkbox[data-invalid][data-checked],
+.checkbox[data-invalid][data-indeterminate] {
+  background: var(--rs-color-background-danger-primary);
+  border-color: var(--rs-color-border-danger-primary);
+}
+
+/* A4: Disabled state */
+.checkbox[data-disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+/* A4: Preserve checked state when disabled */
+.checkbox[data-disabled][data-checked],
+.checkbox[data-disabled][data-checked]:hover {
+  background: var(--rs-color-background-accent-emphasis);
+  border: none;
+}
+
+/* A4: Preserve indeterminate state when disabled */
+.checkbox[data-disabled][data-indeterminate],
+.checkbox[data-disabled][data-indeterminate]:hover {
+  background: var(--rs-color-background-neutral-tertiary);
+  border: none;
 }
 
 .indicator {
@@ -65,6 +117,6 @@
 }
 
 .icon {
-  width: var(--rs-space-5);
-  height: var(--rs-space-5);
+  width: 100%;
+  height: 100%;
 }

--- a/packages/raystack/components/checkbox/checkbox.module.css
+++ b/packages/raystack/components/checkbox/checkbox.module.css
@@ -37,12 +37,6 @@
   min-height: var(--rs-space-4);
 }
 
-/* A1: Focus-visible ring for keyboard navigation (WCAG 2.4.7) */
-.checkbox:focus-visible {
-  outline: 2px solid var(--rs-color-border-accent-emphasis);
-  outline-offset: 2px;
-}
-
 .checkbox:hover {
   background: var(--rs-color-background-base-primary-hover);
   border-color: var(--rs-color-border-base-focus);

--- a/packages/raystack/components/checkbox/checkbox.tsx
+++ b/packages/raystack/components/checkbox/checkbox.tsx
@@ -3,7 +3,6 @@
 import { Checkbox as CheckboxPrimitive } from '@base-ui/react/checkbox';
 import { CheckboxGroup as CheckboxGroupPrimitive } from '@base-ui/react/checkbox-group';
 import { cva, cx, type VariantProps } from 'class-variance-authority';
-import { type ReactNode } from 'react';
 import { useFieldContext } from '../field';
 
 import styles from './checkbox.module.css';
@@ -84,18 +83,13 @@ CheckboxGroup.displayName = 'Checkbox.Group';
 
 interface CheckboxItemProps
   extends CheckboxPrimitive.Root.Props,
-    VariantProps<typeof checkboxVariants> {
-  /** Custom indicator content. Can be a ReactNode or a function receiving the checkbox state. */
-  children?:
-    | ReactNode
-    | ((state: { checked: boolean; indeterminate: boolean }) => ReactNode);
-}
+    VariantProps<typeof checkboxVariants> {}
 
 function CheckboxItem({
   className,
   required,
   size,
-  children,
+  render,
   ...props
 }: CheckboxItemProps) {
   const fieldContext = useFieldContext();
@@ -109,24 +103,14 @@ function CheckboxItem({
     >
       <CheckboxPrimitive.Indicator
         className={styles.indicator}
-        render={(props, state) => (
-          <span {...props}>
-            {children ? (
-              typeof children === 'function' ? (
-                children({
-                  checked: state.checked,
-                  indeterminate: state.indeterminate
-                })
-              ) : (
-                children
-              )
-            ) : state.indeterminate ? (
-              <IndeterminateIcon />
-            ) : (
-              <CheckMarkIcon />
-            )}
-          </span>
-        )}
+        render={
+          render ??
+          ((props, state) => (
+            <span {...props}>
+              {state.indeterminate ? <IndeterminateIcon /> : <CheckMarkIcon />}
+            </span>
+          ))
+        }
       />
     </CheckboxPrimitive.Root>
   );

--- a/packages/raystack/components/checkbox/checkbox.tsx
+++ b/packages/raystack/components/checkbox/checkbox.tsx
@@ -3,7 +3,7 @@
 import { Checkbox as CheckboxPrimitive } from '@base-ui/react/checkbox';
 import { CheckboxGroup as CheckboxGroupPrimitive } from '@base-ui/react/checkbox-group';
 import { cva, cx, type VariantProps } from 'class-variance-authority';
-import { ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { useFieldContext } from '../field';
 
 import styles from './checkbox.module.css';
@@ -85,22 +85,17 @@ CheckboxGroup.displayName = 'Checkbox.Group';
 interface CheckboxItemProps
   extends CheckboxPrimitive.Root.Props,
     VariantProps<typeof checkboxVariants> {
-  /** Custom icon to render when the checkbox is checked. */
-  checkedIcon?: ReactNode;
-  /** Custom icon to render when the checkbox is in the indeterminate state. */
-  indeterminateIcon?: ReactNode;
-  /** Ref to the hidden <input> element for form integration. */
-  inputRef?: React.Ref<HTMLInputElement>;
-  /** When true, the checkbox acts as a parent (select all) checkbox within a group. */
-  parent?: boolean;
+  /** Custom indicator content. Can be a ReactNode or a function receiving the checkbox state. */
+  children?:
+    | ReactNode
+    | ((state: { checked: boolean; indeterminate: boolean }) => ReactNode);
 }
 
 function CheckboxItem({
   className,
   required,
   size,
-  checkedIcon,
-  indeterminateIcon,
+  children,
   ...props
 }: CheckboxItemProps) {
   const fieldContext = useFieldContext();
@@ -116,9 +111,20 @@ function CheckboxItem({
         className={styles.indicator}
         render={(props, state) => (
           <span {...props}>
-            {state.indeterminate
-              ? (indeterminateIcon ?? <IndeterminateIcon />)
-              : (checkedIcon ?? <CheckMarkIcon />)}
+            {children ? (
+              typeof children === 'function' ? (
+                children({
+                  checked: state.checked,
+                  indeterminate: state.indeterminate
+                })
+              ) : (
+                children
+              )
+            ) : state.indeterminate ? (
+              <IndeterminateIcon />
+            ) : (
+              <CheckMarkIcon />
+            )}
           </span>
         )}
       />

--- a/packages/raystack/components/checkbox/checkbox.tsx
+++ b/packages/raystack/components/checkbox/checkbox.tsx
@@ -2,7 +2,8 @@
 
 import { Checkbox as CheckboxPrimitive } from '@base-ui/react/checkbox';
 import { CheckboxGroup as CheckboxGroupPrimitive } from '@base-ui/react/checkbox-group';
-import { cx } from 'class-variance-authority';
+import { cva, cx, type VariantProps } from 'class-variance-authority';
+import { ReactNode } from 'react';
 import { useFieldContext } from '../field';
 
 import styles from './checkbox.module.css';
@@ -43,10 +44,37 @@ const IndeterminateIcon = () => (
   </svg>
 );
 
-function CheckboxGroup({ className, ...props }: CheckboxGroupPrimitive.Props) {
+const checkboxVariants = cva(styles.checkbox, {
+  variants: {
+    size: {
+      small: styles.small,
+      large: styles.large
+    }
+  },
+  defaultVariants: {
+    size: 'large'
+  }
+});
+
+interface CheckboxGroupProps extends CheckboxGroupPrimitive.Props {
+  /** Layout direction of the checkbox group.
+   * @defaultValue 'vertical'
+   */
+  orientation?: 'vertical' | 'horizontal';
+}
+
+function CheckboxGroup({
+  className,
+  orientation = 'vertical',
+  ...props
+}: CheckboxGroupProps) {
   return (
     <CheckboxGroupPrimitive
-      className={cx(styles.group, className)}
+      className={cx(
+        styles.group,
+        orientation === 'horizontal' && styles['group-horizontal'],
+        className
+      )}
       {...props}
     />
   );
@@ -54,17 +82,33 @@ function CheckboxGroup({ className, ...props }: CheckboxGroupPrimitive.Props) {
 
 CheckboxGroup.displayName = 'Checkbox.Group';
 
+interface CheckboxItemProps
+  extends CheckboxPrimitive.Root.Props,
+    VariantProps<typeof checkboxVariants> {
+  /** Custom icon to render when the checkbox is checked. */
+  checkedIcon?: ReactNode;
+  /** Custom icon to render when the checkbox is in the indeterminate state. */
+  indeterminateIcon?: ReactNode;
+  /** Ref to the hidden <input> element for form integration. */
+  inputRef?: React.Ref<HTMLInputElement>;
+  /** When true, the checkbox acts as a parent (select all) checkbox within a group. */
+  parent?: boolean;
+}
+
 function CheckboxItem({
   className,
   required,
+  size,
+  checkedIcon,
+  indeterminateIcon,
   ...props
-}: CheckboxPrimitive.Root.Props) {
+}: CheckboxItemProps) {
   const fieldContext = useFieldContext();
   const resolvedRequired = required ?? fieldContext?.required;
 
   return (
     <CheckboxPrimitive.Root
-      className={cx(styles.checkbox, className)}
+      className={checkboxVariants({ size, className })}
       required={resolvedRequired}
       {...props}
     >
@@ -72,7 +116,9 @@ function CheckboxItem({
         className={styles.indicator}
         render={(props, state) => (
           <span {...props}>
-            {state.indeterminate ? <IndeterminateIcon /> : <CheckMarkIcon />}
+            {state.indeterminate
+              ? (indeterminateIcon ?? <IndeterminateIcon />)
+              : (checkedIcon ?? <CheckMarkIcon />)}
           </span>
         )}
       />


### PR DESCRIPTION
## Summary

- **A2**: Add `[data-readonly]` styling with reduced opacity and default cursor
- **A4**: Fix disabled+checked/indeterminate hover bug that visually "unchecked" disabled checkboxes on hover. Added `pointer-events: none` and explicit state-preserving rules
- **A5**: Add indeterminate hover feedback with a distinct background shade
- **F1**: Add `size` prop with `small` (12px) and `large` (16px, default) variants via CVA. SVG icons now scale to 100% of container
- **F2**: Support custom indicator via `render` prop — extracted from checkbox props and passed to the Indicator primitive. Receives `(props, state)` with `checked` and `indeterminate`
- **F4**: Add `orientation` prop to `CheckboxGroup` (`'vertical'` default, `'horizontal'`)
- Updated props documentation and playground demos for new features

### Scoped out
- Focus-visible ring (cross-cutting concern, will be handled separately)
- Explicit `inputRef`/`parent` typing (already exposed via Base UI's `CheckboxPrimitive.Root.Props`)

## Test plan

- [x] All 53 checkbox tests pass (36 checkbox + 17 group)
- [x] New tests for size variants (`small`, `large`, default `large`)
- [x] New tests for custom indicator via `render` prop (checked state, indeterminate state)
- [x] New tests for `required` prop emitting `data-required`
- [x] New tests for group `orientation` (`vertical`, `horizontal`)
- [x] No new type errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)