### PR TITLE
fix: alias dayjs imports to ESM builds for Vite SSR compatibility

### DIFF
--- a/packages/raystack/components/calendar/date-picker.tsx
+++ b/packages/raystack/components/calendar/date-picker.tsx
@@ -3,7 +3,7 @@
 import { CalendarIcon } from '@radix-ui/react-icons';
 import { cx } from 'class-variance-authority';
 import dayjs from 'dayjs';
-import customParseFormat from 'dayjs/plugin/customParseFormat.js';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 import {
   isValidElement,
   useCallback,

--- a/packages/raystack/components/data-table/utils/filter-operations.tsx
+++ b/packages/raystack/components/data-table/utils/filter-operations.tsx
@@ -1,7 +1,7 @@
 import type { FilterFn } from '@tanstack/table-core';
 import dayjs from 'dayjs';
-import isSameOrAfter from 'dayjs/plugin/isSameOrAfter.js';
-import isSameOrBefore from 'dayjs/plugin/isSameOrBefore.js';
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 
 import {
   DataTableFilterOperatorTypes,

--- a/packages/raystack/rollup.config.mjs
+++ b/packages/raystack/rollup.config.mjs
@@ -100,7 +100,13 @@ const rollupConfig = configs.map(conf => {
         sourcemap: true,
         exports: 'named',
         preserveModules: true,
-        preserveModulesRoot: conf.inputPath
+        preserveModulesRoot: conf.inputPath,
+        paths: id => {
+          if (id === 'dayjs') return 'dayjs/esm';
+          if (id.startsWith('dayjs/plugin/'))
+            return id.replace('dayjs/plugin/', 'dayjs/esm/plugin/');
+          return id;
+        }
       },
       {
         dir: conf.outputPath,


### PR DESCRIPTION
## Summary
- Vite SSR module runner can't convert dayjs's CJS `module.exports` to ESM default export, causing `dayjs` to be `undefined` and `.extend()` to crash
- Use rollup `output.paths` to rewrite `dayjs` → `dayjs/esm` and `dayjs/plugin/*` → `dayjs/esm/plugin/*` in ESM output only
- CJS output unchanged — no breakage for CJS consumers

## Test plan
- [ ] Verify ESM dist imports reference `dayjs/esm/...`
- [ ] Verify CJS dist imports reference `dayjs` (unchanged)
- [ ] Test in Vite SSR app — `dayjs` no longer `undefined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)