### PR TITLE
feat: migrate command to Base UI

### DIFF
--- a/apps/www/src/app/examples/combobox/page.tsx
+++ b/apps/www/src/app/examples/combobox/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Combobox, Flex } from '@raystack/apsara';
+import { Combobox, Flex, Slider } from '@raystack/apsara';
 
 const Page = () => {
   return (
@@ -8,19 +8,12 @@ const Page = () => {
         height: '100vh',
         width: '100%',
         backgroundColor: 'var(--rs-color-background-base-primary)',
-        padding: '32px'
+        padding: '80px'
       }}
       direction='column'
       gap={8}
     >
-      <Combobox>
-        <Combobox.Input />
-        <Combobox.Content>
-          <Combobox.Item value='item-1'>Item 1</Combobox.Item>
-          <Combobox.Item value='item-2'>Item 2</Combobox.Item>
-          <Combobox.Item value='item-3'>Item 3</Combobox.Item>
-        </Combobox.Content>
-      </Combobox>
+      <Slider defaultValue={50} thumbSize='small' label='Slider Label' />
     </Flex>
   );
 };

--- a/apps/www/src/components/demo/demo.tsx
+++ b/apps/www/src/components/demo/demo.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import {
+  BorderSolidIcon,
+  ColorWheelIcon,
   Component1Icon,
   FileIcon,
   FontBoldIcon,
@@ -11,7 +13,9 @@ import {
   OpenInNewWindowIcon,
   Pencil2Icon,
   PlusIcon,
+  ShadowIcon,
   Share2Icon,
+  SpaceBetweenHorizontallyIcon,
   TextAlignCenterIcon,
   TextAlignLeftIcon,
   TextAlignRightIcon,
@@ -73,6 +77,10 @@ export default function Demo(props: DemoProps) {
       LayersIcon,
       OpenInNewWindowIcon,
       Share2Icon,
+      BorderSolidIcon,
+      ColorWheelIcon,
+      ShadowIcon,
+      SpaceBetweenHorizontallyIcon,
       dayjs
     }
   } = props;

--- a/apps/www/src/components/demo/demo.tsx
+++ b/apps/www/src/components/demo/demo.tsx
@@ -1,11 +1,17 @@
 'use client';
 
 import {
+  Component1Icon,
+  FileIcon,
   FontBoldIcon,
+  FontFamilyIcon,
   FontItalicIcon,
   InfoCircledIcon,
+  LayersIcon,
+  OpenInNewWindowIcon,
   Pencil2Icon,
   PlusIcon,
+  Share2Icon,
   TextAlignCenterIcon,
   TextAlignLeftIcon,
   TextAlignRightIcon,
@@ -61,6 +67,12 @@ export default function Demo(props: DemoProps) {
       TextAlignLeftIcon,
       TextAlignCenterIcon,
       TextAlignRightIcon,
+      Component1Icon,
+      FileIcon,
+      FontFamilyIcon,
+      LayersIcon,
+      OpenInNewWindowIcon,
+      Share2Icon,
       dayjs
     }
   } = props;

--- a/apps/www/src/components/docs/search.tsx
+++ b/apps/www/src/components/docs/search.tsx
@@ -158,7 +158,7 @@ export default function DocsSearch({ pageTree }: { pageTree: Root }) {
               </IconButton>
             )}
           </Flex>
-          <Command.List className={styles.searchList}>
+          <Command.Content className={styles.searchList}>
             <Command.Empty>
               <EmptyState
                 variant='empty1'
@@ -214,7 +214,7 @@ export default function DocsSearch({ pageTree }: { pageTree: Root }) {
                 {index < defaultItems.length - 1 && <Command.Separator />}
               </div>
             ))}
-          </Command.List>
+          </Command.Content>
         </Command>
       </Dialog.Content>
     </Dialog>

--- a/apps/www/src/components/playground/command-examples.tsx
+++ b/apps/www/src/components/playground/command-examples.tsx
@@ -24,54 +24,35 @@ export function CommandExamples() {
         <Text>Inline command menu</Text>
         <Flex style={{ width: 420 }}>
           <Command>
-            <Command.Panel>
-              <Command.Input placeholder='Type a command or search...' />
-              <Command.List>
-                <Command.Empty>No results found.</Command.Empty>
-                <Command.Group>
-                  <Command.Label>Suggestions</Command.Label>
-                  <Command.Item>Calendar</Command.Item>
-                  <Command.Item>Search Emoji</Command.Item>
-                  <Command.Item>Calculator</Command.Item>
-                </Command.Group>
-                <Command.Separator />
-                <Command.Group>
-                  <Command.Label>Settings</Command.Label>
-                  <Command.Item>
-                    Profile <Command.Shortcut>⌘P</Command.Shortcut>
-                  </Command.Item>
-                  <Command.Item>
-                    Billing <Command.Shortcut>⌘B</Command.Shortcut>
-                  </Command.Item>
-                  <Command.Item>
-                    Settings <Command.Shortcut>⌘S</Command.Shortcut>
-                  </Command.Item>
-                </Command.Group>
-              </Command.List>
-              <Command.Footer>
-                <span>
-                  Press <Command.Shortcut>↵</Command.Shortcut> to select
-                </span>
-                <span>
-                  <Command.Shortcut>ESC</Command.Shortcut> to close
-                </span>
-              </Command.Footer>
-            </Command.Panel>
+            <Command.Input placeholder='Type a command or search...' />
+            <Command.Content>
+              <Command.Empty>No results found.</Command.Empty>
+              <Command.Group>
+                <Command.Label>Suggestions</Command.Label>
+                <Command.Item>Calendar</Command.Item>
+                <Command.Item>Search Emoji</Command.Item>
+                <Command.Item>Calculator</Command.Item>
+              </Command.Group>
+              <Command.Separator />
+              <Command.Group>
+                <Command.Label>Settings</Command.Label>
+                <Command.Item>Profile</Command.Item>
+                <Command.Item>Billing</Command.Item>
+                <Command.Item>Settings</Command.Item>
+              </Command.Group>
+            </Command.Content>
           </Command>
         </Flex>
 
-        <Text>
-          Dialog — press <Command.Shortcut>⌘K</Command.Shortcut> or click the
-          button
-        </Text>
+        <Text>Dialog — press ⌘K or click the button</Text>
         <Command.Dialog open={open} onOpenChange={setOpen}>
-          <Command.Dialog.Trigger render={<Button variant='outline' />}>
+          <Command.DialogTrigger render={<Button variant='outline' />}>
             Open Command Menu
-          </Command.Dialog.Trigger>
-          <Command.Dialog.Content>
+          </Command.DialogTrigger>
+          <Command.DialogContent>
             <Command>
               <Command.Input placeholder='Type a command or search...' />
-              <Command.List>
+              <Command.Content>
                 <Command.Empty>No results found.</Command.Empty>
                 <Command.Group>
                   <Command.Label>Suggestions</Command.Label>
@@ -85,9 +66,9 @@ export function CommandExamples() {
                     Calculator
                   </Command.Item>
                 </Command.Group>
-              </Command.List>
+              </Command.Content>
             </Command>
-          </Command.Dialog.Content>
+          </Command.DialogContent>
         </Command.Dialog>
       </Flex>
     </PlaygroundLayout>

--- a/apps/www/src/components/playground/command-examples.tsx
+++ b/apps/www/src/components/playground/command-examples.tsx
@@ -1,29 +1,94 @@
 'use client';
 
-import { Command, Flex } from '@raystack/apsara';
+import { Button, Command, Flex, Text } from '@raystack/apsara';
+import { useEffect, useState } from 'react';
 import PlaygroundLayout from './playground-layout';
 
 export function CommandExamples() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
+        event.preventDefault();
+        setOpen(prev => !prev);
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, []);
+
   return (
     <PlaygroundLayout title='Command'>
-      <Flex style={{ width: 400 }}>
-        <Command>
-          <Command.Input placeholder='Type a command or search...' />
-          <Command.List>
-            <Command.Empty>No results found.</Command.Empty>
-            <Command.Group heading='Suggestions'>
-              <Command.Item>Calendar</Command.Item>
-              <Command.Item>Search Emoji</Command.Item>
-              <Command.Item>Calculator</Command.Item>
-            </Command.Group>
-            <Command.Separator />
-            <Command.Group heading='Settings'>
-              <Command.Item>Profile</Command.Item>
-              <Command.Item>Billing</Command.Item>
-              <Command.Item>Settings</Command.Item>
-            </Command.Group>
-          </Command.List>
-        </Command>
+      <Flex direction='column' gap='large'>
+        <Text>Inline command menu</Text>
+        <Flex style={{ width: 420 }}>
+          <Command>
+            <Command.Panel>
+              <Command.Input placeholder='Type a command or search...' />
+              <Command.List>
+                <Command.Empty>No results found.</Command.Empty>
+                <Command.Group>
+                  <Command.Label>Suggestions</Command.Label>
+                  <Command.Item>Calendar</Command.Item>
+                  <Command.Item>Search Emoji</Command.Item>
+                  <Command.Item>Calculator</Command.Item>
+                </Command.Group>
+                <Command.Separator />
+                <Command.Group>
+                  <Command.Label>Settings</Command.Label>
+                  <Command.Item>
+                    Profile <Command.Shortcut>⌘P</Command.Shortcut>
+                  </Command.Item>
+                  <Command.Item>
+                    Billing <Command.Shortcut>⌘B</Command.Shortcut>
+                  </Command.Item>
+                  <Command.Item>
+                    Settings <Command.Shortcut>⌘S</Command.Shortcut>
+                  </Command.Item>
+                </Command.Group>
+              </Command.List>
+              <Command.Footer>
+                <span>
+                  Press <Command.Shortcut>↵</Command.Shortcut> to select
+                </span>
+                <span>
+                  <Command.Shortcut>ESC</Command.Shortcut> to close
+                </span>
+              </Command.Footer>
+            </Command.Panel>
+          </Command>
+        </Flex>
+
+        <Text>
+          Dialog — press <Command.Shortcut>⌘K</Command.Shortcut> or click the
+          button
+        </Text>
+        <Command.Dialog open={open} onOpenChange={setOpen}>
+          <Command.Dialog.Trigger render={<Button variant='outline' />}>
+            Open Command Menu
+          </Command.Dialog.Trigger>
+          <Command.Dialog.Content>
+            <Command>
+              <Command.Input placeholder='Type a command or search...' />
+              <Command.List>
+                <Command.Empty>No results found.</Command.Empty>
+                <Command.Group>
+                  <Command.Label>Suggestions</Command.Label>
+                  <Command.Item onClick={() => setOpen(false)}>
+                    Calendar
+                  </Command.Item>
+                  <Command.Item onClick={() => setOpen(false)}>
+                    Search Emoji
+                  </Command.Item>
+                  <Command.Item onClick={() => setOpen(false)}>
+                    Calculator
+                  </Command.Item>
+                </Command.Group>
+              </Command.List>
+            </Command>
+          </Command.Dialog.Content>
+        </Command.Dialog>
       </Flex>
     </PlaygroundLayout>
   );

--- a/apps/www/src/content/docs/components/command/demo.ts
+++ b/apps/www/src/content/docs/components/command/demo.ts
@@ -161,11 +161,13 @@ export const shortcutDemo = {
       const handler = (event) => {
         if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
           event.preventDefault();
+          event.stopPropagation();
+          event.stopImmediatePropagation();
           setOpen(prev => !prev);
         }
       };
-      document.addEventListener('keydown', handler);
-      return () => document.removeEventListener('keydown', handler);
+      document.addEventListener('keydown', handler, true);
+      return () => document.removeEventListener('keydown', handler, true);
     }, []);`
   )
 };

--- a/apps/www/src/content/docs/components/command/demo.ts
+++ b/apps/www/src/content/docs/components/command/demo.ts
@@ -3,23 +3,51 @@
 export const preview = {
   type: 'code',
   code: `
-  <Flex style={{width:400}}>
+  <Flex style={{ width: 400 }}>
     <Command>
-      <Command.Input placeholder="Type a command or search..." />
-      <Command.List>
-        <Command.Empty>No results found.</Command.Empty>
-        <Command.Group heading="Suggestions">
-          <Command.Item>Calendar</Command.Item>
-          <Command.Item>Search Emoji</Command.Item>
-          <Command.Item>Calculator</Command.Item>
-        </Command.Group>
-        <Command.Separator />
-        <Command.Group heading="Settings">
-          <Command.Item>Profile</Command.Item>
-          <Command.Item>Billing</Command.Item>
-          <Command.Item>Settings</Command.Item>
-        </Command.Group>
-      </Command.List>
+      <Command.Panel>
+        <Command.Input placeholder="Search..." />
+        <Command.List>
+          <Command.Empty>No results found.</Command.Empty>
+          <Command.Group>
+            <Command.Label>Actions</Command.Label>
+            <Command.Item leadingIcon={<TransformIcon />}>
+              Create AOI...
+              <Command.Shortcut>
+                <span>⌘</span>
+                <span>⇧</span>
+                <span>A</span>
+              </Command.Shortcut>
+            </Command.Item>
+            <Command.Item leadingIcon={<Share2Icon />}>
+              Run workflow...
+              <Command.Shortcut>
+                <span>⌘</span>
+                <span>⇧</span>
+                <span>W</span>
+              </Command.Shortcut>
+            </Command.Item>
+            <Command.Item leadingIcon={<FileIcon />}>
+              View documentation
+              <Command.Shortcut>
+                <OpenInNewWindowIcon />
+              </Command.Shortcut>
+            </Command.Item>
+          </Command.Group>
+          <Command.Group>
+            <Command.Label>Foundations</Command.Label>
+            <Command.Item leadingIcon={<FontFamilyIcon />}>
+              Typography
+            </Command.Item>
+            <Command.Item leadingIcon={<Component1Icon />}>
+              Design Tokens
+            </Command.Item>
+            <Command.Item leadingIcon={<LayersIcon />}>
+              Styles
+            </Command.Item>
+          </Command.Group>
+        </Command.List>
+      </Command.Panel>
     </Command>
   </Flex>`
 };
@@ -27,24 +55,168 @@ export const preview = {
 export const basicDemo = {
   type: 'code',
   code: `
-  <Flex style={{ width: 400 }}>
-  <Command>
-    <Command.Input placeholder="Type a command or search..." />
-    <Command.List>
-      <Command.Empty>No results found.</Command.Empty>
-      <Command.Group heading="Suggestions">
-        <Command.Item>Calendar</Command.Item>
-        <Command.Item>Search Emoji</Command.Item>
-        <Command.Item>Calculator</Command.Item>
-      </Command.Group>
-      <Command.Separator />
-      <Command.Group heading="Settings">
-        <Command.Item>Profile</Command.Item>
-        <Command.Item>Billing</Command.Item>
-        <Command.Item>Settings</Command.Item>
-      </Command.Group>
-    </Command.List>
-  </Command>
-</Flex>
-  `
+  <Flex style={{ width: 420 }}>
+    <Command>
+      <Command.Panel>
+        <Command.Input placeholder="Search..." />
+        <Command.List>
+          <Command.Empty>No results found.</Command.Empty>
+          <Command.Item>Calendar</Command.Item>
+          <Command.Item>Search Emoji</Command.Item>
+          <Command.Item>Calculator</Command.Item>
+          <Command.Item>Profile</Command.Item>
+          <Command.Item>Billing</Command.Item>
+          <Command.Item>Settings</Command.Item>
+        </Command.List>
+      </Command.Panel>
+    </Command>
+  </Flex>`
+};
+
+export const groupedDemo = {
+  type: 'code',
+  code: `
+  <Flex style={{ width: 420 }}>
+    <Command>
+      <Command.Panel>
+        <Command.Input placeholder="Type a command or search..." />
+        <Command.List>
+          <Command.Empty>No results found.</Command.Empty>
+          <Command.Group>
+            <Command.Label>Suggestions</Command.Label>
+            <Command.Item>Calendar</Command.Item>
+            <Command.Item>Search Emoji</Command.Item>
+            <Command.Item>Calculator</Command.Item>
+          </Command.Group>
+          <Command.Separator />
+          <Command.Group>
+            <Command.Label>Settings</Command.Label>
+            <Command.Item>Profile</Command.Item>
+            <Command.Item>Billing</Command.Item>
+            <Command.Item>Settings</Command.Item>
+          </Command.Group>
+        </Command.List>
+      </Command.Panel>
+    </Command>
+  </Flex>`
+};
+
+export const withIconsDemo = {
+  type: 'code',
+  code: `
+  <Flex style={{ width: 420 }}>
+    <Command>
+      <Command.Panel>
+        <Command.Input placeholder="Search..." />
+        <Command.List>
+          <Command.Empty>No results found.</Command.Empty>
+          <Command.Item leadingIcon={<Calendar size={16} />}>Calendar</Command.Item>
+          <Command.Item leadingIcon={<Smile size={16} />}>Search Emoji</Command.Item>
+          <Command.Item leadingIcon={<Calculator size={16} />}>Calculator</Command.Item>
+          <Command.Item leadingIcon={<User size={16} />}>Profile</Command.Item>
+          <Command.Item leadingIcon={<CreditCard size={16} />}>Billing</Command.Item>
+          <Command.Item leadingIcon={<Settings size={16} />}>Settings</Command.Item>
+        </Command.List>
+      </Command.Panel>
+    </Command>
+  </Flex>`
+};
+
+export const withShortcutsDemo = {
+  type: 'code',
+  code: `
+  <Flex style={{ width: 420 }}>
+    <Command>
+      <Command.Panel>
+        <Command.Input placeholder="Search..." />
+        <Command.List>
+          <Command.Empty>No results found.</Command.Empty>
+          <Command.Item>
+            Profile <Command.Shortcut>⌘P</Command.Shortcut>
+          </Command.Item>
+          <Command.Item>
+            Billing <Command.Shortcut>⌘B</Command.Shortcut>
+          </Command.Item>
+          <Command.Item>
+            Settings <Command.Shortcut>⌘S</Command.Shortcut>
+          </Command.Item>
+        </Command.List>
+        <Command.Footer>
+          <span>Press <Command.Shortcut>↵</Command.Shortcut> to select</span>
+          <span><Command.Shortcut>ESC</Command.Shortcut> to close</span>
+        </Command.Footer>
+      </Command.Panel>
+    </Command>
+  </Flex>`
+};
+
+export const dialogDemo = {
+  type: 'code',
+  code: `
+  function CommandDialogExample() {
+    const [open, setOpen] = React.useState(false);
+
+    React.useEffect(() => {
+      const handler = (event) => {
+        if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
+          event.preventDefault();
+          setOpen(prev => !prev);
+        }
+      };
+      document.addEventListener('keydown', handler);
+      return () => document.removeEventListener('keydown', handler);
+    }, []);
+
+    return (
+      <Flex direction="column" gap="medium" align="center">
+        <Text>
+          Press <Command.Shortcut>⌘K</Command.Shortcut> to open the command menu
+        </Text>
+        <Command.Dialog open={open} onOpenChange={setOpen}>
+          <Command.Dialog.Trigger render={<Button variant="outline" />}>
+            Open Command Menu
+          </Command.Dialog.Trigger>
+          <Command.Dialog.Content>
+            <Command>
+              <Command.Input placeholder="Type a command or search..." />
+              <Command.List>
+                <Command.Empty>No results found.</Command.Empty>
+                <Command.Group>
+                  <Command.Label>Suggestions</Command.Label>
+                  <Command.Item onClick={() => setOpen(false)}>Calendar</Command.Item>
+                  <Command.Item onClick={() => setOpen(false)}>Search Emoji</Command.Item>
+                  <Command.Item onClick={() => setOpen(false)}>Calculator</Command.Item>
+                </Command.Group>
+              </Command.List>
+            </Command>
+          </Command.Dialog.Content>
+        </Command.Dialog>
+      </Flex>
+    );
+  }`
+};
+
+export const controlledDemo = {
+  type: 'code',
+  code: `
+  function ControlledCommand() {
+    const [value, setValue] = React.useState('');
+
+    return (
+      <Flex direction="column" gap="medium" style={{ width: 420 }}>
+        <Text>Query: {value || '(empty)'}</Text>
+        <Command value={value} onValueChange={setValue}>
+          <Command.Panel>
+            <Command.Input placeholder="Search..." />
+            <Command.List>
+              <Command.Empty>No results found.</Command.Empty>
+              <Command.Item>Calendar</Command.Item>
+              <Command.Item>Search Emoji</Command.Item>
+              <Command.Item>Calculator</Command.Item>
+            </Command.List>
+          </Command.Panel>
+        </Command>
+      </Flex>
+    );
+  }`
 };

--- a/apps/www/src/content/docs/components/command/demo.ts
+++ b/apps/www/src/content/docs/components/command/demo.ts
@@ -1,160 +1,149 @@
 'use client';
 
+const wrapInDialog = (body: string, extraState = '') => `
+  function CommandDialogExample() {
+    const [open, setOpen] = React.useState(false);${extraState}
+
+    return (
+      <Command.Dialog open={open} onOpenChange={setOpen}>
+        <Command.DialogTrigger render={<Button variant="outline" />}>
+          Open Command Menu
+        </Command.DialogTrigger>
+        <Command.DialogContent>
+          <Command>
+${body}
+          </Command>
+        </Command.DialogContent>
+      </Command.Dialog>
+    );
+  }`;
+
 export const preview = {
   type: 'code',
-  code: `
-  <Flex style={{ width: 400 }}>
-    <Command>
-      <Command.Panel>
-        <Command.Input placeholder="Search..." />
-        <Command.List>
-          <Command.Empty>No results found.</Command.Empty>
-          <Command.Group>
-            <Command.Label>Actions</Command.Label>
-            <Command.Item leadingIcon={<TransformIcon />}>
-              Create AOI...
-              <Command.Shortcut>
-                <span>⌘</span>
-                <span>⇧</span>
-                <span>A</span>
-              </Command.Shortcut>
-            </Command.Item>
-            <Command.Item leadingIcon={<Share2Icon />}>
-              Run workflow...
-              <Command.Shortcut>
-                <span>⌘</span>
-                <span>⇧</span>
-                <span>W</span>
-              </Command.Shortcut>
-            </Command.Item>
-            <Command.Item leadingIcon={<FileIcon />}>
-              View documentation
-              <Command.Shortcut>
-                <OpenInNewWindowIcon />
-              </Command.Shortcut>
-            </Command.Item>
-          </Command.Group>
-          <Command.Group>
-            <Command.Label>Foundations</Command.Label>
-            <Command.Item leadingIcon={<FontFamilyIcon />}>
-              Typography
-            </Command.Item>
-            <Command.Item leadingIcon={<Component1Icon />}>
-              Design Tokens
-            </Command.Item>
-            <Command.Item leadingIcon={<LayersIcon />}>
-              Styles
-            </Command.Item>
-          </Command.Group>
-        </Command.List>
-      </Command.Panel>
-    </Command>
-  </Flex>`
+  code: wrapInDialog(`            <Command.Input placeholder="Search..." />
+            <Command.Content>
+              <Command.Empty>No results found.</Command.Empty>
+              <Command.Group>
+                <Command.Label>Actions</Command.Label>
+                <Command.Item
+                  leadingIcon={<TransformIcon />}
+                  trailingIcon={<Command.Shortcut>⌘ ⇧ A</Command.Shortcut>}
+                  onClick={() => setOpen(false)}
+                >
+                  Create AOI...
+                </Command.Item>
+                <Command.Item
+                  leadingIcon={<Share2Icon />}
+                  trailingIcon={<Command.Shortcut>⌘ ⇧ W</Command.Shortcut>}
+                  onClick={() => setOpen(false)}
+                >
+                  Run workflow...
+                </Command.Item>
+                <Command.Item
+                  leadingIcon={<FileIcon />}
+                  trailingIcon={<OpenInNewWindowIcon />}
+                  onClick={() => setOpen(false)}
+                >
+                  View documentation
+                </Command.Item>
+              </Command.Group>
+              <Command.Group>
+                <Command.Label>Foundations</Command.Label>
+                <Command.Item leadingIcon={<FontFamilyIcon />} onClick={() => setOpen(false)}>
+                  Typography
+                </Command.Item>
+                <Command.Item leadingIcon={<Component1Icon />} onClick={() => setOpen(false)}>
+                  Design Tokens
+                </Command.Item>
+                <Command.Item leadingIcon={<LayersIcon />} onClick={() => setOpen(false)}>
+                  Styles
+                </Command.Item>
+              </Command.Group>
+            </Command.Content>`)
 };
 
-export const basicDemo = {
+export const inlineDemo = {
   type: 'code',
   code: `
   <Flex style={{ width: 420 }}>
     <Command>
-      <Command.Panel>
-        <Command.Input placeholder="Search..." />
-        <Command.List>
-          <Command.Empty>No results found.</Command.Empty>
-          <Command.Item>Calendar</Command.Item>
-          <Command.Item>Search Emoji</Command.Item>
-          <Command.Item>Calculator</Command.Item>
-          <Command.Item>Profile</Command.Item>
-          <Command.Item>Billing</Command.Item>
-          <Command.Item>Settings</Command.Item>
-        </Command.List>
-      </Command.Panel>
+      <Command.Input placeholder="Search..." />
+      <Command.Content>
+        <Command.Empty>No results found.</Command.Empty>
+        <Command.Item>Calendar</Command.Item>
+        <Command.Item>Search Emoji</Command.Item>
+        <Command.Item>Calculator</Command.Item>
+        <Command.Item>Profile</Command.Item>
+        <Command.Item>Billing</Command.Item>
+        <Command.Item>Settings</Command.Item>
+      </Command.Content>
     </Command>
   </Flex>`
 };
 
 export const groupedDemo = {
   type: 'code',
-  code: `
-  <Flex style={{ width: 420 }}>
-    <Command>
-      <Command.Panel>
-        <Command.Input placeholder="Type a command or search..." />
-        <Command.List>
-          <Command.Empty>No results found.</Command.Empty>
-          <Command.Group>
-            <Command.Label>Suggestions</Command.Label>
-            <Command.Item>Calendar</Command.Item>
-            <Command.Item>Search Emoji</Command.Item>
-            <Command.Item>Calculator</Command.Item>
-          </Command.Group>
-          <Command.Separator />
-          <Command.Group>
-            <Command.Label>Settings</Command.Label>
-            <Command.Item>Profile</Command.Item>
-            <Command.Item>Billing</Command.Item>
-            <Command.Item>Settings</Command.Item>
-          </Command.Group>
-        </Command.List>
-      </Command.Panel>
-    </Command>
-  </Flex>`
+  code: wrapInDialog(`            <Command.Input placeholder="Type a command or search..." />
+            <Command.Content>
+              <Command.Empty>No results found.</Command.Empty>
+              <Command.Group>
+                <Command.Label>Suggestions</Command.Label>
+                <Command.Item onClick={() => setOpen(false)}>Calendar</Command.Item>
+                <Command.Item onClick={() => setOpen(false)}>Search Emoji</Command.Item>
+                <Command.Item onClick={() => setOpen(false)}>Calculator</Command.Item>
+              </Command.Group>
+              <Command.Group>
+                <Command.Label>Settings</Command.Label>
+                <Command.Item onClick={() => setOpen(false)}>Profile</Command.Item>
+                <Command.Item onClick={() => setOpen(false)}>Billing</Command.Item>
+                <Command.Item onClick={() => setOpen(false)}>Settings</Command.Item>
+              </Command.Group>
+            </Command.Content>`)
 };
 
 export const withIconsDemo = {
   type: 'code',
-  code: `
-  <Flex style={{ width: 420 }}>
-    <Command>
-      <Command.Panel>
-        <Command.Input placeholder="Search..." />
-        <Command.List>
-          <Command.Empty>No results found.</Command.Empty>
-          <Command.Item leadingIcon={<Calendar size={16} />}>Calendar</Command.Item>
-          <Command.Item leadingIcon={<Smile size={16} />}>Search Emoji</Command.Item>
-          <Command.Item leadingIcon={<Calculator size={16} />}>Calculator</Command.Item>
-          <Command.Item leadingIcon={<User size={16} />}>Profile</Command.Item>
-          <Command.Item leadingIcon={<CreditCard size={16} />}>Billing</Command.Item>
-          <Command.Item leadingIcon={<Settings size={16} />}>Settings</Command.Item>
-        </Command.List>
-      </Command.Panel>
-    </Command>
-  </Flex>`
+  code: wrapInDialog(`            <Command.Input placeholder="Search..." />
+            <Command.Content>
+              <Command.Empty>No results found.</Command.Empty>
+              <Command.Item leadingIcon={<Home />} onClick={() => setOpen(false)}>Home</Command.Item>
+              <Command.Item leadingIcon={<BellIcon />} onClick={() => setOpen(false)}>Notifications</Command.Item>
+              <Command.Item leadingIcon={<FilterIcon />} onClick={() => setOpen(false)}>Filters</Command.Item>
+              <Command.Item leadingIcon={<OrganizationIcon />} onClick={() => setOpen(false)}>Organization</Command.Item>
+              <Command.Item leadingIcon={<ShoppingBagFilledIcon />} onClick={() => setOpen(false)}>Orders</Command.Item>
+              <Command.Item leadingIcon={<SidebarIcon />} onClick={() => setOpen(false)}>Layout</Command.Item>
+            </Command.Content>`)
 };
 
-export const withShortcutsDemo = {
+export const shortcutDemo = {
   type: 'code',
-  code: `
-  <Flex style={{ width: 420 }}>
-    <Command>
-      <Command.Panel>
-        <Command.Input placeholder="Search..." />
-        <Command.List>
-          <Command.Empty>No results found.</Command.Empty>
-          <Command.Item>
-            Profile <Command.Shortcut>⌘P</Command.Shortcut>
-          </Command.Item>
-          <Command.Item>
-            Billing <Command.Shortcut>⌘B</Command.Shortcut>
-          </Command.Item>
-          <Command.Item>
-            Settings <Command.Shortcut>⌘S</Command.Shortcut>
-          </Command.Item>
-        </Command.List>
-        <Command.Footer>
-          <span>Press <Command.Shortcut>↵</Command.Shortcut> to select</span>
-          <span><Command.Shortcut>ESC</Command.Shortcut> to close</span>
-        </Command.Footer>
-      </Command.Panel>
-    </Command>
-  </Flex>`
-};
-
-export const dialogDemo = {
-  type: 'code',
-  code: `
-  function CommandDialogExample() {
-    const [open, setOpen] = React.useState(false);
+  code: wrapInDialog(
+    `            <Command.Input placeholder="Type a command or search..." />
+            <Command.Content>
+              <Command.Empty>No results found.</Command.Empty>
+              <Command.Group>
+                <Command.Label>Suggestions</Command.Label>
+                <Command.Item
+                  trailingIcon={<Command.Shortcut>⌘ P</Command.Shortcut>}
+                  onClick={() => setOpen(false)}
+                >
+                  Profile
+                </Command.Item>
+                <Command.Item
+                  trailingIcon={<Command.Shortcut>⌘ B</Command.Shortcut>}
+                  onClick={() => setOpen(false)}
+                >
+                  Billing
+                </Command.Item>
+                <Command.Item
+                  trailingIcon={<Command.Shortcut>⌘ S</Command.Shortcut>}
+                  onClick={() => setOpen(false)}
+                >
+                  Settings
+                </Command.Item>
+              </Command.Group>
+            </Command.Content>`,
+    `
 
     React.useEffect(() => {
       const handler = (event) => {
@@ -165,58 +154,34 @@ export const dialogDemo = {
       };
       document.addEventListener('keydown', handler);
       return () => document.removeEventListener('keydown', handler);
-    }, []);
-
-    return (
-      <Flex direction="column" gap="medium" align="center">
-        <Text>
-          Press <Command.Shortcut>⌘K</Command.Shortcut> to open the command menu
-        </Text>
-        <Command.Dialog open={open} onOpenChange={setOpen}>
-          <Command.Dialog.Trigger render={<Button variant="outline" />}>
-            Open Command Menu
-          </Command.Dialog.Trigger>
-          <Command.Dialog.Content>
-            <Command>
-              <Command.Input placeholder="Type a command or search..." />
-              <Command.List>
-                <Command.Empty>No results found.</Command.Empty>
-                <Command.Group>
-                  <Command.Label>Suggestions</Command.Label>
-                  <Command.Item onClick={() => setOpen(false)}>Calendar</Command.Item>
-                  <Command.Item onClick={() => setOpen(false)}>Search Emoji</Command.Item>
-                  <Command.Item onClick={() => setOpen(false)}>Calculator</Command.Item>
-                </Command.Group>
-              </Command.List>
-            </Command>
-          </Command.Dialog.Content>
-        </Command.Dialog>
-      </Flex>
-    );
-  }`
+    }, []);`
+  )
 };
 
 export const controlledDemo = {
   type: 'code',
   code: `
   function ControlledCommand() {
+    const [open, setOpen] = React.useState(false);
     const [value, setValue] = React.useState('');
 
     return (
-      <Flex direction="column" gap="medium" style={{ width: 420 }}>
-        <Text>Query: {value || '(empty)'}</Text>
-        <Command value={value} onValueChange={setValue}>
-          <Command.Panel>
+      <Command.Dialog open={open} onOpenChange={setOpen}>
+        <Command.DialogTrigger render={<Button variant="outline" />}>
+          Open Command Menu
+        </Command.DialogTrigger>
+        <Command.DialogContent>
+          <Command value={value} onValueChange={setValue}>
             <Command.Input placeholder="Search..." />
-            <Command.List>
+            <Command.Content>
               <Command.Empty>No results found.</Command.Empty>
-              <Command.Item>Calendar</Command.Item>
-              <Command.Item>Search Emoji</Command.Item>
-              <Command.Item>Calculator</Command.Item>
-            </Command.List>
-          </Command.Panel>
-        </Command>
-      </Flex>
+              <Command.Item onClick={() => setOpen(false)}>Calendar</Command.Item>
+              <Command.Item onClick={() => setOpen(false)}>Search Emoji</Command.Item>
+              <Command.Item onClick={() => setOpen(false)}>Calculator</Command.Item>
+            </Command.Content>
+          </Command>
+        </Command.DialogContent>
+      </Command.Dialog>
     );
   }`
 };

--- a/apps/www/src/content/docs/components/command/demo.ts
+++ b/apps/www/src/content/docs/components/command/demo.ts
@@ -58,6 +58,18 @@ export const preview = {
                 <Command.Item leadingIcon={<LayersIcon />} onClick={() => setOpen(false)}>
                   Styles
                 </Command.Item>
+                <Command.Item leadingIcon={<ColorWheelIcon />} onClick={() => setOpen(false)}>
+                  Colors
+                </Command.Item>
+                <Command.Item leadingIcon={<SpaceBetweenHorizontallyIcon />} onClick={() => setOpen(false)}>
+                  Spacing
+                </Command.Item>
+                <Command.Item leadingIcon={<BorderSolidIcon />} onClick={() => setOpen(false)}>
+                  Borders
+                </Command.Item>
+                <Command.Item leadingIcon={<ShadowIcon />} onClick={() => setOpen(false)}>
+                  Shadows
+                </Command.Item>
               </Command.Group>
             </Command.Content>`)
 };
@@ -67,7 +79,7 @@ export const inlineDemo = {
   code: `
   <Flex style={{ width: 420 }}>
     <Command>
-      <Command.Input placeholder="Search..." />
+      <Command.Input placeholder="Search..." autoFocus={false} />
       <Command.Content>
         <Command.Empty>No results found.</Command.Empty>
         <Command.Item>Calendar</Command.Item>
@@ -156,6 +168,46 @@ export const shortcutDemo = {
       return () => document.removeEventListener('keydown', handler);
     }, []);`
   )
+};
+
+export const itemsDemo = {
+  type: 'code',
+  code: `
+  function ItemsCommand() {
+    const [open, setOpen] = React.useState(false);
+    const items = [
+      'Calendar',
+      'Search Emoji',
+      'Calculator',
+      'Profile',
+      'Billing',
+      'Settings'
+    ];
+
+    return (
+      <Command.Dialog open={open} onOpenChange={setOpen}>
+        <Command.DialogTrigger render={<Button variant="outline" />}>
+          Open Command Menu
+        </Command.DialogTrigger>
+        <Command.DialogContent>
+          <Command items={items}>
+            <Command.Input placeholder="Search..." />
+            <Command.Content>
+              {(item) => (
+                <Command.Item
+                  key={item}
+                  value={item}
+                  onClick={() => setOpen(false)}
+                >
+                  {item}
+                </Command.Item>
+              )}
+            </Command.Content>
+          </Command>
+        </Command.DialogContent>
+      </Command.Dialog>
+    );
+  }`
 };
 
 export const controlledDemo = {

--- a/apps/www/src/content/docs/components/command/demo.ts
+++ b/apps/www/src/content/docs/components/command/demo.ts
@@ -36,6 +36,7 @@ export const preview = {
                   leadingIcon={<Share2Icon />}
                   trailingIcon={<Command.Shortcut>⌘ ⇧ W</Command.Shortcut>}
                   onClick={() => setOpen(false)}
+                  disabled
                 >
                   Run workflow...
                 </Command.Item>

--- a/apps/www/src/content/docs/components/command/index.mdx
+++ b/apps/www/src/content/docs/components/command/index.mdx
@@ -7,11 +7,10 @@ tag: update
 
 import {
   preview,
-  basicDemo,
+  inlineDemo,
   groupedDemo,
   withIconsDemo,
-  withShortcutsDemo,
-  dialogDemo,
+  shortcutDemo,
   controlledDemo,
 } from "./demo.ts";
 
@@ -19,40 +18,31 @@ import {
 
 ## Anatomy
 
-Import and assemble the component:
+Import and assemble the component inside `Command.Dialog` for a command palette:
 
 ```tsx
 import { Command } from "@raystack/apsara";
 
-<Command>
-  <Command.Panel>
-    <Command.Input />
-    <Command.List>
-      <Command.Empty>No results found.</Command.Empty>
-      <Command.Group>
-        <Command.Label>Suggestions</Command.Label>
-        <Command.Item>Item</Command.Item>
-      </Command.Group>
-      <Command.Separator />
-    </Command.List>
-    <Command.Footer />
-  </Command.Panel>
-</Command>
-```
-
-For a command palette launched by a keyboard shortcut, wrap `Command` in `Command.Dialog`:
-
-```tsx
 <Command.Dialog>
-  <Command.Dialog.Trigger>Open</Command.Dialog.Trigger>
-  <Command.Dialog.Content>
+  <Command.DialogTrigger>Open</Command.DialogTrigger>
+  <Command.DialogContent>
     <Command>
       <Command.Input />
-      <Command.List>{/* ... */}</Command.List>
+      <Command.Content>
+        <Command.Empty>No results found.</Command.Empty>
+        <Command.Group>
+          <Command.Label>Suggestions</Command.Label>
+          <Command.Item>Item</Command.Item>
+        </Command.Group>
+        <Command.Separator />
+      </Command.Content>
     </Command>
-  </Command.Dialog.Content>
+  </Command.DialogContent>
 </Command.Dialog>
 ```
+
+`Command` can also be rendered inline (without a dialog) — useful for embedding a
+persistent command menu in a page or surface.
 
 ## Built-in auto-search
 
@@ -64,15 +54,9 @@ Pass the `items` prop to opt out of this built-in behavior and delegate filterin
 
 ### Root
 
-The root element owns the input value, the list of items, and the context used by every sub-component.
+The root element owns the input value, the list of items, and the context used by every sub-component. Renders as a styled panel that gives the command menu its popover look.
 
 <auto-type-table path="./props.ts" name="CommandRootProps" />
-
-### Panel
-
-A styled card wrapper that gives the command menu its popover look when used inline (outside of `Command.Dialog`).
-
-<auto-type-table path="./props.ts" name="CommandPanelProps" />
 
 ### Input
 
@@ -80,11 +64,11 @@ Text input that drives the search. Accepts the same props as `InputField` and de
 
 <auto-type-table path="./props.ts" name="CommandInputProps" />
 
-### List
+### Content
 
 Scrollable container for groups and items. Renders with `role="listbox"`.
 
-<auto-type-table path="./props.ts" name="CommandListProps" />
+<auto-type-table path="./props.ts" name="CommandContentProps" />
 
 ### Empty
 
@@ -118,33 +102,29 @@ Visual divider between groups. Hidden while searching.
 
 ### Shortcut
 
-A `<kbd>` element for keyboard hints inline with items or the footer.
+A `<kbd>` element for keyboard hints. Typically passed as `trailingIcon` on `Command.Item`.
 
 <auto-type-table path="./props.ts" name="CommandShortcutProps" />
 
-### Footer
-
-Optional footer slot rendered below the list.
-
-<auto-type-table path="./props.ts" name="CommandFooterProps" />
-
 ### Dialog
 
-`Command.Dialog` is an alias for the Base UI Dialog root, plus a composed `Content` sub-component that provides the portal, backdrop, viewport, and popup.
+`Command.Dialog` is an alias for the Base UI Dialog root. Pair it with `Command.DialogTrigger` and `Command.DialogContent` to render the command menu in a centered modal.
 
 <auto-type-table path="./props.ts" name="CommandDialogProps" />
 
-#### Dialog Content
+#### DialogContent
+
+Renders the portal, backdrop, viewport, and popup for the command palette. The backdrop is not blurred by default — pass `overlay={{ blur: true }}` to enable it. Unlike `Dialog.Content`, there is no close button; users dismiss the palette via `Escape` or by clicking the backdrop.
 
 <auto-type-table path="./props.ts" name="CommandDialogContentProps" />
 
 ## Examples
 
-### Basic
+### Inline
 
-A command menu with a flat list of items. Type to filter.
+A command menu rendered inline, without a dialog. Use this when the command menu is a permanent surface on the page.
 
-<Demo data={basicDemo} />
+<Demo data={inlineDemo} />
 
 ### Groups and Separators
 
@@ -158,17 +138,11 @@ Pass a `leadingIcon` on `Command.Item` to render an icon before the label.
 
 <Demo data={withIconsDemo} />
 
-### With Shortcuts and Footer
+### Keyboard Shortcut
 
-Annotate items with `Command.Shortcut` and pair with `Command.Footer` for help text.
+Bind a keyboard shortcut (e.g. `⌘K`) to toggle the command palette open.
 
-<Demo data={withShortcutsDemo} />
-
-### Command Dialog
-
-Use `Command.Dialog` to render the command menu in a modal triggered by a keyboard shortcut.
-
-<Demo data={dialogDemo} />
+<Demo data={shortcutDemo} />
 
 ### Controlled
 

--- a/apps/www/src/content/docs/components/command/index.mdx
+++ b/apps/www/src/content/docs/components/command/index.mdx
@@ -12,6 +12,7 @@ import {
   withIconsDemo,
   shortcutDemo,
   controlledDemo,
+  itemsDemo,
 } from "./demo.ts";
 
 <Demo data={preview} />
@@ -43,12 +44,6 @@ import { Command } from "@raystack/apsara";
 
 `Command` can also be rendered inline (without a dialog) — useful for embedding a
 persistent command menu in a page or surface.
-
-## Built-in auto-search
-
-By default, `Command` filters `Command.Item` children based on the input value — the same behavior as our [Combobox](/docs/components/combobox). No `items` prop is required. Matching is case-insensitive and looks at both the `value` prop and the item's text content.
-
-Pass the `items` prop to opt out of this built-in behavior and delegate filtering to Base UI's internal logic (or your own `filter` function).
 
 ## API Reference
 
@@ -149,6 +144,14 @@ Bind a keyboard shortcut (e.g. `⌘K`) to toggle the command palette open.
 Control the input value by passing `value` and `onValueChange`.
 
 <Demo data={controlledDemo} />
+
+### Items prop
+
+By default, `Command` filters `Command.Item` children based on the input value — the same behavior as our [Combobox](/docs/components/combobox). No `items` prop is required. Matching is case-insensitive and looks at both the `value` prop and the item's text content.
+
+Pass the `items` prop to opt out of this built-in behavior and delegate filtering to Base UI's internal logic (or your own `filter` function). `Command.Content` then accepts a render function that receives each item.
+
+<Demo data={itemsDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/command/index.mdx
+++ b/apps/www/src/content/docs/components/command/index.mdx
@@ -1,10 +1,19 @@
 ---
 title: Command
-description: Fast, composable, unstyled command menu for React.
+description: Fast, composable command menu built on top of the Base UI Autocomplete primitive.
 source: packages/raystack/components/command
+tag: update
 ---
 
-import { basicDemo, preview } from "./demo.ts";
+import {
+  preview,
+  basicDemo,
+  groupedDemo,
+  withIconsDemo,
+  withShortcutsDemo,
+  dialogDemo,
+  controlledDemo,
+} from "./demo.ts";
 
 <Demo data={preview} />
 
@@ -15,16 +24,162 @@ Import and assemble the component:
 ```tsx
 import { Command } from "@raystack/apsara";
 
-<Command />
+<Command>
+  <Command.Panel>
+    <Command.Input />
+    <Command.List>
+      <Command.Empty>No results found.</Command.Empty>
+      <Command.Group>
+        <Command.Label>Suggestions</Command.Label>
+        <Command.Item>Item</Command.Item>
+      </Command.Group>
+      <Command.Separator />
+    </Command.List>
+    <Command.Footer />
+  </Command.Panel>
+</Command>
 ```
+
+For a command palette launched by a keyboard shortcut, wrap `Command` in `Command.Dialog`:
+
+```tsx
+<Command.Dialog>
+  <Command.Dialog.Trigger>Open</Command.Dialog.Trigger>
+  <Command.Dialog.Content>
+    <Command>
+      <Command.Input />
+      <Command.List>{/* ... */}</Command.List>
+    </Command>
+  </Command.Dialog.Content>
+</Command.Dialog>
+```
+
+## Built-in auto-search
+
+By default, `Command` filters `Command.Item` children based on the input value — the same behavior as our [Combobox](/docs/components/combobox). No `items` prop is required. Matching is case-insensitive and looks at both the `value` prop and the item's text content.
+
+Pass the `items` prop to opt out of this built-in behavior and delegate filtering to Base UI's internal logic (or your own `filter` function).
+
+## API Reference
+
+### Root
+
+The root element owns the input value, the list of items, and the context used by every sub-component.
+
+<auto-type-table path="./props.ts" name="CommandRootProps" />
+
+### Panel
+
+A styled card wrapper that gives the command menu its popover look when used inline (outside of `Command.Dialog`).
+
+<auto-type-table path="./props.ts" name="CommandPanelProps" />
+
+### Input
+
+Text input that drives the search. Accepts the same props as `InputField` and defaults to a magnifying-glass leading icon.
+
+<auto-type-table path="./props.ts" name="CommandInputProps" />
+
+### List
+
+Scrollable container for groups and items. Renders with `role="listbox"`.
+
+<auto-type-table path="./props.ts" name="CommandListProps" />
+
+### Empty
+
+Rendered when no items are visible (all filtered out, or the list is empty). Automatically hidden when the list contains at least one item.
+
+<auto-type-table path="./props.ts" name="CommandEmptyProps" />
+
+### Item
+
+A selectable entry. When `value` is omitted and `children` is a string, the string is used as the value. `onClick` fires on pointer click **and** on keyboard `Enter` when the item is highlighted.
+
+<auto-type-table path="./props.ts" name="CommandItemProps" />
+
+### Group
+
+Groups related items. The group and its children are hidden automatically while the user is searching.
+
+<auto-type-table path="./props.ts" name="CommandGroupProps" />
+
+### Label
+
+Renders a label inside `Command.Group`.
+
+<auto-type-table path="./props.ts" name="CommandLabelProps" />
+
+### Separator
+
+Visual divider between groups. Hidden while searching.
+
+<auto-type-table path="./props.ts" name="CommandSeparatorProps" />
+
+### Shortcut
+
+A `<kbd>` element for keyboard hints inline with items or the footer.
+
+<auto-type-table path="./props.ts" name="CommandShortcutProps" />
+
+### Footer
+
+Optional footer slot rendered below the list.
+
+<auto-type-table path="./props.ts" name="CommandFooterProps" />
+
+### Dialog
+
+`Command.Dialog` is an alias for the Base UI Dialog root, plus a composed `Content` sub-component that provides the portal, backdrop, viewport, and popup.
+
+<auto-type-table path="./props.ts" name="CommandDialogProps" />
+
+#### Dialog Content
+
+<auto-type-table path="./props.ts" name="CommandDialogContentProps" />
+
 ## Examples
 
-### Basic Usage
+### Basic
+
+A command menu with a flat list of items. Type to filter.
 
 <Demo data={basicDemo} />
 
+### Groups and Separators
+
+Organise items into groups with labels and visual separators. Groups, labels, and separators are hidden automatically while searching.
+
+<Demo data={groupedDemo} />
+
+### With Icons
+
+Pass a `leadingIcon` on `Command.Item` to render an icon before the label.
+
+<Demo data={withIconsDemo} />
+
+### With Shortcuts and Footer
+
+Annotate items with `Command.Shortcut` and pair with `Command.Footer` for help text.
+
+<Demo data={withShortcutsDemo} />
+
+### Command Dialog
+
+Use `Command.Dialog` to render the command menu in a modal triggered by a keyboard shortcut.
+
+<Demo data={dialogDemo} />
+
+### Controlled
+
+Control the input value by passing `value` and `onValueChange`.
+
+<Demo data={controlledDemo} />
+
 ## Accessibility
 
-- Follows the [WAI-ARIA Combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
-- Supports keyboard navigation with arrow keys and Enter to select
-- Uses `role="listbox"` for the command list and `role="option"` for items
+- Follows the [WAI-ARIA Combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/).
+- Input uses `role="combobox"`, list uses `role="listbox"`, items use `role="option"`.
+- Keyboard: `ArrowDown` / `ArrowUp` move the highlight, `Enter` activates the highlighted item, `Escape` closes the dialog.
+- Disabled items expose `aria-disabled="true"` and are skipped in keyboard navigation.
+- When used inside `Command.Dialog`, focus is trapped in the dialog and returned to the trigger on close.

--- a/apps/www/src/content/docs/components/command/index.mdx
+++ b/apps/www/src/content/docs/components/command/index.mdx
@@ -79,19 +79,19 @@ A selectable entry. When `value` is omitted and `children` is a string, the stri
 
 ### Group
 
-Groups related items. The group and its children are hidden automatically while the user is searching.
+Groups related items inside `Command.Content`.
 
 <auto-type-table path="./props.ts" name="CommandGroupProps" />
 
 ### Label
 
-Renders a label inside `Command.Group`.
+Renders a label inside `Command.Group`. The label is hidden automatically while the user is searching.
 
 <auto-type-table path="./props.ts" name="CommandLabelProps" />
 
 ### Separator
 
-Visual divider between groups. Hidden while searching.
+Visual divider between groups. The separator is hidden automatically while the user is searching.
 
 <auto-type-table path="./props.ts" name="CommandSeparatorProps" />
 

--- a/apps/www/src/content/docs/components/command/props.ts
+++ b/apps/www/src/content/docs/components/command/props.ts
@@ -49,10 +49,8 @@ export interface CommandRootProps {
    * Only applied when `items` is provided.
    */
   filter?: (itemValue: unknown, query: string) => boolean;
-}
 
-export interface CommandPanelProps {
-  /** Additional CSS class names. */
+  /** Additional CSS class names for the panel wrapper. */
   className?: string;
 }
 
@@ -79,7 +77,7 @@ export interface CommandInputProps {
   className?: string;
 }
 
-export interface CommandListProps {
+export interface CommandContentProps {
   /** Additional CSS class names. */
   className?: string;
 }
@@ -104,6 +102,9 @@ export interface CommandItemProps {
 
   /** Icon rendered before the item label. */
   leadingIcon?: React.ReactNode;
+
+  /** Node rendered after the item label (e.g. `Command.Shortcut` or an icon). */
+  trailingIcon?: React.ReactNode;
 
   /**
    * Click handler fired on pointer click and on keyboard `Enter`
@@ -135,11 +136,6 @@ export interface CommandShortcutProps {
   className?: string;
 }
 
-export interface CommandFooterProps {
-  /** Additional CSS class names. */
-  className?: string;
-}
-
 export interface CommandDialogProps {
   /** Controlled open state. */
   open?: boolean;
@@ -164,9 +160,16 @@ export interface CommandDialogContentProps {
   /** Additional CSS class names applied to the dialog popup. */
   className?: string;
 
-  /** Class name applied to the backdrop. */
-  backdropClassName?: string;
+  /**
+   * Props forwarded to the backdrop element. Set `blur` to `true` to enable
+   * a backdrop blur.
+   * @defaultValue `{ blur: false }`
+   */
+  overlay?: {
+    blur?: boolean;
+    className?: string;
+  };
 
-  /** Class name applied to the viewport. */
-  viewportClassName?: string;
+  /** Explicit width for the dialog popup. */
+  width?: string | number;
 }

--- a/apps/www/src/content/docs/components/command/props.ts
+++ b/apps/www/src/content/docs/components/command/props.ts
@@ -1,0 +1,172 @@
+export interface CommandRootProps {
+  /**
+   * Items to display and filter via Base UI's internal logic.
+   * When provided, the built-in auto-search that filters `Command.Item`
+   * children is disabled — filtering is delegated to Base UI
+   * (or your custom `filter` function).
+   */
+  items?: readonly unknown[];
+
+  /** Controlled input value. */
+  value?: string;
+
+  /** Default input value (uncontrolled). */
+  defaultValue?: string;
+
+  /**
+   * Callback fired when the input value changes.
+   */
+  onValueChange?: (value: string) => void;
+
+  /**
+   * Whether the list is rendered inline (without a popup).
+   * @defaultValue true
+   */
+  inline?: boolean;
+
+  /**
+   * Whether the list is considered open (items focusable).
+   * @defaultValue true
+   */
+  open?: boolean;
+
+  /**
+   * Whether the first matching item is highlighted automatically.
+   * - `true`: highlight after the user types
+   * - `'always'`: highlight the first item as soon as the list opens
+   * @defaultValue "always"
+   */
+  autoHighlight?: boolean | 'always';
+
+  /**
+   * Whether the highlighted item should be preserved when the pointer leaves.
+   * @defaultValue true
+   */
+  keepHighlight?: boolean;
+
+  /**
+   * Filter function used to match items against the input query.
+   * Only applied when `items` is provided.
+   */
+  filter?: (itemValue: unknown, query: string) => boolean;
+}
+
+export interface CommandPanelProps {
+  /** Additional CSS class names. */
+  className?: string;
+}
+
+export interface CommandInputProps {
+  /** Placeholder text for the input. */
+  placeholder?: string;
+
+  /** Icon rendered at the start of the input. Defaults to a magnifying glass. */
+  leadingIcon?: React.ReactNode;
+
+  /**
+   * Auto-focus the input when it mounts (typical command-palette behavior).
+   * @defaultValue true
+   */
+  autoFocus?: boolean;
+
+  /**
+   * Size variant of the input field.
+   * @defaultValue "large"
+   */
+  size?: 'small' | 'large';
+
+  /** Additional CSS class names. */
+  className?: string;
+}
+
+export interface CommandListProps {
+  /** Additional CSS class names. */
+  className?: string;
+}
+
+export interface CommandEmptyProps {
+  /** Additional CSS class names. */
+  className?: string;
+}
+
+export interface CommandItemProps {
+  /**
+   * A unique value that identifies this item.
+   * If omitted and `children` is a string, the string is used as the value.
+   */
+  value?: unknown;
+
+  /**
+   * Whether the item is disabled.
+   * @defaultValue false
+   */
+  disabled?: boolean;
+
+  /** Icon rendered before the item label. */
+  leadingIcon?: React.ReactNode;
+
+  /**
+   * Click handler fired on pointer click and on keyboard `Enter`
+   * when the item is highlighted.
+   */
+  onClick?: React.MouseEventHandler<HTMLDivElement>;
+
+  /** Additional CSS class names. */
+  className?: string;
+}
+
+export interface CommandGroupProps {
+  /** Additional CSS class names. */
+  className?: string;
+}
+
+export interface CommandLabelProps {
+  /** Additional CSS class names. */
+  className?: string;
+}
+
+export interface CommandSeparatorProps {
+  /** Additional CSS class names. */
+  className?: string;
+}
+
+export interface CommandShortcutProps {
+  /** Additional CSS class names. */
+  className?: string;
+}
+
+export interface CommandFooterProps {
+  /** Additional CSS class names. */
+  className?: string;
+}
+
+export interface CommandDialogProps {
+  /** Controlled open state. */
+  open?: boolean;
+
+  /**
+   * Default open state (uncontrolled).
+   * @defaultValue false
+   */
+  defaultOpen?: boolean;
+
+  /** Event handler called when the dialog is opened or closed. */
+  onOpenChange?: (open: boolean) => void;
+
+  /**
+   * Whether the dialog is modal.
+   * @defaultValue true
+   */
+  modal?: boolean;
+}
+
+export interface CommandDialogContentProps {
+  /** Additional CSS class names applied to the dialog popup. */
+  className?: string;
+
+  /** Class name applied to the backdrop. */
+  backdropClassName?: string;
+
+  /** Class name applied to the viewport. */
+  viewportClassName?: string;
+}

--- a/docs/V1-migration.md
+++ b/docs/V1-migration.md
@@ -25,37 +25,39 @@ This guide covers all breaking changes when upgrading from the last stable Radix
       - [New: `Checkbox.Group`](#new-checkboxgroup)
     - [Combobox](#combobox)
       - [New Features](#new-features)
+    - [Command](#command)
+      - [New Features](#new-features-1)
     - [Data Table](#data-table)
     - [Dialog](#dialog)
-      - [New Features](#new-features-1)
-    - [DropdownMenu -\> Menu](#dropdownmenu---menu)
       - [New Features](#new-features-2)
+    - [DropdownMenu -\> Menu](#dropdownmenu---menu)
+      - [New Features](#new-features-3)
     - [Flex](#flex)
     - [Grid](#grid)
     - [Headline](#headline)
     - [InputField](#inputfield)
     - [Popover](#popover)
-      - [New Features](#new-features-3)
+      - [New Features](#new-features-4)
     - [Radio](#radio)
     - [ScrollArea](#scrollarea)
     - [Select](#select)
-      - [New Features](#new-features-4)
+      - [New Features](#new-features-5)
     - [Separator](#separator)
     - [Sheet -\> Drawer](#sheet---drawer)
-      - [New Features](#new-features-5)
-    - [Sidebar](#sidebar)
       - [New Features](#new-features-6)
-    - [Slider](#slider)
+    - [Sidebar](#sidebar)
       - [New Features](#new-features-7)
+    - [Slider](#slider)
+      - [New Features](#new-features-8)
     - [Switch](#switch)
     - [Tabs](#tabs)
-      - [New Features](#new-features-8)
+      - [New Features](#new-features-9)
     - [Text](#text)
     - [TextArea](#textarea)
     - [Toast](#toast)
-      - [New Features](#new-features-9)
-    - [Tooltip](#tooltip)
       - [New Features](#new-features-10)
+    - [Tooltip](#tooltip)
+      - [New Features](#new-features-11)
   - [New Components](#new-components)
   - [Removed Exports](#removed-exports)
   - [| `RadioItem` | `Radio` | See Radio |](#-radioitem--radio--see-radio-)
@@ -539,6 +541,209 @@ Unchanged: `size`, `radius`, `variant`, `color`, `fallback`, `src`, `alt`, `clas
 - Generic value type support: `<Combobox<CustomType>>`
 - `items` prop on Root for built-in filtering
 - `render` prop on Content and Item
+
+---
+
+### Command
+
+**Underlying primitive changed from `cmdk` to Base UI `Autocomplete`.** Most usages will need to be rewritten.
+
+1. **`Command.List` renamed to `Command.Content`:**
+
+```tsx
+// Before
+<Command>
+  <Command.Input />
+  <Command.List>
+    <Command.Empty>No results</Command.Empty>
+    <Command.Item>Item</Command.Item>
+  </Command.List>
+</Command>
+
+// After
+<Command>
+  <Command.Input />
+  <Command.Content>
+    <Command.Empty>No results</Command.Empty>
+    <Command.Item>Item</Command.Item>
+  </Command.Content>
+</Command>
+```
+
+2. **`Command.Group` `heading` prop replaced by `Command.Label` child:**
+
+```tsx
+// Before
+<Command.Group heading="Suggestions">
+  <Command.Item>Calendar</Command.Item>
+  <Command.Item>Calculator</Command.Item>
+</Command.Group>
+
+// After
+<Command.Group>
+  <Command.Label>Suggestions</Command.Label>
+  <Command.Item>Calendar</Command.Item>
+  <Command.Item>Calculator</Command.Item>
+</Command.Group>
+```
+
+3. **`Command.Item` `onSelect` replaced by `onClick`:**
+
+```tsx
+// Before — cmdk's onSelect with the item's value
+<Command.Item value="calendar" onSelect={(value) => handleSelect(value)}>
+  Calendar
+</Command.Item>
+
+// After — standard DOM onClick; derive the value from your handler closure
+<Command.Item value="calendar" onClick={() => handleSelect('calendar')}>
+  Calendar
+</Command.Item>
+```
+
+`onClick` fires on pointer click and on keyboard `Enter` when the item is highlighted.
+
+4. **Icons now use `leadingIcon` / `trailingIcon` props** instead of being composed inline:
+
+```tsx
+// Before — icons rendered as children
+<Command.Item>
+  <CalendarIcon />
+  Calendar
+  <Command.Shortcut>⌘ C</Command.Shortcut>
+</Command.Item>
+
+// After — icons passed as props, layout handled internally
+<Command.Item
+  leadingIcon={<CalendarIcon />}
+  trailingIcon={<Command.Shortcut>⌘ C</Command.Shortcut>}
+>
+  Calendar
+</Command.Item>
+```
+
+5. **`Command.Shortcut` now wraps each key in its own `<kbd>`.** The string children are split on whitespace; array/element children are wrapped per item. Previously `Command.Shortcut` rendered a single `<span>`:
+
+```tsx
+// Before — plain <span>
+<Command.Shortcut>⌘ K</Command.Shortcut>
+// renders: <span>⌘ K</span>
+
+// After — <kbd> per token, split by whitespace
+<Command.Shortcut>⌘ K</Command.Shortcut>
+// renders: <span><kbd>⌘</kbd><kbd>K</kbd></span>
+```
+
+If you had custom CSS targeting `Command.Shortcut`'s inner content, update it to target the inner `<kbd>` elements.
+
+6. **Dialog composition is now explicit.** The old `Command.Dialog` internally wrapped Apsara's `Dialog` + `Dialog.Content` and nested a `Command` root automatically. The new API splits that into three pieces: `Command.Dialog` (root), `Command.DialogTrigger`, and `Command.DialogContent`. You must render `<Command>` yourself inside `DialogContent`:
+
+```tsx
+// Before — Dialog and Command were fused
+<Command.Dialog open={open} onOpenChange={setOpen}>
+  <Command.Input />
+  <Command.List>
+    <Command.Item>Item</Command.Item>
+  </Command.List>
+</Command.Dialog>
+{/* separate trigger wired via keyboard shortcut only */}
+
+// After — explicit trigger + content + nested Command
+<Command.Dialog open={open} onOpenChange={setOpen}>
+  <Command.DialogTrigger render={<Button variant="outline" />}>
+    Open Command Menu
+  </Command.DialogTrigger>
+  <Command.DialogContent>
+    <Command>
+      <Command.Input />
+      <Command.Content>
+        <Command.Item>Item</Command.Item>
+      </Command.Content>
+    </Command>
+  </Command.DialogContent>
+</Command.Dialog>
+```
+
+`Command.DialogContent` replaces the old reliance on `Dialog.Content`: it renders its own portal, backdrop, viewport, and popup. It does not render a close button — users dismiss with `Escape` or by clicking the backdrop. Pass `overlay={{ blur: true }}` for a blurred backdrop.
+
+7. **`filter` prop signature changed** and now only applies when `items` is provided (see New Features). The old cmdk signature was `(value: string, search: string, keywords?: string[]) => number` (returning a 0–1 score); the new Base UI signature is `(itemValue: unknown, query: string) => boolean`:
+
+```tsx
+// Before — cmdk numeric score
+<Command filter={(value, search) => value.includes(search) ? 1 : 0}>
+
+// After — Base UI boolean (only active when `items` is provided)
+<Command
+  items={items}
+  filter={(itemValue, query) =>
+    String(itemValue).toLowerCase().includes(query.toLowerCase())
+  }
+>
+```
+
+Without `items`, `Command` uses its built-in auto-filter over `Command.Item` children (case-insensitive match against `value` and text content), and `filter` is ignored.
+
+8. **`onValueChange` receives 2 args** on both the root and `Command.Input` — `(value: string, eventDetails)`.
+
+9. **`Command.Input` props changed.** It now accepts the same props as `InputField` (e.g. `size`, `leadingIcon`, `placeholder`, `autoFocus`). Defaults: `size="large"`, `autoFocus={true}`, leading icon is a magnifying glass. `trailingIcon`, `chips`, `maxChipsVisible`, and `variant` are not accepted.
+
+**Full before/after example:**
+
+```tsx
+// Before
+import { Command } from '@raystack/apsara';
+
+<Command.Dialog open={open} onOpenChange={setOpen}>
+  <Command.Input placeholder="Type a command..." />
+  <Command.List>
+    <Command.Empty>No results.</Command.Empty>
+    <Command.Group heading="Suggestions">
+      <Command.Item value="calendar" onSelect={(v) => run(v)}>
+        <CalendarIcon />
+        Calendar
+        <Command.Shortcut>⌘ C</Command.Shortcut>
+      </Command.Item>
+    </Command.Group>
+  </Command.List>
+</Command.Dialog>
+
+// After
+import { Command, Button } from '@raystack/apsara';
+
+<Command.Dialog open={open} onOpenChange={setOpen}>
+  <Command.DialogTrigger render={<Button variant="outline" />}>
+    Open Command Menu
+  </Command.DialogTrigger>
+  <Command.DialogContent>
+    <Command>
+      <Command.Input placeholder="Type a command..." />
+      <Command.Content>
+        <Command.Empty>No results.</Command.Empty>
+        <Command.Group>
+          <Command.Label>Suggestions</Command.Label>
+          <Command.Item
+            value="calendar"
+            leadingIcon={<CalendarIcon />}
+            trailingIcon={<Command.Shortcut>⌘ C</Command.Shortcut>}
+            onClick={() => run('calendar')}
+          >
+            Calendar
+          </Command.Item>
+        </Command.Group>
+      </Command.Content>
+    </Command>
+  </Command.DialogContent>
+</Command.Dialog>
+```
+
+#### New Features
+
+- `Command.Label` sub-component for group labels (pairs with `Command.Group`).
+- `Command.DialogTrigger` and `Command.DialogContent` sub-components for composing the palette's dialog shell.
+- `items` prop on Root to delegate filtering to Base UI. When provided, `Command.Content` accepts a render function that receives each item.
+- `leadingIcon` / `trailingIcon` props on `Command.Item` with built-in layout.
+- `autoHighlight`, `keepHighlight`, `inline`, and `open` props forwarded from Base UI `Autocomplete.Root`.
+- Inherits Base UI combobox a11y: `role="combobox"` on the input, `role="listbox"` on the content, `role="option"` on items. `ArrowUp`/`ArrowDown`/`Enter`/`Escape` keyboard navigation.
 
 ---
 
@@ -1685,6 +1890,7 @@ These are purely additive -- no migration needed.
 - [ ] Remove `Select.Viewport` wrapper
 - [ ] Rewrite all Tooltip usages to compound component pattern
 - [ ] Update Accordion: `type` -> `multiple`, remove `collapsible`, `forceMount` -> `keepMounted`
+- [ ] Update Command: `Command.List` -> `Command.Content`, `Group heading` -> `<Command.Label>`, `onSelect` -> `onClick`, inline icons -> `leadingIcon`/`trailingIcon`, wrap dialog usages with `Command.DialogTrigger` + `Command.DialogContent` (see [Command](#command))
 - [ ] Wrap InputField usages with `<Field>` — move `label`, `helperText`, `error`, `optional` to Field props (see [InputField](#inputfield))
 - [ ] Wrap TextArea usages with `<Field>` — move `label`, `helperText`, `error`, `required` to Field props (see [TextArea](#textarea))
 - [ ] Remove `infoTooltip` from InputField and TextArea (no longer supported)

--- a/packages/raystack/components/command/__tests__/command.test.tsx
+++ b/packages/raystack/components/command/__tests__/command.test.tsx
@@ -22,17 +22,15 @@ const ITEMS = [
 
 const BasicCommand = (props: React.ComponentProps<typeof Command>) => (
   <Command {...props}>
-    <Command.Panel>
-      <Command.Input placeholder='Type a command or search...' />
-      <Command.List>
-        <Command.Empty>No results found.</Command.Empty>
-        {ITEMS.map(item => (
-          <Command.Item key={item.value} value={item.value}>
-            {item.label}
-          </Command.Item>
-        ))}
-      </Command.List>
-    </Command.Panel>
+    <Command.Input placeholder='Type a command or search...' />
+    <Command.Content>
+      <Command.Empty>No results found.</Command.Empty>
+      {ITEMS.map(item => (
+        <Command.Item key={item.value} value={item.value}>
+          {item.label}
+        </Command.Item>
+      ))}
+    </Command.Content>
   </Command>
 );
 
@@ -64,6 +62,11 @@ describe('Command', () => {
     it('list has listbox role', () => {
       render(<BasicCommand />);
       expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+
+    it('renders root with panel styles', () => {
+      const { container } = render(<BasicCommand />);
+      expect(container.querySelector(`.${styles.panel}`)).toBeInTheDocument();
     });
   });
 
@@ -135,12 +138,10 @@ describe('Command', () => {
 
       render(
         <Command items={items}>
-          <Command.Panel>
-            <Command.Input placeholder='Search...' />
-            <Command.List>
-              <Command.Item>Always Visible Custom</Command.Item>
-            </Command.List>
-          </Command.Panel>
+          <Command.Input placeholder='Search...' />
+          <Command.Content>
+            <Command.Item>Always Visible Custom</Command.Item>
+          </Command.Content>
         </Command>
       );
 
@@ -156,23 +157,21 @@ describe('Command', () => {
   describe('Groups and Separators', () => {
     const GroupedCommand = () => (
       <Command>
-        <Command.Panel>
-          <Command.Input placeholder='Search' />
-          <Command.List>
-            <Command.Empty>No results</Command.Empty>
-            <Command.Group>
-              <Command.Label>Suggestions</Command.Label>
-              <Command.Item>Calendar</Command.Item>
-              <Command.Item>Calculator</Command.Item>
-            </Command.Group>
-            <Command.Separator />
-            <Command.Group>
-              <Command.Label>Settings</Command.Label>
-              <Command.Item>Profile</Command.Item>
-              <Command.Item>Billing</Command.Item>
-            </Command.Group>
-          </Command.List>
-        </Command.Panel>
+        <Command.Input placeholder='Search' />
+        <Command.Content>
+          <Command.Empty>No results</Command.Empty>
+          <Command.Group>
+            <Command.Label>Suggestions</Command.Label>
+            <Command.Item>Calendar</Command.Item>
+            <Command.Item>Calculator</Command.Item>
+          </Command.Group>
+          <Command.Separator />
+          <Command.Group>
+            <Command.Label>Settings</Command.Label>
+            <Command.Item>Profile</Command.Item>
+            <Command.Item>Billing</Command.Item>
+          </Command.Group>
+        </Command.Content>
       </Command>
     );
 
@@ -203,12 +202,10 @@ describe('Command', () => {
       const handleClick = vi.fn();
       render(
         <Command>
-          <Command.Panel>
-            <Command.Input placeholder='Search' />
-            <Command.List>
-              <Command.Item onClick={handleClick}>Calendar</Command.Item>
-            </Command.List>
-          </Command.Panel>
+          <Command.Input placeholder='Search' />
+          <Command.Content>
+            <Command.Item onClick={handleClick}>Calendar</Command.Item>
+          </Command.Content>
         </Command>
       );
 
@@ -222,13 +219,11 @@ describe('Command', () => {
 
       render(
         <Command>
-          <Command.Panel>
-            <Command.Input placeholder='Search' />
-            <Command.List>
-              <Command.Item onClick={handleClick}>Calendar</Command.Item>
-              <Command.Item>Calculator</Command.Item>
-            </Command.List>
-          </Command.Panel>
+          <Command.Input placeholder='Search' />
+          <Command.Content>
+            <Command.Item onClick={handleClick}>Calendar</Command.Item>
+            <Command.Item>Calculator</Command.Item>
+          </Command.Content>
         </Command>
       );
 
@@ -255,13 +250,11 @@ describe('Command', () => {
               handleChange(v, details);
             }}
           >
-            <Command.Panel>
-              <Command.Input placeholder='Search' />
-              <Command.List>
-                <Command.Item>Calendar</Command.Item>
-                <Command.Item>Calculator</Command.Item>
-              </Command.List>
-            </Command.Panel>
+            <Command.Input placeholder='Search' />
+            <Command.Content>
+              <Command.Item>Calendar</Command.Item>
+              <Command.Item>Calculator</Command.Item>
+            </Command.Content>
           </Command>
         );
       };
@@ -279,79 +272,15 @@ describe('Command', () => {
     it('marks item as disabled via aria-disabled', () => {
       render(
         <Command>
-          <Command.Panel>
-            <Command.Input placeholder='Search' />
-            <Command.List>
-              <Command.Item disabled>Calendar</Command.Item>
-            </Command.List>
-          </Command.Panel>
+          <Command.Input placeholder='Search' />
+          <Command.Content>
+            <Command.Item disabled>Calendar</Command.Item>
+          </Command.Content>
         </Command>
       );
 
       const option = screen.getByText('Calendar').closest('[role="option"]');
       expect(option).toHaveAttribute('aria-disabled', 'true');
-    });
-  });
-
-  describe('Panel / Footer / Shortcut', () => {
-    it('renders Command.Panel wrapper with default class', () => {
-      render(
-        <Command>
-          <Command.Panel data-testid='panel'>
-            <Command.Input placeholder='Search' />
-          </Command.Panel>
-        </Command>
-      );
-
-      const panel = screen.getByTestId('panel');
-      expect(panel).toHaveClass(styles.panel);
-    });
-
-    it('merges custom className on Panel', () => {
-      render(
-        <Command>
-          <Command.Panel className='custom-panel' data-testid='panel'>
-            <Command.Input placeholder='Search' />
-          </Command.Panel>
-        </Command>
-      );
-
-      const panel = screen.getByTestId('panel');
-      expect(panel).toHaveClass('custom-panel');
-      expect(panel).toHaveClass(styles.panel);
-    });
-
-    it('renders Command.Footer', () => {
-      render(
-        <Command>
-          <Command.Panel>
-            <Command.Input placeholder='Search' />
-            <Command.Footer data-testid='footer'>Footer content</Command.Footer>
-          </Command.Panel>
-        </Command>
-      );
-
-      const footer = screen.getByTestId('footer');
-      expect(footer).toHaveTextContent('Footer content');
-      expect(footer).toHaveClass(styles.footer);
-    });
-
-    it('renders Command.Shortcut as <kbd>', () => {
-      render(
-        <Command>
-          <Command.Panel>
-            <Command.Input placeholder='Search' />
-            <Command.List>
-              <Command.Item>
-                Profile <Command.Shortcut>⌘P</Command.Shortcut>
-              </Command.Item>
-            </Command.List>
-          </Command.Panel>
-        </Command>
-      );
-
-      const kbd = screen.getByText('⌘P');
-      expect(kbd.tagName).toBe('KBD');
     });
   });
 
@@ -361,15 +290,15 @@ describe('Command', () => {
 
       render(
         <Command.Dialog>
-          <Command.Dialog.Trigger>Open Menu</Command.Dialog.Trigger>
-          <Command.Dialog.Content>
+          <Command.DialogTrigger>Open Menu</Command.DialogTrigger>
+          <Command.DialogContent>
             <Command>
               <Command.Input placeholder='Search' />
-              <Command.List>
+              <Command.Content>
                 <Command.Item>Calendar</Command.Item>
-              </Command.List>
+              </Command.Content>
             </Command>
-          </Command.Dialog.Content>
+          </Command.DialogContent>
         </Command.Dialog>
       );
 

--- a/packages/raystack/components/command/__tests__/command.test.tsx
+++ b/packages/raystack/components/command/__tests__/command.test.tsx
@@ -1,6 +1,9 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { Command } from '../command';
+import styles from '../command.module.css';
 
 // Mock scrollIntoView for test environment
 Object.defineProperty(Element.prototype, 'scrollIntoView', {
@@ -8,126 +11,379 @@ Object.defineProperty(Element.prototype, 'scrollIntoView', {
   writable: true
 });
 
+const ITEMS = [
+  { value: 'calendar', label: 'Calendar' },
+  { value: 'emoji', label: 'Search Emoji' },
+  { value: 'calculator', label: 'Calculator' },
+  { value: 'profile', label: 'Profile' },
+  { value: 'billing', label: 'Billing' },
+  { value: 'settings', label: 'Settings' }
+];
+
+const BasicCommand = (props: React.ComponentProps<typeof Command>) => (
+  <Command {...props}>
+    <Command.Panel>
+      <Command.Input placeholder='Type a command or search...' />
+      <Command.List>
+        <Command.Empty>No results found.</Command.Empty>
+        {ITEMS.map(item => (
+          <Command.Item key={item.value} value={item.value}>
+            {item.label}
+          </Command.Item>
+        ))}
+      </Command.List>
+    </Command.Panel>
+  </Command>
+);
+
+const selectOption = async (element: HTMLElement) => {
+  const option = element.closest('[role="option"]') ?? element;
+  fireEvent.pointerDown(option);
+  fireEvent.click(option);
+};
+
 describe('Command', () => {
   describe('Basic Rendering', () => {
-    it('renders command root', () => {
-      render(
-        <Command>
-          <Command.Input placeholder='Search...' />
-          <Command.List>
-            <Command.Item>Item 1</Command.Item>
-            <Command.Item>Item 2</Command.Item>
-          </Command.List>
-        </Command>
-      );
-
+    it('renders input and items', () => {
+      render(<BasicCommand />);
       expect(screen.getByRole('combobox')).toBeInTheDocument();
-      expect(screen.getByPlaceholderText('Search...')).toBeInTheDocument();
-    });
-
-    it('applies custom className', () => {
-      render(
-        <Command className='custom-command'>
-          <Command.Input placeholder='Search...' />
-          <Command.List>
-            <Command.Item>Item 1</Command.Item>
-          </Command.List>
-        </Command>
-      );
-
-      const command = document.querySelector('.custom-command');
-      expect(command).toBeInTheDocument();
-    });
-  });
-
-  describe('Command Input', () => {
-    it('renders input with placeholder', () => {
-      render(
-        <Command>
-          <Command.Input placeholder='Type to search...' />
-          <Command.List>
-            <Command.Item>Item 1</Command.Item>
-          </Command.List>
-        </Command>
-      );
-
       expect(
-        screen.getByPlaceholderText('Type to search...')
+        screen.getByPlaceholderText('Type a command or search...')
       ).toBeInTheDocument();
+      ITEMS.forEach(item => {
+        expect(screen.getByText(item.label)).toBeInTheDocument();
+      });
     });
 
-    it('renders search icon', () => {
-      render(
-        <Command>
-          <Command.Input placeholder='Search...' />
-          <Command.List>
-            <Command.Item>Item 1</Command.Item>
-          </Command.List>
-        </Command>
-      );
-
-      // Search icon should be present (it's rendered by the Command.Input component)
-      expect(screen.getByRole('combobox')).toBeInTheDocument();
-    });
-  });
-
-  describe('Command List and Items', () => {
-    it('renders command items', () => {
-      render(
-        <Command>
-          <Command.Input placeholder='Search...' />
-          <Command.List>
-            <Command.Item>First Item</Command.Item>
-            <Command.Item>Second Item</Command.Item>
-          </Command.List>
-        </Command>
-      );
-
-      expect(screen.getByText('First Item')).toBeInTheDocument();
-      expect(screen.getByText('Second Item')).toBeInTheDocument();
+    it('items have option role', () => {
+      render(<BasicCommand />);
+      const options = screen.getAllByRole('option');
+      expect(options).toHaveLength(ITEMS.length);
     });
 
-    it('applies item classes', () => {
-      render(
-        <Command>
-          <Command.Input placeholder='Search...' />
-          <Command.List>
-            <Command.Item className='custom-item'>Item 1</Command.Item>
-          </Command.List>
-        </Command>
-      );
-
-      const item = screen.getByText('Item 1');
-      expect(item).toHaveClass('custom-item');
+    it('list has listbox role', () => {
+      render(<BasicCommand />);
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
     });
   });
 
-  describe('Command Empty State', () => {
-    it('renders empty state when no results', () => {
-      render(
-        <Command>
-          <Command.Input placeholder='Search...' />
-          <Command.List>
-            <Command.Empty>No results found</Command.Empty>
-          </Command.List>
-        </Command>
-      );
+  describe('Auto-search (no items prop)', () => {
+    it('filters items based on input value', async () => {
+      const user = userEvent.setup();
+      render(<BasicCommand />);
 
-      expect(screen.getByText('No results found')).toBeInTheDocument();
+      const input = screen.getByRole('combobox');
+      await user.type(input, 'cal');
+
+      await waitFor(() => {
+        const options = screen.getAllByRole('option');
+        expect(options).toHaveLength(2);
+        expect(screen.getByText('Calendar')).toBeInTheDocument();
+        expect(screen.getByText('Calculator')).toBeInTheDocument();
+        expect(screen.queryByText('Profile')).not.toBeInTheDocument();
+      });
     });
 
-    it('applies empty state classes', () => {
+    it('matches case-insensitively', async () => {
+      const user = userEvent.setup();
+      render(<BasicCommand />);
+
+      const input = screen.getByRole('combobox');
+      await user.type(input, 'PROFILE');
+
+      await waitFor(() => {
+        const options = screen.getAllByRole('option');
+        expect(options).toHaveLength(1);
+        expect(screen.getByText('Profile')).toBeInTheDocument();
+      });
+    });
+
+    it('restores all items when search is cleared', async () => {
+      const user = userEvent.setup();
+      render(<BasicCommand />);
+
+      const input = screen.getByRole('combobox');
+      await user.type(input, 'cal');
+      await waitFor(() =>
+        expect(screen.getAllByRole('option')).toHaveLength(2)
+      );
+
+      await user.clear(input);
+      await waitFor(() =>
+        expect(screen.getAllByRole('option')).toHaveLength(ITEMS.length)
+      );
+    });
+
+    it('shows empty state when no items match', async () => {
+      const user = userEvent.setup();
+      render(<BasicCommand />);
+
+      const input = screen.getByRole('combobox');
+      await user.type(input, 'zzzzz');
+
+      await waitFor(() => {
+        expect(screen.queryAllByRole('option')).toHaveLength(0);
+        expect(screen.getByText('No results found.')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Auto-search disabled when items prop is passed', () => {
+    it('does not apply custom filtering to CommandItem when items is provided', async () => {
+      const user = userEvent.setup();
+      const items = ['Calendar', 'Search Emoji', 'Calculator'];
+
       render(
-        <Command>
-          <Command.Input placeholder='Search...' />
-          <Command.List>
-            <Command.Empty className='custom-empty'>No results</Command.Empty>
-          </Command.List>
+        <Command items={items}>
+          <Command.Panel>
+            <Command.Input placeholder='Search...' />
+            <Command.List>
+              <Command.Item>Always Visible Custom</Command.Item>
+            </Command.List>
+          </Command.Panel>
         </Command>
       );
 
-      const empty = screen.getByText('No results');
-      expect(empty).toHaveClass('custom-empty');
+      // Our per-item filtering does not apply (because items was passed).
+      // Even with an unrelated query, the hardcoded item should still render.
+      const input = screen.getByRole('combobox');
+      await user.type(input, 'zzzzz');
+
+      expect(screen.getByText('Always Visible Custom')).toBeInTheDocument();
+    });
+  });
+
+  describe('Groups and Separators', () => {
+    const GroupedCommand = () => (
+      <Command>
+        <Command.Panel>
+          <Command.Input placeholder='Search' />
+          <Command.List>
+            <Command.Empty>No results</Command.Empty>
+            <Command.Group>
+              <Command.Label>Suggestions</Command.Label>
+              <Command.Item>Calendar</Command.Item>
+              <Command.Item>Calculator</Command.Item>
+            </Command.Group>
+            <Command.Separator />
+            <Command.Group>
+              <Command.Label>Settings</Command.Label>
+              <Command.Item>Profile</Command.Item>
+              <Command.Item>Billing</Command.Item>
+            </Command.Group>
+          </Command.List>
+        </Command.Panel>
+      </Command>
+    );
+
+    it('renders group labels and separator when not searching', () => {
+      render(<GroupedCommand />);
+      expect(screen.getByText('Suggestions')).toBeInTheDocument();
+      expect(screen.getByText('Settings')).toBeInTheDocument();
+    });
+
+    it('hides group labels and separators while searching', async () => {
+      const user = userEvent.setup();
+      render(<GroupedCommand />);
+
+      const input = screen.getByRole('combobox');
+      await user.type(input, 'cal');
+
+      await waitFor(() => {
+        expect(screen.queryByText('Suggestions')).not.toBeInTheDocument();
+        expect(screen.queryByText('Settings')).not.toBeInTheDocument();
+        expect(screen.getByText('Calendar')).toBeInTheDocument();
+        expect(screen.getByText('Calculator')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Item selection', () => {
+    it('invokes onClick when item is clicked', async () => {
+      const handleClick = vi.fn();
+      render(
+        <Command>
+          <Command.Panel>
+            <Command.Input placeholder='Search' />
+            <Command.List>
+              <Command.Item onClick={handleClick}>Calendar</Command.Item>
+            </Command.List>
+          </Command.Panel>
+        </Command>
+      );
+
+      await selectOption(screen.getByText('Calendar'));
+      expect(handleClick).toHaveBeenCalled();
+    });
+
+    it('selects highlighted item with Enter key', async () => {
+      const user = userEvent.setup();
+      const handleClick = vi.fn();
+
+      render(
+        <Command>
+          <Command.Panel>
+            <Command.Input placeholder='Search' />
+            <Command.List>
+              <Command.Item onClick={handleClick}>Calendar</Command.Item>
+              <Command.Item>Calculator</Command.Item>
+            </Command.List>
+          </Command.Panel>
+        </Command>
+      );
+
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      await user.keyboard('{Enter}');
+
+      expect(handleClick).toHaveBeenCalled();
+    });
+  });
+
+  describe('Controlled input value', () => {
+    it('supports controlled value / onValueChange', async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+
+      const Wrapper = () => {
+        const [value, setValue] = React.useState('');
+        return (
+          <Command
+            value={value}
+            onValueChange={(v, details) => {
+              setValue(v);
+              handleChange(v, details);
+            }}
+          >
+            <Command.Panel>
+              <Command.Input placeholder='Search' />
+              <Command.List>
+                <Command.Item>Calendar</Command.Item>
+                <Command.Item>Calculator</Command.Item>
+              </Command.List>
+            </Command.Panel>
+          </Command>
+        );
+      };
+
+      render(<Wrapper />);
+      const input = screen.getByRole('combobox');
+      await user.type(input, 'cal');
+
+      expect(handleChange).toHaveBeenCalled();
+      expect(input).toHaveValue('cal');
+    });
+  });
+
+  describe('Disabled Item', () => {
+    it('marks item as disabled via aria-disabled', () => {
+      render(
+        <Command>
+          <Command.Panel>
+            <Command.Input placeholder='Search' />
+            <Command.List>
+              <Command.Item disabled>Calendar</Command.Item>
+            </Command.List>
+          </Command.Panel>
+        </Command>
+      );
+
+      const option = screen.getByText('Calendar').closest('[role="option"]');
+      expect(option).toHaveAttribute('aria-disabled', 'true');
+    });
+  });
+
+  describe('Panel / Footer / Shortcut', () => {
+    it('renders Command.Panel wrapper with default class', () => {
+      render(
+        <Command>
+          <Command.Panel data-testid='panel'>
+            <Command.Input placeholder='Search' />
+          </Command.Panel>
+        </Command>
+      );
+
+      const panel = screen.getByTestId('panel');
+      expect(panel).toHaveClass(styles.panel);
+    });
+
+    it('merges custom className on Panel', () => {
+      render(
+        <Command>
+          <Command.Panel className='custom-panel' data-testid='panel'>
+            <Command.Input placeholder='Search' />
+          </Command.Panel>
+        </Command>
+      );
+
+      const panel = screen.getByTestId('panel');
+      expect(panel).toHaveClass('custom-panel');
+      expect(panel).toHaveClass(styles.panel);
+    });
+
+    it('renders Command.Footer', () => {
+      render(
+        <Command>
+          <Command.Panel>
+            <Command.Input placeholder='Search' />
+            <Command.Footer data-testid='footer'>Footer content</Command.Footer>
+          </Command.Panel>
+        </Command>
+      );
+
+      const footer = screen.getByTestId('footer');
+      expect(footer).toHaveTextContent('Footer content');
+      expect(footer).toHaveClass(styles.footer);
+    });
+
+    it('renders Command.Shortcut as <kbd>', () => {
+      render(
+        <Command>
+          <Command.Panel>
+            <Command.Input placeholder='Search' />
+            <Command.List>
+              <Command.Item>
+                Profile <Command.Shortcut>⌘P</Command.Shortcut>
+              </Command.Item>
+            </Command.List>
+          </Command.Panel>
+        </Command>
+      );
+
+      const kbd = screen.getByText('⌘P');
+      expect(kbd.tagName).toBe('KBD');
+    });
+  });
+
+  describe('CommandDialog', () => {
+    it('shows dialog when trigger is clicked and dismisses on Escape', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Command.Dialog>
+          <Command.Dialog.Trigger>Open Menu</Command.Dialog.Trigger>
+          <Command.Dialog.Content>
+            <Command>
+              <Command.Input placeholder='Search' />
+              <Command.List>
+                <Command.Item>Calendar</Command.Item>
+              </Command.List>
+            </Command>
+          </Command.Dialog.Content>
+        </Command.Dialog>
+      );
+
+      expect(screen.queryByText('Calendar')).not.toBeInTheDocument();
+
+      await user.click(screen.getByText('Open Menu'));
+      await waitFor(() => {
+        expect(screen.getByText('Calendar')).toBeInTheDocument();
+      });
+
+      await user.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(screen.queryByText('Calendar')).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/packages/raystack/components/command/command-content.tsx
+++ b/packages/raystack/components/command/command-content.tsx
@@ -4,13 +4,13 @@ import { Autocomplete as AutocompletePrimitive } from '@base-ui/react/autocomple
 import { cx } from 'class-variance-authority';
 import styles from './command.module.css';
 
-export type CommandListProps = AutocompletePrimitive.List.Props;
+export type CommandContentProps = AutocompletePrimitive.List.Props;
 
-export const CommandList = ({
+export const CommandContent = ({
   ref,
   className,
   ...props
-}: CommandListProps & { ref?: React.Ref<HTMLDivElement> }) => {
+}: CommandContentProps & { ref?: React.Ref<HTMLDivElement> }) => {
   return (
     <AutocompletePrimitive.List
       ref={ref}
@@ -20,4 +20,4 @@ export const CommandList = ({
   );
 };
 
-CommandList.displayName = 'Command.List';
+CommandContent.displayName = 'Command.Content';

--- a/packages/raystack/components/command/command-dialog.tsx
+++ b/packages/raystack/components/command/command-dialog.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
+import { cx } from 'class-variance-authority';
+import { type ComponentProps } from 'react';
+import styles from './command.module.css';
+
+export const CommandDialogRoot = DialogPrimitive.Root;
+
+export const CommandDialogTrigger = DialogPrimitive.Trigger;
+
+export const CommandDialogClose = DialogPrimitive.Close;
+
+export const CommandDialogTitle = DialogPrimitive.Title;
+
+export const CommandDialogDescription = DialogPrimitive.Description;
+
+export interface CommandDialogContentProps extends DialogPrimitive.Popup.Props {
+  /** Props forwarded to the underlying `Dialog.Portal`. */
+  portalProps?: ComponentProps<typeof DialogPrimitive.Portal>;
+  /** Override the class applied to the backdrop. */
+  backdropClassName?: string;
+  /** Override the class applied to the viewport. */
+  viewportClassName?: string;
+}
+
+export const CommandDialogContent = ({
+  className,
+  children,
+  portalProps,
+  backdropClassName,
+  viewportClassName,
+  ...props
+}: CommandDialogContentProps) => {
+  return (
+    <DialogPrimitive.Portal {...portalProps}>
+      <DialogPrimitive.Backdrop
+        className={cx(styles.backdrop, backdropClassName)}
+      />
+      <DialogPrimitive.Viewport
+        className={cx(styles.viewport, viewportClassName)}
+      >
+        <DialogPrimitive.Popup
+          className={cx(styles.dialogPopup, className)}
+          {...props}
+        >
+          {children}
+        </DialogPrimitive.Popup>
+      </DialogPrimitive.Viewport>
+    </DialogPrimitive.Portal>
+  );
+};
+CommandDialogContent.displayName = 'Command.Dialog.Content';

--- a/packages/raystack/components/command/command-dialog.tsx
+++ b/packages/raystack/components/command/command-dialog.tsx
@@ -2,46 +2,52 @@
 
 import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
 import { cx } from 'class-variance-authority';
-import { type ComponentProps } from 'react';
+import { forwardRef } from 'react';
 import styles from './command.module.css';
 
-export const CommandDialogRoot = DialogPrimitive.Root;
+export const CommandDialog = (props: DialogPrimitive.Root.Props) => (
+  <DialogPrimitive.Root {...props} />
+);
+CommandDialog.displayName = 'Command.Dialog';
 
-export const CommandDialogTrigger = DialogPrimitive.Trigger;
-
-export const CommandDialogClose = DialogPrimitive.Close;
-
-export const CommandDialogTitle = DialogPrimitive.Title;
-
-export const CommandDialogDescription = DialogPrimitive.Description;
+export const CommandDialogTrigger = forwardRef<
+  HTMLButtonElement,
+  DialogPrimitive.Trigger.Props
+>((props, ref) => <DialogPrimitive.Trigger ref={ref} {...props} />);
+CommandDialogTrigger.displayName = 'Command.DialogTrigger';
 
 export interface CommandDialogContentProps extends DialogPrimitive.Popup.Props {
-  /** Props forwarded to the underlying `Dialog.Portal`. */
-  portalProps?: ComponentProps<typeof DialogPrimitive.Portal>;
-  /** Override the class applied to the backdrop. */
-  backdropClassName?: string;
-  /** Override the class applied to the viewport. */
-  viewportClassName?: string;
+  overlay?: DialogPrimitive.Backdrop.Props & { blur?: boolean };
+  width?: string | number;
 }
 
-export const CommandDialogContent = ({
+export function CommandDialogContent({
   className,
   children,
-  portalProps,
-  backdropClassName,
-  viewportClassName,
+  overlay,
+  width,
+  style,
   ...props
-}: CommandDialogContentProps) => {
+}: CommandDialogContentProps) {
+  const {
+    blur = false,
+    className: overlayClassName,
+    ...overlayProps
+  } = overlay ?? {};
   return (
-    <DialogPrimitive.Portal {...portalProps}>
+    <DialogPrimitive.Portal>
       <DialogPrimitive.Backdrop
-        className={cx(styles.backdrop, backdropClassName)}
+        {...overlayProps}
+        className={cx(
+          styles.backdrop,
+          blur && styles.backdropBlur,
+          overlayClassName
+        )}
       />
-      <DialogPrimitive.Viewport
-        className={cx(styles.viewport, viewportClassName)}
-      >
+      <DialogPrimitive.Viewport className={styles.viewport}>
         <DialogPrimitive.Popup
           className={cx(styles.dialogPopup, className)}
+          style={{ width, ...style }}
           {...props}
         >
           {children}
@@ -49,5 +55,5 @@ export const CommandDialogContent = ({
       </DialogPrimitive.Viewport>
     </DialogPrimitive.Portal>
   );
-};
-CommandDialogContent.displayName = 'Command.Dialog.Content';
+}
+CommandDialogContent.displayName = 'Command.DialogContent';

--- a/packages/raystack/components/command/command-empty.tsx
+++ b/packages/raystack/components/command/command-empty.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { cx } from 'class-variance-authority';
+import { type ComponentProps } from 'react';
+import styles from './command.module.css';
+
+export interface CommandEmptyProps extends ComponentProps<'div'> {}
+
+export const CommandEmpty = ({
+  ref,
+  className,
+  ...props
+}: CommandEmptyProps & { ref?: React.Ref<HTMLDivElement> }) => {
+  return <div ref={ref} className={cx(styles.empty, className)} {...props} />;
+};
+
+CommandEmpty.displayName = 'Command.Empty';

--- a/packages/raystack/components/command/command-input.tsx
+++ b/packages/raystack/components/command/command-input.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Autocomplete as AutocompletePrimitive } from '@base-ui/react/autocomplete';
-import { MagnifyingGlassIcon } from '@radix-ui/react-icons';
 import { type ComponentProps, type ReactNode } from 'react';
 import { InputField } from '../input-field';
 import styles from './command.module.css';
@@ -12,7 +11,7 @@ export interface CommandInputProps
     ComponentProps<typeof InputField>,
     'trailingIcon' | 'chips' | 'maxChipsVisible' | 'variant'
   > {
-  /** Icon rendered at the start of the input. Defaults to a magnifying glass. */
+  /** Icon rendered at the start of the input. */
   leadingIcon?: ReactNode;
 }
 
@@ -32,15 +31,7 @@ export const CommandInput = ({
         render={
           <InputField
             containerRef={inputContainerRef}
-            leadingIcon={
-              leadingIcon ?? (
-                <MagnifyingGlassIcon
-                  className={styles.inputIcon}
-                  width={16}
-                  height={16}
-                />
-              )
-            }
+            leadingIcon={leadingIcon}
             variant='borderless'
             size={size}
             autoFocus={autoFocus}

--- a/packages/raystack/components/command/command-input.tsx
+++ b/packages/raystack/components/command/command-input.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { Autocomplete as AutocompletePrimitive } from '@base-ui/react/autocomplete';
+import { MagnifyingGlassIcon } from '@radix-ui/react-icons';
+import { type ComponentProps, type ReactNode } from 'react';
+import { InputField } from '../input-field';
+import styles from './command.module.css';
+import { useCommandContext } from './command-root';
+
+export interface CommandInputProps
+  extends Omit<
+    ComponentProps<typeof InputField>,
+    'trailingIcon' | 'chips' | 'maxChipsVisible' | 'variant'
+  > {
+  /** Icon rendered at the start of the input. Defaults to a magnifying glass. */
+  leadingIcon?: ReactNode;
+}
+
+export const CommandInput = ({
+  ref,
+  leadingIcon,
+  autoFocus = true,
+  size = 'large',
+  placeholder = 'Search...',
+  ...props
+}: CommandInputProps) => {
+  const { inputContainerRef } = useCommandContext();
+  return (
+    <div className={styles.inputWrapper}>
+      <AutocompletePrimitive.Input
+        ref={ref}
+        render={
+          <InputField
+            containerRef={inputContainerRef}
+            leadingIcon={
+              leadingIcon ?? (
+                <MagnifyingGlassIcon
+                  className={styles.inputIcon}
+                  width={16}
+                  height={16}
+                />
+              )
+            }
+            variant='borderless'
+            size={size}
+            autoFocus={autoFocus}
+            placeholder={placeholder}
+            {...props}
+          />
+        }
+      />
+    </div>
+  );
+};
+
+CommandInput.displayName = 'Command.Input';

--- a/packages/raystack/components/command/command-item.tsx
+++ b/packages/raystack/components/command/command-item.tsx
@@ -10,6 +10,8 @@ import { useCommandContext } from './command-root';
 export interface CommandItemProps extends AutocompletePrimitive.Item.Props {
   /** Icon rendered at the start of the item. */
   leadingIcon?: ReactNode;
+  /** Node rendered at the end of the item (e.g. `Command.Shortcut`). */
+  trailingIcon?: ReactNode;
 }
 
 export const CommandItem = ({
@@ -17,6 +19,7 @@ export const CommandItem = ({
   children,
   value: providedValue,
   leadingIcon,
+  trailingIcon,
   ...props
 }: CommandItemProps) => {
   const value =
@@ -44,7 +47,10 @@ export const CommandItem = ({
       {...props}
     >
       {leadingIcon && <span className={styles.itemIcon}>{leadingIcon}</span>}
-      {children}
+      <span className={styles.itemLabel}>{children}</span>
+      {trailingIcon && (
+        <span className={styles.itemTrailing}>{trailingIcon}</span>
+      )}
     </AutocompletePrimitive.Item>
   );
 };

--- a/packages/raystack/components/command/command-item.tsx
+++ b/packages/raystack/components/command/command-item.tsx
@@ -10,7 +10,7 @@ import { useCommandContext } from './command-root';
 export interface CommandItemProps extends AutocompletePrimitive.Item.Props {
   /** Icon rendered at the start of the item. */
   leadingIcon?: ReactNode;
-  /** Node rendered at the end of the item (e.g. `Command.Shortcut`). */
+  /** Icon rendered at the end of the item (e.g. `Command.Shortcut`). */
   trailingIcon?: ReactNode;
 }
 
@@ -20,6 +20,7 @@ export const CommandItem = ({
   value: providedValue,
   leadingIcon,
   trailingIcon,
+  disabled,
   ...props
 }: CommandItemProps) => {
   const value =
@@ -40,17 +41,40 @@ export const CommandItem = ({
     if (!isMatched) return null;
   }
 
+  const content = (
+    <>
+      {leadingIcon && <span className={styles.itemIcon}>{leadingIcon}</span>}
+      <span className={styles.itemLabel}>{children}</span>
+      {trailingIcon && (
+        <span className={styles.itemTrailing}>{trailingIcon}</span>
+      )}
+    </>
+  );
+
+  /**
+   * TODO: Fix this when Base UI fixes this issue
+   * This is a workaround to prevent item focus when the disabled prop is true.
+   */
+  if (disabled) {
+    return (
+      <div
+        className={cx(styles.item, className)}
+        role='option'
+        data-disabled={true}
+        aria-disabled={true}
+      >
+        {content}
+      </div>
+    );
+  }
+
   return (
     <AutocompletePrimitive.Item
       value={value}
       className={cx(styles.item, className)}
       {...props}
     >
-      {leadingIcon && <span className={styles.itemIcon}>{leadingIcon}</span>}
-      <span className={styles.itemLabel}>{children}</span>
-      {trailingIcon && (
-        <span className={styles.itemTrailing}>{trailingIcon}</span>
-      )}
+      {content}
     </AutocompletePrimitive.Item>
   );
 };

--- a/packages/raystack/components/command/command-item.tsx
+++ b/packages/raystack/components/command/command-item.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { Autocomplete as AutocompletePrimitive } from '@base-ui/react/autocomplete';
+import { cx } from 'class-variance-authority';
+import { type ReactNode } from 'react';
+import { getMatch } from '../menu/utils';
+import styles from './command.module.css';
+import { useCommandContext } from './command-root';
+
+export interface CommandItemProps extends AutocompletePrimitive.Item.Props {
+  /** Icon rendered at the start of the item. */
+  leadingIcon?: ReactNode;
+}
+
+export const CommandItem = ({
+  className,
+  children,
+  value: providedValue,
+  leadingIcon,
+  ...props
+}: CommandItemProps) => {
+  const value =
+    providedValue !== undefined
+      ? providedValue
+      : typeof children === 'string'
+        ? children
+        : undefined;
+
+  const { inputValue, hasItems } = useCommandContext();
+
+  if (!hasItems && inputValue?.length) {
+    const isMatched = getMatch(
+      typeof value === 'string' ? value : undefined,
+      children,
+      inputValue
+    );
+    if (!isMatched) return null;
+  }
+
+  return (
+    <AutocompletePrimitive.Item
+      value={value}
+      className={cx(styles.item, className)}
+      {...props}
+    >
+      {leadingIcon && <span className={styles.itemIcon}>{leadingIcon}</span>}
+      {children}
+    </AutocompletePrimitive.Item>
+  );
+};
+
+CommandItem.displayName = 'Command.Item';

--- a/packages/raystack/components/command/command-list.tsx
+++ b/packages/raystack/components/command/command-list.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { Autocomplete as AutocompletePrimitive } from '@base-ui/react/autocomplete';
+import { cx } from 'class-variance-authority';
+import styles from './command.module.css';
+
+export type CommandListProps = AutocompletePrimitive.List.Props;
+
+export const CommandList = ({
+  ref,
+  className,
+  ...props
+}: CommandListProps & { ref?: React.Ref<HTMLDivElement> }) => {
+  return (
+    <AutocompletePrimitive.List
+      ref={ref}
+      className={cx(styles.list, className)}
+      {...props}
+    />
+  );
+};
+
+CommandList.displayName = 'Command.List';

--- a/packages/raystack/components/command/command-misc.tsx
+++ b/packages/raystack/components/command/command-misc.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { Autocomplete as AutocompletePrimitive } from '@base-ui/react/autocomplete';
+import { cx } from 'class-variance-authority';
+import { type ComponentProps } from 'react';
+import styles from './command.module.css';
+import { useCommandContext } from './command-root';
+
+export type CommandGroupProps = AutocompletePrimitive.Group.Props;
+
+export const CommandGroup = ({
+  className,
+  children,
+  ...props
+}: CommandGroupProps) => {
+  const { inputValue, hasItems } = useCommandContext();
+  if (!hasItems && inputValue?.length) return <>{children}</>;
+
+  return (
+    <AutocompletePrimitive.Group
+      className={cx(styles.group, className)}
+      {...props}
+    >
+      {children}
+    </AutocompletePrimitive.Group>
+  );
+};
+CommandGroup.displayName = 'Command.Group';
+
+export type CommandLabelProps = AutocompletePrimitive.GroupLabel.Props;
+
+export const CommandLabel = ({ className, ...props }: CommandLabelProps) => {
+  const { inputValue, hasItems } = useCommandContext();
+  if (!hasItems && inputValue?.length) return null;
+
+  return (
+    <AutocompletePrimitive.GroupLabel
+      className={cx(styles.label, className)}
+      {...props}
+    />
+  );
+};
+CommandLabel.displayName = 'Command.Label';
+
+export type CommandSeparatorProps = AutocompletePrimitive.Separator.Props;
+
+export const CommandSeparator = ({
+  className,
+  ...props
+}: CommandSeparatorProps) => {
+  const { inputValue, hasItems } = useCommandContext();
+  if (!hasItems && inputValue?.length) return null;
+
+  return (
+    <AutocompletePrimitive.Separator
+      className={cx(styles.separator, className)}
+      {...props}
+    />
+  );
+};
+CommandSeparator.displayName = 'Command.Separator';
+
+export type CommandShortcutProps = ComponentProps<'kbd'>;
+
+export const CommandShortcut = ({
+  className,
+  ...props
+}: CommandShortcutProps) => (
+  <kbd className={cx(styles.shortcut, className)} {...props} />
+);
+CommandShortcut.displayName = 'Command.Shortcut';
+
+export type CommandFooterProps = ComponentProps<'div'>;
+
+export const CommandFooter = ({ className, ...props }: CommandFooterProps) => (
+  <div className={cx(styles.footer, className)} {...props} />
+);
+CommandFooter.displayName = 'Command.Footer';
+
+export type CommandPanelProps = ComponentProps<'div'>;
+
+export const CommandPanel = ({ className, ...props }: CommandPanelProps) => (
+  <div className={cx(styles.panel, className)} {...props} />
+);
+CommandPanel.displayName = 'Command.Panel';
+
+export const CommandCollection = AutocompletePrimitive.Collection;

--- a/packages/raystack/components/command/command-misc.tsx
+++ b/packages/raystack/components/command/command-misc.tsx
@@ -60,28 +60,28 @@ export const CommandSeparator = ({
 };
 CommandSeparator.displayName = 'Command.Separator';
 
-export type CommandShortcutProps = ComponentProps<'kbd'>;
+export type CommandShortcutProps = ComponentProps<'span'>;
 
 export const CommandShortcut = ({
   className,
+  children,
   ...props
-}: CommandShortcutProps) => (
-  <kbd className={cx(styles.shortcut, className)} {...props} />
-);
+}: CommandShortcutProps) => {
+  const keys =
+    typeof children === 'string'
+      ? children.trim().split(/\s+/).filter(Boolean)
+      : Array.isArray(children)
+        ? children
+        : [children];
+
+  return (
+    <span className={cx(styles.shortcut, className)} {...props}>
+      {keys.map((key, index) => (
+        <kbd key={index} className={styles.shortcutKey}>
+          {key}
+        </kbd>
+      ))}
+    </span>
+  );
+};
 CommandShortcut.displayName = 'Command.Shortcut';
-
-export type CommandFooterProps = ComponentProps<'div'>;
-
-export const CommandFooter = ({ className, ...props }: CommandFooterProps) => (
-  <div className={cx(styles.footer, className)} {...props} />
-);
-CommandFooter.displayName = 'Command.Footer';
-
-export type CommandPanelProps = ComponentProps<'div'>;
-
-export const CommandPanel = ({ className, ...props }: CommandPanelProps) => (
-  <div className={cx(styles.panel, className)} {...props} />
-);
-CommandPanel.displayName = 'Command.Panel';
-
-export const CommandCollection = AutocompletePrimitive.Collection;

--- a/packages/raystack/components/command/command-root.tsx
+++ b/packages/raystack/components/command/command-root.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { Autocomplete as AutocompletePrimitive } from '@base-ui/react/autocomplete';
+import {
+  createContext,
+  type RefObject,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
+
+interface CommandContextValue {
+  inputValue: string;
+  hasItems: boolean;
+  inputContainerRef: RefObject<HTMLDivElement | null>;
+}
+
+const CommandContext = createContext<CommandContextValue | undefined>(
+  undefined
+);
+
+export const useCommandContext = (): CommandContextValue => {
+  const context = useContext(CommandContext);
+  if (!context) {
+    throw new Error('useCommandContext must be used within a Command');
+  }
+  return context;
+};
+
+export interface CommandRootProps
+  extends Omit<AutocompletePrimitive.Root.Props<any>, 'items'> {
+  /**
+   * Items to be displayed and filtered by Base UI internally.
+   * When provided, the auto-search fallback is disabled and filtering is
+   * delegated to Base UI's built-in logic (or the user's custom `filter`).
+   */
+  items?: readonly any[];
+}
+
+export const CommandRoot = ({
+  value: providedValue,
+  defaultValue,
+  onValueChange,
+  items,
+  inline = true,
+  open = true,
+  autoHighlight = 'always',
+  keepHighlight = true,
+  children,
+  ...props
+}: CommandRootProps) => {
+  const [internalValue, setInternalValue] = useState<string>(
+    typeof defaultValue === 'string' ? defaultValue : ''
+  );
+  const inputContainerRef = useRef<HTMLDivElement>(null);
+
+  const computedValue =
+    typeof providedValue === 'string' ? providedValue : internalValue;
+
+  const handleValueChange = useCallback(
+    (
+      value: string,
+      eventDetails: AutocompletePrimitive.Root.ChangeEventDetails
+    ) => {
+      setInternalValue(value);
+      onValueChange?.(value, eventDetails);
+    },
+    [onValueChange]
+  );
+
+  const contextValue = useMemo(
+    () => ({
+      inputValue: computedValue,
+      hasItems: !!items,
+      inputContainerRef
+    }),
+    [computedValue, items]
+  );
+
+  return (
+    <CommandContext.Provider value={contextValue}>
+      <AutocompletePrimitive.Root
+        inline={inline}
+        open={open}
+        autoHighlight={autoHighlight}
+        keepHighlight={keepHighlight}
+        value={providedValue}
+        defaultValue={defaultValue}
+        onValueChange={handleValueChange}
+        items={items}
+        {...props}
+      >
+        {children}
+      </AutocompletePrimitive.Root>
+    </CommandContext.Provider>
+  );
+};
+
+CommandRoot.displayName = 'Command';

--- a/packages/raystack/components/command/command-root.tsx
+++ b/packages/raystack/components/command/command-root.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Autocomplete as AutocompletePrimitive } from '@base-ui/react/autocomplete';
+import { cx } from 'class-variance-authority';
 import {
   createContext,
   type RefObject,
@@ -10,6 +11,7 @@ import {
   useRef,
   useState
 } from 'react';
+import styles from './command.module.css';
 
 interface CommandContextValue {
   inputValue: string;
@@ -37,6 +39,8 @@ export interface CommandRootProps
    * delegated to Base UI's built-in logic (or the user's custom `filter`).
    */
   items?: readonly any[];
+  /** Additional CSS class for the panel wrapper. */
+  className?: string;
 }
 
 export const CommandRoot = ({
@@ -48,6 +52,7 @@ export const CommandRoot = ({
   open = true,
   autoHighlight = 'always',
   keepHighlight = true,
+  className,
   children,
   ...props
 }: CommandRootProps) => {
@@ -92,7 +97,7 @@ export const CommandRoot = ({
         items={items}
         {...props}
       >
-        {children}
+        <div className={cx(styles.panel, className)}>{children}</div>
       </AutocompletePrimitive.Root>
     </CommandContext.Provider>
   );

--- a/packages/raystack/components/command/command.module.css
+++ b/packages/raystack/components/command/command.module.css
@@ -168,7 +168,7 @@
 }
 
 .backdropBlur {
-  backdrop-filter: blur(var(--rs-space-2));
+  backdrop-filter: var(--rs-blur-lg);
 }
 
 .backdrop[data-starting-style],

--- a/packages/raystack/components/command/command.module.css
+++ b/packages/raystack/components/command/command.module.css
@@ -1,74 +1,197 @@
-.command {
+.panel {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  height: 100%;
+  isolation: isolate;
   width: 100%;
-  border-radius: var(--rs-radius-4);
+  border-radius: var(--rs-radius-2);
   background-color: var(--rs-color-background-base-primary);
   box-shadow: var(--rs-shadow-floating);
-  border: 1px solid var(--rs-color-border-base-secondary);
 }
 
 .inputWrapper {
-  padding: 0 var(--rs-space-4);
-  border-bottom: 1px solid var(--rs-color-border-base-secondary);
+  display: flex;
+  flex-direction: column;
+  padding: var(--rs-space-2);
+  background-color: var(--rs-color-background-base-primary);
 }
 
 .inputIcon {
-  opacity: 0.5;
-}
-
-.input {
-  display: flex;
-  padding: var(--rs-space-4) 0;
-  background-color: transparent;
-  font-size: var(--rs-font-size-small);
-  line-height: var(--rs-line-height-mini);
-  width: 100%;
-  border-radius: var(--rs-radius-2);
-  outline: none;
-  border: none;
-  color: var(--rs-color-foreground-base-primary);
-}
-
-.input::placeholder {
-  color: var(--rs-color-foreground-base-primary);
+  color: var(--rs-color-foreground-base-tertiary);
+  flex-shrink: 0;
 }
 
 .list {
+  display: flex;
+  flex-direction: column;
   overflow-y: auto;
   overflow-x: hidden;
-  max-height: 300px;
+  max-height: 320px;
+  padding: 0 var(--rs-space-2);
 }
 
-.empty {
-  font-size: var(--rs-font-size-micro);
-  line-height: var(--rs-line-height-mini);
-  padding: 30px 0;
-  text-align: center;
+/* Flat items (no groups) — apply section-like vertical padding & gap. */
+.list:not(:has(.group)) {
+  padding: var(--rs-space-3) var(--rs-space-2);
+  gap: var(--rs-space-1);
 }
 
-.group {
-  padding: var(--rs-space-2);
-}
-.group [cmdk-group-heading] {
-  font-size: var(--rs-font-size-micro);
-  line-height: var(--rs-line-height-mini);
-  color: var(--rs-color-foreground-base-primary);
-  padding: var(--rs-space-2) var(--rs-space-3);
+.list:empty {
+  padding: 0;
 }
 
 .item {
+  display: flex;
+  align-items: center;
+  gap: var(--rs-space-3);
+  padding: var(--rs-space-3);
+  font-family: var(--rs-font-body);
   font-size: var(--rs-font-size-small);
-  line-height: var(--rs-line-height-mini);
-  padding: var(--rs-space-2) var(--rs-space-3);
+  line-height: var(--rs-line-height-small);
+  letter-spacing: var(--rs-letter-spacing-small);
+  color: var(--rs-color-foreground-base-primary);
+  background-color: var(--rs-color-background-base-primary);
+  border-radius: var(--rs-radius-2);
+  cursor: pointer;
+  outline: none;
+  user-select: none;
+  scroll-margin-block: var(--rs-space-2);
 }
 
-.item:hover {
+.item[data-highlighted] {
   background-color: var(--rs-color-background-base-primary-hover);
 }
 
+.item[data-disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.itemIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--rs-color-foreground-base-secondary);
+}
+
+.itemIcon svg {
+  width: var(--rs-space-5);
+  height: var(--rs-space-5);
+}
+
+.empty {
+  padding: var(--rs-space-7) var(--rs-space-3);
+  text-align: center;
+  font-family: var(--rs-font-body);
+  font-size: var(--rs-font-size-small);
+  line-height: var(--rs-line-height-small);
+  color: var(--rs-color-foreground-base-secondary);
+}
+
+.list:has([role='option']) .empty {
+  display: none;
+}
+
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--rs-space-1);
+  padding: var(--rs-space-3) 0;
+}
+
+.label {
+  display: flex;
+  align-items: center;
+  padding: var(--rs-space-2) var(--rs-space-3);
+  font-family: var(--rs-font-body);
+  font-size: var(--rs-font-size-micro);
+  font-weight: var(--rs-font-weight-regular);
+  line-height: var(--rs-line-height-micro);
+  letter-spacing: var(--rs-letter-spacing-micro);
+  color: var(--rs-color-foreground-base-tertiary);
+}
+
 .separator {
-  border-bottom: 1px solid var(--rs-color-border-base-secondary);
+  height: 1px;
+  margin-block: var(--rs-space-1);
+  background-color: var(--rs-color-border-base-primary);
+}
+
+.shortcut {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--rs-space-1);
+  margin-left: auto;
+  font-family: var(--rs-font-body);
+  font-weight: var(--rs-font-weight-regular);
+  font-size: var(--rs-font-size-micro);
+  line-height: var(--rs-line-height-micro);
+  letter-spacing: var(--rs-letter-spacing-micro);
+  color: var(--rs-color-foreground-base-tertiary);
+  white-space: nowrap;
+  text-align: right;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--rs-space-2);
+  padding: var(--rs-space-3) var(--rs-space-5);
+  border-top: 1px solid var(--rs-color-border-base-secondary);
+  font-size: var(--rs-font-size-micro);
+  color: var(--rs-color-foreground-base-secondary);
+}
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: var(--rs-z-index-portal);
+  background-color: rgb(0 0 0 / 0.32);
+  backdrop-filter: blur(4px);
+  transition:
+    opacity 200ms ease-out,
+    backdrop-filter 200ms ease-out;
+}
+
+.backdrop[data-starting-style],
+.backdrop[data-ending-style] {
+  opacity: 0;
+}
+
+.viewport {
+  position: fixed;
+  inset: 0;
+  z-index: var(--rs-z-index-portal);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: max(var(--rs-space-4), 10vh) var(--rs-space-4) var(--rs-space-4);
+  pointer-events: none;
+}
+
+.dialogPopup {
+  pointer-events: auto;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 400px;
+  max-height: min(420px, 80vh);
+  min-height: 0;
+  background-color: var(--rs-color-background-base-primary);
+  border-radius: var(--rs-radius-2);
+  box-shadow: var(--rs-shadow-floating);
+  overflow: hidden;
+  outline: none;
+  isolation: isolate;
+  transition:
+    opacity 200ms ease-out,
+    transform 200ms ease-out;
+}
+
+.dialogPopup[data-starting-style],
+.dialogPopup[data-ending-style] {
+  opacity: 0;
+  transform: scale(0.98);
 }

--- a/packages/raystack/components/command/command.module.css
+++ b/packages/raystack/components/command/command.module.css
@@ -161,7 +161,7 @@
   position: fixed;
   inset: 0;
   z-index: var(--rs-z-index-portal);
-  background-color: rgb(0 0 0 / 0.32);
+  background-color: var(--rs-color-overlay-base-primary);
   transition:
     opacity 200ms ease-out,
     backdrop-filter 200ms ease-out;

--- a/packages/raystack/components/command/command.module.css
+++ b/packages/raystack/components/command/command.module.css
@@ -4,9 +4,7 @@
   overflow: hidden;
   isolation: isolate;
   width: 100%;
-  border-radius: var(--rs-radius-2);
   background-color: var(--rs-color-background-base-primary);
-  box-shadow: var(--rs-shadow-floating);
 }
 
 .inputWrapper {
@@ -14,11 +12,6 @@
   flex-direction: column;
   padding: var(--rs-space-2);
   background-color: var(--rs-color-background-base-primary);
-}
-
-.inputIcon {
-  color: var(--rs-color-foreground-base-tertiary);
-  flex-shrink: 0;
 }
 
 .list {
@@ -89,7 +82,7 @@
   color: var(--rs-color-foreground-base-secondary);
 }
 
-.list:has([role='option']) .empty {
+.list:has([role="option"]) .empty {
   display: none;
 }
 

--- a/packages/raystack/components/command/command.module.css
+++ b/packages/raystack/components/command/command.module.css
@@ -14,6 +14,11 @@
   background-color: var(--rs-color-background-base-primary);
 }
 
+.inputWrapper > *:hover,
+.inputWrapper > *:focus-within {
+  background: var(--rs-color-background-base-primary);
+}
+
 .list {
   display: flex;
   flex-direction: column;
@@ -73,6 +78,47 @@
   height: var(--rs-space-5);
 }
 
+.itemLabel {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.itemTrailing {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  margin-left: auto;
+  color: var(--rs-color-foreground-base-tertiary);
+}
+
+.itemTrailing svg {
+  width: var(--rs-space-5);
+  height: var(--rs-space-5);
+}
+
+.shortcut {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--rs-space-1);
+  white-space: nowrap;
+  font-family: var(--rs-font-body);
+  font-weight: var(--rs-font-weight-regular);
+  font-size: var(--rs-font-size-micro);
+  line-height: var(--rs-line-height-micro);
+  letter-spacing: var(--rs-letter-spacing-micro);
+  color: var(--rs-color-foreground-base-tertiary);
+}
+
+.shortcutKey {
+  font: inherit;
+  color: inherit;
+}
+
 .empty {
   padding: var(--rs-space-7) var(--rs-space-3);
   text-align: center;
@@ -111,41 +157,18 @@
   background-color: var(--rs-color-border-base-primary);
 }
 
-.shortcut {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--rs-space-1);
-  margin-left: auto;
-  font-family: var(--rs-font-body);
-  font-weight: var(--rs-font-weight-regular);
-  font-size: var(--rs-font-size-micro);
-  line-height: var(--rs-line-height-micro);
-  letter-spacing: var(--rs-letter-spacing-micro);
-  color: var(--rs-color-foreground-base-tertiary);
-  white-space: nowrap;
-  text-align: right;
-}
-
-.footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--rs-space-2);
-  padding: var(--rs-space-3) var(--rs-space-5);
-  border-top: 1px solid var(--rs-color-border-base-secondary);
-  font-size: var(--rs-font-size-micro);
-  color: var(--rs-color-foreground-base-secondary);
-}
-
 .backdrop {
   position: fixed;
   inset: 0;
   z-index: var(--rs-z-index-portal);
   background-color: rgb(0 0 0 / 0.32);
-  backdrop-filter: blur(4px);
   transition:
     opacity 200ms ease-out,
     backdrop-filter 200ms ease-out;
+}
+
+.backdropBlur {
+  backdrop-filter: blur(var(--rs-space-2));
 }
 
 .backdrop[data-starting-style],
@@ -160,7 +183,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: max(var(--rs-space-4), 10vh) var(--rs-space-4) var(--rs-space-4);
+  justify-content: center;
+  padding: var(--rs-space-4);
   pointer-events: none;
 }
 
@@ -169,7 +193,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  max-width: 400px;
+  max-width: 540px;
   max-height: min(420px, 80vh);
   min-height: 0;
   background-color: var(--rs-color-background-base-primary);

--- a/packages/raystack/components/command/command.tsx
+++ b/packages/raystack/components/command/command.tsx
@@ -1,126 +1,45 @@
-'use client';
+import {
+  CommandDialogClose,
+  CommandDialogContent,
+  CommandDialogDescription,
+  CommandDialogRoot,
+  CommandDialogTitle,
+  CommandDialogTrigger
+} from './command-dialog';
+import { CommandEmpty } from './command-empty';
+import { CommandInput } from './command-input';
+import { CommandItem } from './command-item';
+import { CommandList } from './command-list';
+import {
+  CommandCollection,
+  CommandFooter,
+  CommandGroup,
+  CommandLabel,
+  CommandPanel,
+  CommandSeparator,
+  CommandShortcut
+} from './command-misc';
+import { CommandRoot } from './command-root';
 
-import { Dialog as DialogPrimitive } from '@base-ui/react';
-import { MagnifyingGlassIcon } from '@radix-ui/react-icons';
-import { cva } from 'class-variance-authority';
-import { Command as CommandPrimitive } from 'cmdk';
-import { type ComponentProps, ReactNode } from 'react';
-
-import { Dialog } from '../dialog';
-import { Flex } from '../flex';
-import styles from './command.module.css';
-
-const command = cva(styles.command);
-function CommandRoot({
-  className,
-  ...props
-}: ComponentProps<typeof CommandPrimitive>) {
-  return <CommandPrimitive className={command({ className })} {...props} />;
-}
-CommandRoot.displayName = 'Command';
-
-interface CommandDialogProps extends DialogPrimitive.Root.Props {
-  children: ReactNode;
-}
-
-const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
-  return (
-    <Dialog {...props}>
-      <Dialog.Content style={{ overflow: 'hidden', padding: '0' }}>
-        <Command className={styles.dialogcommand}>{children}</Command>
-      </Dialog.Content>
-    </Dialog>
-  );
-};
-CommandDialog.displayName = 'Command.Dialog';
-
-const input = cva(styles.input);
-function CommandInput({
-  className,
-  ...props
-}: ComponentProps<typeof CommandPrimitive.Input>) {
-  return (
-    <Flex
-      align='center'
-      gap='small'
-      cmdk-input-wrapper=''
-      className={styles.inputWrapper}
-    >
-      <MagnifyingGlassIcon
-        className={styles.inputIcon}
-        width={16}
-        height={16}
-      />
-      <CommandPrimitive.Input className={input({ className })} {...props} />
-    </Flex>
-  );
-}
-
-CommandInput.displayName = 'Command.Input';
-
-const list = cva(styles.list);
-function CommandList({
-  className,
-  ...props
-}: ComponentProps<typeof CommandPrimitive.List>) {
-  return <CommandPrimitive.List className={list({ className })} {...props} />;
-}
-
-CommandList.displayName = 'Command.List';
-
-function CommandEmpty(props: ComponentProps<typeof CommandPrimitive.Empty>) {
-  return <CommandPrimitive.Empty className={styles.empty} {...props} />;
-}
-
-CommandEmpty.displayName = 'Command.Empty';
-
-const group = cva(styles.group);
-function CommandGroup({
-  className,
-  ...props
-}: ComponentProps<typeof CommandPrimitive.Group>) {
-  return <CommandPrimitive.Group className={group({ className })} {...props} />;
-}
-
-CommandGroup.displayName = 'Command.Group';
-
-const separator = cva(styles.separator);
-function CommandSeparator({
-  className,
-  ...props
-}: ComponentProps<typeof CommandPrimitive.Separator>) {
-  return (
-    <CommandPrimitive.Separator
-      className={separator({ className })}
-      {...props}
-    />
-  );
-}
-CommandSeparator.displayName = 'Command.Separator';
-
-const item = cva(styles.item);
-function CommandItem({
-  className,
-  ...props
-}: ComponentProps<typeof CommandPrimitive.Item>) {
-  return <CommandPrimitive.Item className={item({ className })} {...props} />;
-}
-
-CommandItem.displayName = 'Command.Item';
-
-const shortcut = cva(styles.shortcut);
-const CommandShortcut = ({ className, ...props }: ComponentProps<'span'>) => {
-  return <span className={shortcut({ className })} {...props} />;
-};
-CommandShortcut.displayName = 'Command.Shortcut';
+const CommandDialog = Object.assign(CommandDialogRoot, {
+  Trigger: CommandDialogTrigger,
+  Content: CommandDialogContent,
+  Close: CommandDialogClose,
+  Title: CommandDialogTitle,
+  Description: CommandDialogDescription
+});
 
 export const Command = Object.assign(CommandRoot, {
-  Dialog: CommandDialog,
   Input: CommandInput,
   List: CommandList,
+  Item: CommandItem,
   Empty: CommandEmpty,
   Group: CommandGroup,
-  Item: CommandItem,
+  Label: CommandLabel,
+  Separator: CommandSeparator,
   Shortcut: CommandShortcut,
-  Separator: CommandSeparator
+  Footer: CommandFooter,
+  Panel: CommandPanel,
+  Collection: CommandCollection,
+  Dialog: CommandDialog
 });

--- a/packages/raystack/components/command/command.tsx
+++ b/packages/raystack/components/command/command.tsx
@@ -1,45 +1,30 @@
+import { CommandContent } from './command-content';
 import {
-  CommandDialogClose,
+  CommandDialog,
   CommandDialogContent,
-  CommandDialogDescription,
-  CommandDialogRoot,
-  CommandDialogTitle,
   CommandDialogTrigger
 } from './command-dialog';
 import { CommandEmpty } from './command-empty';
 import { CommandInput } from './command-input';
 import { CommandItem } from './command-item';
-import { CommandList } from './command-list';
 import {
-  CommandCollection,
-  CommandFooter,
   CommandGroup,
   CommandLabel,
-  CommandPanel,
   CommandSeparator,
   CommandShortcut
 } from './command-misc';
 import { CommandRoot } from './command-root';
 
-const CommandDialog = Object.assign(CommandDialogRoot, {
-  Trigger: CommandDialogTrigger,
-  Content: CommandDialogContent,
-  Close: CommandDialogClose,
-  Title: CommandDialogTitle,
-  Description: CommandDialogDescription
-});
-
 export const Command = Object.assign(CommandRoot, {
   Input: CommandInput,
-  List: CommandList,
+  Content: CommandContent,
   Item: CommandItem,
   Empty: CommandEmpty,
   Group: CommandGroup,
   Label: CommandLabel,
   Separator: CommandSeparator,
   Shortcut: CommandShortcut,
-  Footer: CommandFooter,
-  Panel: CommandPanel,
-  Collection: CommandCollection,
-  Dialog: CommandDialog
+  Dialog: CommandDialog,
+  DialogTrigger: CommandDialogTrigger,
+  DialogContent: CommandDialogContent
 });


### PR DESCRIPTION
## Summary

- Migrated Command component from `cmdk` to the Base UI Autocomplete primitive with built-in auto-search filtering
- Split monolithic `command.tsx` into dedicated subcomponent files (`command-root`, `command-input`, `command-list`, `command-item`, `command-dialog`, `command-empty`, `command-misc`)
- Added new subcomponents: `Panel`, `Footer`, `Label`, `Collection`, and a composable `Dialog` API (`Dialog.Trigger`, `Dialog.Content`, `Dialog.Close`, `Dialog.Title`, `Dialog.Description`)
- Expanded tests, documentation (API reference, usage examples), demos, and playground examples for the new API surface
- Updated CSS module with styles for all new subcomponents and refined existing styles