### PR TITLE
fix: add nativeButton prop to Popover.Trigger in DatePicker and RangePicker

### DIFF
--- a/packages/raystack/components/calendar/date-picker.tsx
+++ b/packages/raystack/components/calendar/date-picker.tsx
@@ -200,6 +200,7 @@ export function DatePicker({
   return (
     <Popover open={showCalendar} onOpenChange={onOpenChange}>
       <Popover.Trigger
+        nativeButton={isValidElement(trigger) ? false : true}
         render={isValidElement(trigger) ? trigger : <button>{trigger}</button>}
       />
       <Popover.Content

--- a/packages/raystack/components/calendar/range-picker.tsx
+++ b/packages/raystack/components/calendar/range-picker.tsx
@@ -168,6 +168,7 @@ export function RangePicker({
   return (
     <Popover open={showCalendar} onOpenChange={setShowCalendar}>
       <Popover.Trigger
+        nativeButton={isValidElement(trigger) ? false : true}
         render={isValidElement(trigger) ? trigger : <button>{trigger}</button>}
       />
       <Popover.Content


### PR DESCRIPTION
## Summary

- Added `nativeButton` prop to `Popover.Trigger` in `DatePicker` component
- Added `nativeButton` prop to `Popover.Trigger` in `RangePicker` component
- Ensures the trigger renders as a native button element for proper accessibility and event handling