### PR TITLE
fix: add /index.js to dayjs ESM import remap

### DIFF
--- a/packages/raystack/rollup.config.mjs
+++ b/packages/raystack/rollup.config.mjs
@@ -102,9 +102,9 @@ const rollupConfig = configs.map(conf => {
         preserveModules: true,
         preserveModulesRoot: conf.inputPath,
         paths: id => {
-          if (id === 'dayjs') return 'dayjs/esm';
+          if (id === 'dayjs') return 'dayjs/esm/index.js';
           if (id.startsWith('dayjs/plugin/'))
-            return id.replace('dayjs/plugin/', 'dayjs/esm/plugin/');
+            return `${id.replace('dayjs/plugin/', 'dayjs/esm/plugin/')}/index.js`;
           return id;
         }
       },


### PR DESCRIPTION
## Summary
- Rollup output `paths` rewrites `dayjs` / `dayjs/plugin/*` → `dayjs/esm*` in ESM builds, but emitted bare paths like `dayjs/esm/plugin/customParseFormat` without extension.
- `dayjs` has no `exports` map for esm subpaths, and plugin paths are directories (`customParseFormat/index.js`). Strict ESM resolvers (Node `nodenext`, host apps with `"type": "module"`) fail to resolve directory imports without an explicit path.
- Append `/index.js` in the remap so output references the actual file. Works in Bun, Node strict ESM, Vite SSR, and bundlers alike.

## Test plan
- [x] `pnpm build` — ESM dist imports resolve to `dayjs/esm/index.js` and `dayjs/esm/plugin/<name>/index.js`
- [x] CJS dist unchanged (`require('dayjs')`, `require('dayjs/plugin/<name>')`)
- [x] `pnpm test` — 1663/1663 pass
- [ ] Verify consumer host app with `"type": "module"` (Bun/Next) imports DatePicker/RangePicker/DataTable date filters without resolution errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)