### PR TITLE
fix(data-table): guard undefined defaultSort in hasActiveQuery

### DIFF
--- a/packages/raystack/components/data-table/data-table.types.tsx
+++ b/packages/raystack/components/data-table/data-table.types.tsx
@@ -110,7 +110,7 @@ export interface DataTableProps<TData, TValue> {
   totalRowCount?: number;
   loadingRowCount?: number;
   onTableQueryChange?: (query: DataTableQuery) => void;
-  defaultSort: DataTableSort;
+  defaultSort?: DataTableSort;
   onLoadMore?: () => Promise<void>;
   onRowClick?: (row: TData) => void;
   onColumnVisibilityChange?: (columnVisibility: VisibilityState) => void;

--- a/packages/raystack/components/data-table/utils/index.tsx
+++ b/packages/raystack/components/data-table/utils/index.tsx
@@ -117,7 +117,7 @@ const generateFilterMap = (
 };
 
 const generateSortMap = (sort: DataTableSort[] = []): Map<string, string> => {
-  return new Map(sort.map(({ name, order }) => [name, order]));
+  return new Map(sort.filter(Boolean).map(({ name, order }) => [name, order]));
 };
 
 const isFilterChanged = (
@@ -173,7 +173,10 @@ export const hasActiveQuery = (
   const hasSearch = Boolean(
     tableQuery?.search && tableQuery.search.trim() !== ''
   );
-  const sortChanged = isSortChanged([defaultSort], tableQuery.sort || []);
+  const sortChanged = isSortChanged(
+    defaultSort ? [defaultSort] : [],
+    tableQuery.sort || []
+  );
   const groupChanged = isGroupChanged(
     [defaultGroupOption.id],
     tableQuery.group_by || []

--- a/packages/raystack/components/data-table/utils/index.tsx
+++ b/packages/raystack/components/data-table/utils/index.tsx
@@ -349,7 +349,7 @@ export function getDefaultTableQuery(
   const internalQuery = dataTableQueryToInternal(oldQuery);
 
   return {
-    sort: [defaultSort],
+    sort: defaultSort ? [defaultSort] : [],
     group_by: [defaultGroupOption.id],
     ...internalQuery
   };


### PR DESCRIPTION
## Description

`hasActiveQuery` crashed with `TypeError: Cannot destructure property 'name' of 'undefined' as it is undefined.` when consumers passed `undefined` as `defaultSort`. The TypeScript type marks `defaultSort` as required, but at runtime callers can still pass `undefined`, which produced `[undefined]` and crashed `generateSortMap` during the destructure.

Stack trace observed:

```
TypeError: Cannot destructure property 'name' of 'undefined' as it is undefined.
    at index.tsx:119:30
    at Array.map (<anonymous>)
    at generateSortMap (index.tsx:119:23)
    at isSortChanged (index.tsx:142:22)
    at hasActiveQuery (index.tsx:175:23)
    at Content4 (content.tsx:217:5)
```

Two-layer defensive fix in `packages/raystack/components/data-table/utils/index.tsx`:

- `generateSortMap` — filter falsy entries before destructure.
- `hasActiveQuery` — pass `[]` instead of `[undefined]` when `defaultSort` is missing.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

- Reproduced the crash locally with a `DataTable` consumer passing `defaultSort={undefined}`.
- After fix, the table renders without throwing and `hasActiveQuery` returns `false` for the default state.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (.mdx files)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

N/A

## Related Issues

Bug origin: #666 (`fix: DataTable reset and zero state handling`) — introduced `hasActiveQuery` and `generateSortMap` without guarding for an undefined `defaultSort`.