### PR TITLE
fix(theme-provider): callback deps, inline script, and onThemeChange

### DIFF
--- a/apps/www/src/content/docs/theme/overview/props.ts
+++ b/apps/www/src/content/docs/theme/overview/props.ts
@@ -68,6 +68,12 @@ export type ThemeProviderProps = {
   /** Mapping of theme name to HTML attribute value */
   value?: { [themeName: string]: string };
 
+  /**
+   * Called when the active theme changes. `resolvedTheme` is the actual applied theme
+   * (`"light"`/`"dark"` when `theme` is `"system"`). Not fired on initial mount.
+   */
+  onThemeChange?: (theme: string, resolvedTheme: string) => void;
+
   /** React children */
   children?: React.ReactNode;
 };

--- a/packages/raystack/components/theme-provider/theme.tsx
+++ b/packages/raystack/components/theme-provider/theme.tsx
@@ -167,30 +167,23 @@ const Theme = ({
     return () => window.removeEventListener('storage', handleStorage);
   }, [setTheme]);
 
-  // Whenever theme or forcedTheme changes, apply it
+  // Ref-held callback so consumer render churn doesn't drive effect cadence.
+  const onThemeChangeRef = useRef(onThemeChange);
+  onThemeChangeRef.current = onThemeChange;
+  const themeChangeMounted = useRef(false);
+
+  // Apply on theme/forcedTheme change, then notify (skipping initial mount).
   useEffect(() => {
     // @ts-ignore
     applyTheme(forcedTheme ?? theme);
-  }, [forcedTheme, theme]);
 
-  // Fire onThemeChange on actual changes, skipping the initial mount.
-  // Ref keeps the latest callback without re-firing when consumers pass an inline function.
-  const onThemeChangeRef = useRef(onThemeChange);
-  useEffect(() => {
-    onThemeChangeRef.current = onThemeChange;
-  });
-  const themeChangeMounted = useRef(false);
-  useEffect(() => {
-    if (!themeChangeMounted.current) {
-      themeChangeMounted.current = true;
-      return;
-    }
-    if (theme) {
+    if (themeChangeMounted.current && theme) {
       const resolved =
         theme === 'system' && resolvedTheme ? resolvedTheme : theme;
       onThemeChangeRef.current?.(theme, resolved);
     }
-  }, [theme, resolvedTheme]);
+    themeChangeMounted.current = true;
+  }, [forcedTheme, theme, resolvedTheme]);
 
   const providerValue = useMemo(
     () => ({

--- a/packages/raystack/components/theme-provider/theme.tsx
+++ b/packages/raystack/components/theme-provider/theme.tsx
@@ -54,8 +54,8 @@ const Theme = ({
   const [theme, setThemeState] = useState(() =>
     getTheme(storageKey, defaultTheme)
   );
-  const [resolvedTheme, setResolvedTheme] = useState(() =>
-    getTheme(storageKey)
+  const [resolvedTheme, setResolvedTheme] = useState<string | undefined>(
+    undefined
   );
   const attrs = !value ? themes : Object.values(value);
 

--- a/packages/raystack/components/theme-provider/theme.tsx
+++ b/packages/raystack/components/theme-provider/theme.tsx
@@ -178,7 +178,8 @@ const Theme = ({
     applyTheme(forcedTheme ?? theme);
 
     if (!theme) return;
-    const resolved = theme === 'system' ? resolvedTheme : theme;
+    const resolved =
+      forcedTheme ?? (theme === 'system' ? resolvedTheme : theme);
     if (!resolved) return;
 
     if (

--- a/packages/raystack/components/theme-provider/theme.tsx
+++ b/packages/raystack/components/theme-provider/theme.tsx
@@ -170,33 +170,38 @@ const Theme = ({
   // Ref-held callback so consumer render churn doesn't drive effect cadence.
   const onThemeChangeRef = useRef(onThemeChange);
   onThemeChangeRef.current = onThemeChange;
-  const lastResolvedRef = useRef<string | undefined>(undefined);
+  const lastRef = useRef<{ theme: string; resolved: string } | undefined>(
+    undefined
+  );
 
-  // Apply on theme/forcedTheme change, then notify on real resolved-theme changes.
+  // Apply on theme/forcedTheme change, then notify on real changes.
   useEffect(() => {
-    // @ts-ignore
-    applyTheme(forcedTheme ?? theme);
+    const target = forcedTheme ?? theme;
+    if (target) applyTheme(target);
 
     if (!theme) return;
     const resolved =
       forcedTheme ?? (theme === 'system' ? resolvedTheme : theme);
     if (!resolved) return;
 
+    const prev = lastRef.current;
+    lastRef.current = { theme, resolved };
+
     if (
-      lastResolvedRef.current !== undefined &&
-      lastResolvedRef.current !== resolved
+      prev !== undefined &&
+      (prev.theme !== theme || prev.resolved !== resolved)
     ) {
       onThemeChangeRef.current?.(theme, resolved);
     }
-    lastResolvedRef.current = resolved;
-  }, [forcedTheme, theme, resolvedTheme]);
+  }, [forcedTheme, theme, resolvedTheme, applyTheme]);
 
   const providerValue = useMemo(
     () => ({
       theme,
       setTheme,
       forcedTheme,
-      resolvedTheme: theme === 'system' ? resolvedTheme : theme,
+      resolvedTheme:
+        forcedTheme ?? (theme === 'system' ? resolvedTheme : theme),
       themes: enableSystem ? [...themes, 'system'] : themes,
       systemTheme: (enableSystem ? resolvedTheme : undefined) as
         | 'light'

--- a/packages/raystack/components/theme-provider/theme.tsx
+++ b/packages/raystack/components/theme-provider/theme.tsx
@@ -170,19 +170,24 @@ const Theme = ({
   // Ref-held callback so consumer render churn doesn't drive effect cadence.
   const onThemeChangeRef = useRef(onThemeChange);
   onThemeChangeRef.current = onThemeChange;
-  const themeChangeMounted = useRef(false);
+  const lastResolvedRef = useRef<string | undefined>(undefined);
 
-  // Apply on theme/forcedTheme change, then notify (skipping initial mount).
+  // Apply on theme/forcedTheme change, then notify on real resolved-theme changes.
   useEffect(() => {
     // @ts-ignore
     applyTheme(forcedTheme ?? theme);
 
-    if (themeChangeMounted.current && theme) {
-      const resolved =
-        theme === 'system' && resolvedTheme ? resolvedTheme : theme;
+    if (!theme) return;
+    const resolved = theme === 'system' ? resolvedTheme : theme;
+    if (!resolved) return;
+
+    if (
+      lastResolvedRef.current !== undefined &&
+      lastResolvedRef.current !== resolved
+    ) {
       onThemeChangeRef.current?.(theme, resolved);
     }
-    themeChangeMounted.current = true;
+    lastResolvedRef.current = resolved;
   }, [forcedTheme, theme, resolvedTheme]);
 
   const providerValue = useMemo(

--- a/packages/raystack/components/theme-provider/theme.tsx
+++ b/packages/raystack/components/theme-provider/theme.tsx
@@ -8,6 +8,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState
 } from 'react';
 
@@ -47,7 +48,8 @@ const Theme = ({
   nonce,
   style = 'modern',
   accentColor = 'indigo',
-  grayColor = 'gray'
+  grayColor = 'gray',
+  onThemeChange
 }: ThemeProviderProps) => {
   const [theme, setThemeState] = useState(() =>
     getTheme(storageKey, defaultTheme)
@@ -124,7 +126,7 @@ const Theme = ({
         // Unsupported
       }
     },
-    [forcedTheme]
+    [storageKey]
   );
 
   const handleMediaQuery = useCallback(
@@ -136,7 +138,7 @@ const Theme = ({
         applyTheme('system');
       }
     },
-    [theme, forcedTheme]
+    [theme, forcedTheme, enableSystem, applyTheme]
   );
 
   // Always listen to System preference
@@ -170,6 +172,25 @@ const Theme = ({
     // @ts-ignore
     applyTheme(forcedTheme ?? theme);
   }, [forcedTheme, theme]);
+
+  // Fire onThemeChange on actual changes, skipping the initial mount.
+  // Ref keeps the latest callback without re-firing when consumers pass an inline function.
+  const onThemeChangeRef = useRef(onThemeChange);
+  useEffect(() => {
+    onThemeChangeRef.current = onThemeChange;
+  });
+  const themeChangeMounted = useRef(false);
+  useEffect(() => {
+    if (!themeChangeMounted.current) {
+      themeChangeMounted.current = true;
+      return;
+    }
+    if (theme) {
+      const resolved =
+        theme === 'system' && resolvedTheme ? resolvedTheme : theme;
+      onThemeChangeRef.current?.(theme, resolved);
+    }
+  }, [theme, resolvedTheme]);
 
   const providerValue = useMemo(
     () => ({
@@ -277,7 +298,7 @@ const ThemeScript = memo(
       setColorScheme = true
     ) => {
       const resolvedName = value ? value[name] : name;
-      const val = literal ? name + `|| ''` : `'${resolvedName}'`;
+      const val = literal ? name : `'${resolvedName}'`;
       let text = '';
 
       // MUCH faster to set colorScheme alongside HTML attribute/class
@@ -293,13 +314,17 @@ const ThemeScript = memo(
       }
 
       if (attribute === 'class') {
-        if (literal || resolvedName) {
+        if (literal) {
+          text += `if(${val})c.add(${val})`;
+        } else if (resolvedName) {
           text += `c.add(${val})`;
         } else {
           text += `null`;
         }
       } else {
-        if (resolvedName) {
+        if (literal) {
+          text += `if(${val})d[s](n,${val})`;
+        } else if (resolvedName) {
           text += `d[s](n,${val})`;
         }
       }

--- a/packages/raystack/components/theme-provider/types.ts
+++ b/packages/raystack/components/theme-provider/types.ts
@@ -11,7 +11,7 @@ export interface UseThemeProps {
   setTheme: (theme: string) => void;
   /** Active theme name */
   theme?: string;
-  /** If `enableSystem` is true and the active theme is "system", this returns whether the system preference resolved to "dark" or "light". Otherwise, identical to `theme` */
+  /** The actually applied theme. Returns `forcedTheme` when set; otherwise the system preference (`"light"`/`"dark"`) when `theme` is `"system"`; otherwise identical to `theme`. */
   resolvedTheme?: string;
   /** If enableSystem is true, returns the System theme preference ("dark" or "light"), regardless what the active theme is */
   systemTheme?: 'dark' | 'light';

--- a/packages/raystack/components/theme-provider/types.ts
+++ b/packages/raystack/components/theme-provider/types.ts
@@ -14,7 +14,7 @@ export interface UseThemeProps {
   /** If `enableSystem` is true and the active theme is "system", this returns whether the system preference resolved to "dark" or "light". Otherwise, identical to `theme` */
   resolvedTheme?: string;
   /** If enableSystem is true, returns the System theme preference ("dark" or "light"), regardless what the active theme is */
-  systemTheme?: "dark" | "light";
+  systemTheme?: 'dark' | 'light';
 }
 
 export interface ThemeProviderProps {
@@ -33,7 +33,7 @@ export interface ThemeProviderProps {
   /** Default theme name (for v0.0.12 and lower the default was light). If `enableSystem` is false, the default theme is light */
   defaultTheme?: string;
   /** HTML attribute modified based on the active theme. Accepts `class` and `data-*` (meaning any data attribute, `data-mode`, `data-color`, etc.) */
-  attribute?: string | "class";
+  attribute?: string | 'class';
   /** Mapping of theme name to HTML attribute value. Object where key is the theme name and value is the attribute value */
   value?: ValueObject;
   /** Nonce string to pass to the inline script for CSP headers */
@@ -46,4 +46,6 @@ export interface ThemeProviderProps {
   accentColor?: 'indigo' | 'orange' | 'mint';
   /** Gray color variant for the theme, options are 'gray', 'mauve', or 'slate' */
   grayColor?: 'gray' | 'mauve' | 'slate';
+  /** Called when the active theme changes. `resolvedTheme` is the actual applied theme (`'light'`/`'dark'` when `theme` is `'system'`). Not fired on initial mount. */
+  onThemeChange?: (theme: string, resolvedTheme: string) => void;
 }


### PR DESCRIPTION
## Description

Addresses items 2, 3, and 5 from #646.

- **Callback deps** — `setTheme` now tracks `storageKey` (was `forcedTheme`, unused). `handleMediaQuery` now includes `enableSystem` and `applyTheme`. Both fix latent stale-closure bugs that surface only when those props change at runtime.
- **Inline-script fix** — `updateDOM` no longer emits `c.add(x[e]|| '')`. The literal path is gated with `if(${val})` so a missing `value`-map entry doesn't reach `classList.add('')` (throws) or `setAttribute(n, '')` (junk attr).
- **`onThemeChange` callback** — fires on actual `theme`/`resolvedTheme` changes, skips initial mount. Held via ref so consumer render churn doesn't over-fire and the callback never goes stale.

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Improvement

## How Has This Been Tested?

Manual repro on `main` vs branch for each fix. Tests TODO — leaving as draft until `theme-provider.test.tsx` is extended.

## Related Issues

Refs #646 (items 2, 3, 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)