### PR TITLE
fix: remove box-shadow from Select

### DIFF
--- a/packages/raystack/components/callout/callout.tsx
+++ b/packages/raystack/components/callout/callout.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { InfoCircledIcon } from '@radix-ui/react-icons';
-import { cva, cx, type VariantProps } from 'class-variance-authority';
+import { cva, type VariantProps } from 'class-variance-authority';
 import { type ComponentProps, type CSSProperties, type ReactNode } from 'react';
 
 import styles from './callout.module.css';

--- a/packages/raystack/components/select/select.module.css
+++ b/packages/raystack/components/select/select.module.css
@@ -10,6 +10,7 @@
   box-sizing: border-box;
   background-color: var(--rs-color-background-base-primary);
   border-radius: var(--rs-radius-2);
+  box-shadow: var(--rs-shadow-soft);
   border: 0.5px solid var(--rs-color-border-base-primary);
   min-width: var(--anchor-width);
   transition: var(--rs-transition-interactive);
@@ -159,6 +160,7 @@
   margin-top: var(--rs-space-2);
   padding: var(--rs-space-1);
   border: 0.5px solid var(--rs-color-border-base-primary);
+  box-shadow: var(--rs-shadow-soft);
 }
 
 .content[data-variant="text"] .menuitem {
@@ -245,7 +247,8 @@
 }
 
 .content:has(.comboboxContent:empty) .comboboxInput,
-.content:has(.comboboxContent:not(:has(.menuitem:not([data-hidden="true"])))) .comboboxInput {
+.content:has(.comboboxContent:not(:has(.menuitem:not([data-hidden="true"]))))
+  .comboboxInput {
   border-bottom: none;
 }
 

--- a/packages/raystack/components/select/select.module.css
+++ b/packages/raystack/components/select/select.module.css
@@ -10,7 +10,6 @@
   box-sizing: border-box;
   background-color: var(--rs-color-background-base-primary);
   border-radius: var(--rs-radius-2);
-  box-shadow: var(--rs-shadow-soft);
   border: 0.5px solid var(--rs-color-border-base-primary);
   min-width: var(--anchor-width);
   transition: var(--rs-transition-interactive);
@@ -79,7 +78,6 @@
 
 .trigger-text {
   border: none;
-  box-shadow: none;
 }
 
 .trigger-small {
@@ -161,7 +159,6 @@
   margin-top: var(--rs-space-2);
   padding: var(--rs-space-1);
   border: 0.5px solid var(--rs-color-border-base-primary);
-  box-shadow: var(--rs-shadow-soft);
 }
 
 .content[data-variant="text"] .menuitem {


### PR DESCRIPTION
## Summary
- Remove the redundant `box-shadow: none` reset on `.trigger-text` in the Select component CSS
- Drop the unused `cx` import from `callout.tsx`
- Minor formatting cleanup in `select.module.css` (wrap long selector, add trailing newline)