### PR TITLE
fix: update Indicator styles

### DIFF
--- a/packages/raystack/components/indicator/indicator.module.css
+++ b/packages/raystack/components/indicator/indicator.module.css
@@ -5,8 +5,9 @@
 
 .indicator {
   position: absolute;
-  top: calc(-1 * var(--rs-space-2));
-  right: calc(-1 * var(--rs-space-2));
+  top: 0;
+  right: 0;
+  transform: translate(50%, -50%);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -27,21 +28,13 @@
   /* Todo: var does not exist for 18px */
   min-width: 18px;
   height: 18px;
-  top: calc(-1 * var(--rs-space-4));
-  right: calc(-1 * var(--rs-space-6));
-}
-
-/* This adjusts the right side spacing if the label is 1 or 2 characters */
-.indicator:has(.label[data-length="1"]),
-.indicator:has(.label[data-length="2"]) {
-  right: calc(-1 * var(--rs-space-3));
 }
 
 .dot {
   display: block;
-  /* Todo: var does not exist for 6px */
-  width: 6px;
-  height: 6px;
+  /* Todo: var does not exist for 5px */
+  width: 5px;
+  height: 5px;
   border-radius: var(--rs-radius-full);
 }
 

--- a/packages/raystack/components/indicator/indicator.module.css
+++ b/packages/raystack/components/indicator/indicator.module.css
@@ -7,6 +7,9 @@
   position: absolute;
   top: calc(-1 * var(--rs-space-2));
   right: calc(-1 * var(--rs-space-2));
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border-radius: var(--rs-radius-full);
   white-space: nowrap;
   font-weight: var(--rs-font-weight-regular);
@@ -21,6 +24,9 @@
 }
 
 .indicator:has(.label) {
+  /* Todo: var does not exist for 18px */
+  min-width: 18px;
+  height: 18px;
   top: calc(-1 * var(--rs-space-4));
   right: calc(-1 * var(--rs-space-6));
 }
@@ -33,8 +39,9 @@
 
 .dot {
   display: block;
-  width: var(--rs-space-3);
-  height: var(--rs-space-3);
+  /* Todo: var does not exist for 6px */
+  width: 6px;
+  height: 6px;
   border-radius: var(--rs-radius-full);
 }
 


### PR DESCRIPTION
## Summary

- Indicator with a label now enforces a minimum 18x18 circle, expanding into an oval as content grows.
- Content is centered via flex so single-character labels stay visually balanced inside the circle.
- Dot indicator (no label) shrunk from 8px to 6px to match the Figma spec.