### PR TITLE
fix: DisplayControls styles

### DIFF
--- a/apps/www/src/app/examples/datatable/page.tsx
+++ b/apps/www/src/app/examples/datatable/page.tsx
@@ -3,6 +3,7 @@
 import {
   Button,
   DataTable,
+  DataTableColumnDef,
   EmptyState,
   Flex,
   IconButton,
@@ -377,19 +378,22 @@ const sampleData = [
   }
 ];
 
-const columns = [
+const columns: DataTableColumnDef<(typeof sampleData)[number], unknown>[] = [
   {
     accessorKey: 'name',
     header: 'Name',
     enableColumnFilter: true,
     filterType: 'string' as const,
-    enableGrouping: true
+    enableGrouping: true,
+    showGroupCount: true,
+    enableSorting: true
   },
   {
     accessorKey: 'email',
     header: 'Email',
     enableColumnFilter: true,
-    filterType: 'string' as const
+    filterType: 'string' as const,
+    enableSorting: true
   },
   {
     accessorKey: 'role',
@@ -398,18 +402,43 @@ const columns = [
     filterType: 'select' as const,
     enableGrouping: true,
     showGroupCount: true,
+    enableSorting: true,
     filterOptions: [
       { value: 'Admin', label: 'Admin' },
       { value: 'User', label: 'User' },
       { value: 'Manager', label: 'Manager' }
     ]
   },
-  { accessorKey: 'department', header: 'Department' },
-  { accessorKey: 'team', header: 'Team' },
-  { accessorKey: 'location', header: 'Location' },
+  {
+    accessorKey: 'department',
+    header: 'Department',
+    enableGrouping: true,
+    showGroupCount: true,
+    enableSorting: true
+  },
+  {
+    accessorKey: 'team',
+    header: 'Team',
+    enableGrouping: true,
+    showGroupCount: true,
+    enableSorting: true
+  },
+  {
+    accessorKey: 'location',
+    header: 'Location',
+    enableGrouping: true,
+    showGroupCount: true,
+    enableSorting: true
+  },
   { accessorKey: 'phone', header: 'Phone' },
-  { accessorKey: 'status', header: 'Status' },
-  { accessorKey: 'joined', header: 'Joined' },
+  {
+    accessorKey: 'status',
+    header: 'Status',
+    enableGrouping: true,
+    showGroupCount: true,
+    enableSorting: true
+  },
+  { accessorKey: 'joined', header: 'Joined', enableSorting: true },
   { accessorKey: 'name', id: 'name_2', header: 'Name (2)' },
   { accessorKey: 'email', id: 'email_2', header: 'Email (2)' },
   { accessorKey: 'role', id: 'role_2', header: 'Role (2)' },
@@ -424,32 +453,8 @@ const columns = [
   { accessorKey: 'role', id: 'role_3', header: 'Role (3)' }
 ];
 
-const PAGE_SIZE = 10;
-const MAX_ROWS = 50;
-
 const Page = () => {
   const [navbarSearch, setNavbarSearch] = useState('');
-  const [data, setData] = useState(() => sampleData.slice(0, PAGE_SIZE));
-  const [loading, setLoading] = useState(false);
-  const [hasMore, setHasMore] = useState(true);
-
-  const loadMore = (): Promise<void> => {
-    if (loading || !hasMore) return Promise.resolve();
-    setLoading(true);
-    return new Promise(resolve => {
-      setTimeout(() => {
-        setData(prev => {
-          const next = sampleData.slice(prev.length, prev.length + PAGE_SIZE);
-          if (next.length < PAGE_SIZE) setHasMore(false);
-          return prev.length + next.length <= MAX_ROWS
-            ? [...prev, ...next]
-            : prev;
-        });
-        setLoading(false);
-        resolve();
-      }, 500);
-    });
-  };
 
   return (
     <Flex
@@ -502,7 +507,7 @@ const Page = () => {
         <Navbar>
           <Navbar.Start>
             <Text size='regular' weight='medium'>
-              DataTable – Infinite scroll
+              DataTable – Client mode
             </Text>
           </Navbar.Start>
           <Navbar.End>
@@ -532,11 +537,9 @@ const Page = () => {
           }}
         >
           <DataTable
-            data={data}
+            data={sampleData}
             columns={columns}
-            mode='server'
-            isLoading={loading}
-            onLoadMore={loadMore}
+            mode='client'
             defaultSort={{ name: 'name', order: 'asc' }}
             stickyGroupHeader
           >

--- a/packages/raystack/components/data-table/components/display-properties.tsx
+++ b/packages/raystack/components/data-table/components/display-properties.tsx
@@ -13,9 +13,11 @@ export function DisplayProperties<TData, TValue>({
   const hidableColumns = columns?.filter(col => col.columnDef.enableHiding);
 
   return (
-    <Flex direction='column' gap={3}>
-      <Text>Display Properties</Text>
-      <Flex gap={3} wrap='wrap'>
+    <Flex direction='column' gap={5}>
+      <Text size='small' weight='medium' variant='secondary'>
+        Display Properties
+      </Text>
+      <Flex gap={3} wrap='wrap' align='center'>
         {hidableColumns.map(column => (
           <Chip
             key={column.id}

--- a/packages/raystack/components/data-table/components/grouping.tsx
+++ b/packages/raystack/components/data-table/components/grouping.tsx
@@ -41,11 +41,19 @@ export function Grouping<TData, TValue>({
   };
 
   return (
-    <Flex justify='between' align='center'>
-      <Text size={2} weight={500} className={styles['flex-1']}>
+    <Flex align='center' gap={5}>
+      <Text
+        size='small'
+        weight='medium'
+        variant='secondary'
+        className={styles['display-popover-properties-label']}
+      >
         Grouping
       </Text>
-      <Flex className={styles['flex-1']}>
+      <Flex
+        align='center'
+        className={styles['display-popover-properties-control']}
+      >
         <Select onValueChange={handleGroupChange} value={value}>
           <Select.Trigger
             size='small'

--- a/packages/raystack/components/data-table/components/ordering.tsx
+++ b/packages/raystack/components/data-table/components/ordering.tsx
@@ -32,11 +32,20 @@ export function Ordering({ columnList, onChange, value }: OrderingProps) {
   }
 
   return (
-    <Flex justify='between' align='center'>
-      <Text size={2} weight={500} className={styles['flex-1']}>
+    <Flex align='center' gap={5}>
+      <Text
+        size='small'
+        weight='medium'
+        variant='secondary'
+        className={styles['display-popover-properties-label']}
+      >
         Ordering
       </Text>
-      <Flex gap='extra-small' className={styles['flex-1']}>
+      <Flex
+        gap={3}
+        align='center'
+        className={styles['display-popover-properties-control']}
+      >
         <Select
           onValueChange={handleColumnChange}
           value={value.name}
@@ -45,7 +54,6 @@ export function Ordering({ columnList, onChange, value }: OrderingProps) {
           <Select.Trigger
             size='small'
             className={styles['display-popover-properties-select']}
-            with-icon-button='true'
           >
             <Select.Value placeholder='Select value' />
           </Select.Trigger>

--- a/packages/raystack/components/data-table/data-table.module.css
+++ b/packages/raystack/components/data-table/data-table.module.css
@@ -8,24 +8,31 @@
 
 .display-popover-content {
   padding: 0px;
-  /* Todo: var does not exist for 300px */
-  min-width: 300px;
+  /* Todo: var does not exist for 352px */
+  width: 352px;
+  max-width: 352px;
+  border-radius: var(--rs-radius-3);
 }
 
 .display-popover-properties-container {
-  /* Todo: var does not exist for 160px */
-  --select-width: 160px;
   padding: var(--rs-space-5);
   border-bottom: 1px solid var(--rs-color-border-base-primary);
 }
 
-.display-popover-properties-select {
-  width: var(--select-width);
+.display-popover-properties-label {
+  /* Todo: var does not exist for 154px */
+  width: 154px;
+  flex-shrink: 0;
 }
 
-.display-popover-properties-select[with-icon-button] {
-  /* Reduce Icon button with "--rs-space-7" and flex gap "--rs-space-2" */
-  width: calc(var(--select-width) - var(--rs-space-7) - var(--rs-space-2));
+.display-popover-properties-control {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.display-popover-properties-select {
+  flex: 1 1 0;
+  min-width: 0;
 }
 
 .display-popover-properties-select>span {

--- a/packages/raystack/components/data-table/data-table.module.css
+++ b/packages/raystack/components/data-table/data-table.module.css
@@ -8,8 +8,7 @@
 
 .display-popover-content {
   padding: 0px;
-  /* Todo: var does not exist for 352px */
-  width: 352px;
+  min-width: 320px;
   max-width: 352px;
   border-radius: var(--rs-radius-3);
 }
@@ -20,8 +19,7 @@
 }
 
 .display-popover-properties-label {
-  /* Todo: var does not exist for 154px */
-  width: 154px;
+  min-width: 100px;
   flex-shrink: 0;
 }
 
@@ -43,11 +41,6 @@
 
 .display-popover-reset-container {
   padding: var(--rs-space-3) var(--rs-space-5);
-}
-
-.display-popover-sort-icon {
-  height: var(--rs-space-6);
-  width: var(--rs-space-6);
 }
 
 .flex-1 {

--- a/packages/raystack/components/data-table/data-table.module.css
+++ b/packages/raystack/components/data-table/data-table.module.css
@@ -35,7 +35,7 @@
   min-width: 0;
 }
 
-.display-popover-properties-select>span {
+.display-popover-properties-select > span {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Summary

- Resize the DisplayControls popover to 352px wide with `radius-3` to match the Figma spec.
- Update Ordering, Grouping, and Display Properties section labels to use secondary foreground color and Body/Small Plus typography.
- Fix label width at 154px and let the right-side control flex, with `gap-3` between the Ordering select and its sort icon button.
- Use `gap-5` between the Display Properties title and chip wrap.
- Apply biome formatting to the popover CSS.