### PR TITLE
chore: remove outdated v1 comment from theme-provider

### DIFF
--- a/packages/raystack/components/theme-provider/index.tsx
+++ b/packages/raystack/components/theme-provider/index.tsx
@@ -1,4 +1,3 @@
-export { ThemeSwitcher } from "./switcher";
-export { ThemeProvider, useTheme } from "./theme";
-export { ThemeProviderProps } from "./types";
-// Note: This themeProvider folder is a merge of old and the new themeProvider. Both old and the v1 folder contains the exact copy of themeProvider which was merged.
+export { ThemeSwitcher } from './switcher';
+export { ThemeProvider, useTheme } from './theme';
+export { ThemeProviderProps } from './types';


### PR DESCRIPTION
## Summary
- Remove the historical merge note in `packages/raystack/components/theme-provider/index.tsx` that references a long-removed `v1` folder.

## Test plan
- [ ] `pnpm build` in `packages/raystack` (no behavior change — comment-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)