### PR TITLE
feat: introduce alpha-based overlay tokens, remove overlay-base-primary

### DIFF
--- a/apps/www/src/content/docs/theme/colors/index.mdx
+++ b/apps/www/src/content/docs/theme/colors/index.mdx
@@ -97,7 +97,18 @@ Overlay colors are used for modals, tooltips, and layered elements.
 <TokenTable
   type="color"
   tokens={[
-    { name: "--rs-color-overlay-base-primary", description: "Default overlay" },
+    { name: "--rs-color-overlay-base-a1", description: "Theme-aware overlay at 5% opacity" },
+    { name: "--rs-color-overlay-base-a2", description: "Theme-aware overlay at 10% opacity" },
+    { name: "--rs-color-overlay-base-a3", description: "Theme-aware overlay at 15% opacity" },
+    { name: "--rs-color-overlay-base-a4", description: "Theme-aware overlay at 20% opacity" },
+    { name: "--rs-color-overlay-base-a5", description: "Theme-aware overlay at 30% opacity" },
+    { name: "--rs-color-overlay-base-a6", description: "Theme-aware overlay at 40% opacity" },
+    { name: "--rs-color-overlay-base-a7", description: "Theme-aware overlay at 50% opacity" },
+    { name: "--rs-color-overlay-base-a8", description: "Theme-aware overlay at 60% opacity" },
+    { name: "--rs-color-overlay-base-a9", description: "Theme-aware overlay at 70% opacity" },
+    { name: "--rs-color-overlay-base-a10", description: "Theme-aware overlay at 80% opacity" },
+    { name: "--rs-color-overlay-base-a11", description: "Theme-aware overlay at 90% opacity" },
+    { name: "--rs-color-overlay-base-a12", description: "Theme-aware overlay at 95% opacity" },
     { name: "--rs-color-overlay-black-a1", description: "Black overlay at 5% opacity" },
     { name: "--rs-color-overlay-black-a2", description: "Black overlay at 10% opacity" },
     { name: "--rs-color-overlay-black-a3", description: "Black overlay at 15% opacity" },

--- a/docs/V1-migration.md
+++ b/docs/V1-migration.md
@@ -210,6 +210,21 @@ If you reference these CSS variables in custom styles:
 .accordion-panel { height: var(--accordion-panel-height); }
 ```
 
+#### Overlay Tokens
+
+`--rs-color-overlay-base-primary` has been removed. Its direct equivalent is `--rs-color-overlay-black-a5`. For theme-aware behavior (black in light, white in dark), use `--rs-color-overlay-base-a5` instead.
+
+```css
+/* Before */
+.backdrop { background-color: var(--rs-color-overlay-base-primary); }
+
+/* After — equivalent (always 30% black) */
+.backdrop { background-color: var(--rs-color-overlay-black-a5); }
+
+/* After — theme-aware (30% black in light, 30% white in dark) */
+.backdrop { background-color: var(--rs-color-overlay-base-a5); }
+```
+
 ### Form Field Pattern
 
 Labels, descriptions, errors, and optional indicators have been extracted from individual form controls into a new `Field` wrapper component. This is a **breaking change** for `InputField` (now `Input`) and `TextArea`.

--- a/packages/raystack/components/command/command.module.css
+++ b/packages/raystack/components/command/command.module.css
@@ -161,7 +161,7 @@
   position: fixed;
   inset: 0;
   z-index: var(--rs-z-index-portal);
-  background-color: var(--rs-color-overlay-base-primary);
+  background-color: var(--rs-color-overlay-black-a5);
   transition:
     opacity 200ms ease-out,
     backdrop-filter 200ms ease-out;

--- a/packages/raystack/components/dialog/dialog.module.css
+++ b/packages/raystack/components/dialog/dialog.module.css
@@ -1,5 +1,5 @@
 .dialogOverlay {
-  background-color: var(--rs-color-overlay-base-primary);
+  background-color: var(--rs-color-overlay-black-a5);
   position: fixed;
   inset: 0;
   transition: opacity 150ms cubic-bezier(0.45, 1.005, 0, 1.005);
@@ -86,7 +86,9 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .dialogContent {
-    transition: opacity 150ms, transform 150ms;
+    transition:
+      opacity 150ms,
+      transform 150ms;
   }
 }
 

--- a/packages/raystack/components/drawer/drawer.module.css
+++ b/packages/raystack/components/drawer/drawer.module.css
@@ -3,7 +3,7 @@
   inset: 0;
   min-height: 100dvh;
   z-index: var(--rs-z-index-portal);
-  background-color: var(--rs-color-overlay-base-primary);
+  background-color: var(--rs-color-overlay-black-a5);
   opacity: calc(1 - var(--drawer-swipe-progress, 0));
   transition: opacity 450ms cubic-bezier(0.32, 0.72, 0, 1);
 }

--- a/packages/raystack/components/scroll-area/scroll-area.module.css
+++ b/packages/raystack/components/scroll-area/scroll-area.module.css
@@ -47,7 +47,7 @@
 
 .thumb {
   flex: 1;
-  background: var(--rs-color-border-base-primary);
+  background: var(--rs-color-overlay-base-a5);
   border-radius: var(--rs-radius-2);
   transition: opacity 150ms ease-out;
   opacity: 1;

--- a/packages/raystack/styles/colors.css
+++ b/packages/raystack/styles/colors.css
@@ -1,6 +1,6 @@
-/* 
- * Note: Use color variables from this file only. 
- * Avoid using color variables from other files in the v1/styles folder directly. 
+/*
+ * Note: Use color variables from this file only.
+ * Avoid using color variables from other files in the v1/styles folder directly.
  */
 
 :root {
@@ -59,35 +59,47 @@
   --rs-color-border-success-primary: var(--rs-success-7);
   --rs-color-border-success-emphasis: var(--rs-success-9);
 
-  /* Overlay Colors */
-  --rs-color-overlay-base-primary: var(--rs-overlay-1);
+  /* Overlay Base Colors */
+  --rs-color-overlay-base-a1: var(--rs-alpha-a1);
+  --rs-color-overlay-base-a2: var(--rs-alpha-a2);
+  --rs-color-overlay-base-a3: var(--rs-alpha-a3);
+  --rs-color-overlay-base-a4: var(--rs-alpha-a4);
+  --rs-color-overlay-base-a5: var(--rs-alpha-a5);
+  --rs-color-overlay-base-a6: var(--rs-alpha-a6);
+  --rs-color-overlay-base-a7: var(--rs-alpha-a7);
+  --rs-color-overlay-base-a8: var(--rs-alpha-a8);
+  --rs-color-overlay-base-a9: var(--rs-alpha-a9);
+  --rs-color-overlay-base-a10: var(--rs-alpha-a10);
+  --rs-color-overlay-base-a11: var(--rs-alpha-a11);
+  --rs-color-overlay-base-a12: var(--rs-alpha-a12);
+
   /* Black Overlay */
-  --rs-color-overlay-black-a1: oklch(0 0 0 / 0.051); /* 5% opacity */
-  --rs-color-overlay-black-a2: oklch(0 0 0 / 0.102); /* 10% opacity */
-  --rs-color-overlay-black-a3: oklch(0 0 0 / 0.149); /* 15% opacity */
-  --rs-color-overlay-black-a4: oklch(0 0 0 / 0.2); /* 20% opacity */
-  --rs-color-overlay-black-a5: oklch(0 0 0 / 0.302); /* 30% opacity */
-  --rs-color-overlay-black-a6: oklch(0 0 0 / 0.4); /* 40% opacity */
-  --rs-color-overlay-black-a7: oklch(0 0 0 / 0.502); /* 50% opacity */
-  --rs-color-overlay-black-a8: oklch(0 0 0 / 0.6); /* 60% opacity */
-  --rs-color-overlay-black-a9: oklch(0 0 0 / 0.702); /* 70% opacity */
-  --rs-color-overlay-black-a10: oklch(0 0 0 / 0.8); /* 80% opacity */
-  --rs-color-overlay-black-a11: oklch(0 0 0 / 0.902); /* 90% opacity */
-  --rs-color-overlay-black-a12: oklch(0 0 0 / 0.949); /* 95% opacity */
+  --rs-color-overlay-black-a1: oklch(0 0 0 / 0.05);
+  --rs-color-overlay-black-a2: oklch(0 0 0 / 0.1);
+  --rs-color-overlay-black-a3: oklch(0 0 0 / 0.15);
+  --rs-color-overlay-black-a4: oklch(0 0 0 / 0.2);
+  --rs-color-overlay-black-a5: oklch(0 0 0 / 0.3);
+  --rs-color-overlay-black-a6: oklch(0 0 0 / 0.4);
+  --rs-color-overlay-black-a7: oklch(0 0 0 / 0.5);
+  --rs-color-overlay-black-a8: oklch(0 0 0 / 0.6);
+  --rs-color-overlay-black-a9: oklch(0 0 0 / 0.7);
+  --rs-color-overlay-black-a10: oklch(0 0 0 / 0.8);
+  --rs-color-overlay-black-a11: oklch(0 0 0 / 0.9);
+  --rs-color-overlay-black-a12: oklch(0 0 0 / 0.95);
 
   /* White Overlay */
-  --rs-color-overlay-white-a1: oklch(1 0 0 / 0.051); /* 5% opacity */
-  --rs-color-overlay-white-a2: oklch(1 0 0 / 0.102); /* 10% opacity */
-  --rs-color-overlay-white-a3: oklch(1 0 0 / 0.149); /* 15% opacity */
-  --rs-color-overlay-white-a4: oklch(1 0 0 / 0.2); /* 20% opacity */
-  --rs-color-overlay-white-a5: oklch(1 0 0 / 0.302); /* 30% opacity */
-  --rs-color-overlay-white-a6: oklch(1 0 0 / 0.4); /* 40% opacity */
-  --rs-color-overlay-white-a7: oklch(1 0 0 / 0.502); /* 50% opacity */
-  --rs-color-overlay-white-a8: oklch(1 0 0 / 0.6); /* 60% opacity */
-  --rs-color-overlay-white-a9: oklch(1 0 0 / 0.702); /* 70% opacity */
-  --rs-color-overlay-white-a10: oklch(1 0 0 / 0.8); /* 80% opacity */
-  --rs-color-overlay-white-a11: oklch(1 0 0 / 0.902); /* 90% opacity */
-  --rs-color-overlay-white-a12: oklch(1 0 0 / 0.949); /* 95% opacity */
+  --rs-color-overlay-white-a1: oklch(1 0 0 / 0.05);
+  --rs-color-overlay-white-a2: oklch(1 0 0 / 0.1);
+  --rs-color-overlay-white-a3: oklch(1 0 0 / 0.15);
+  --rs-color-overlay-white-a4: oklch(1 0 0 / 0.2);
+  --rs-color-overlay-white-a5: oklch(1 0 0 / 0.3);
+  --rs-color-overlay-white-a6: oklch(1 0 0 / 0.4);
+  --rs-color-overlay-white-a7: oklch(1 0 0 / 0.5);
+  --rs-color-overlay-white-a8: oklch(1 0 0 / 0.6);
+  --rs-color-overlay-white-a9: oklch(1 0 0 / 0.7);
+  --rs-color-overlay-white-a10: oklch(1 0 0 / 0.8);
+  --rs-color-overlay-white-a11: oklch(1 0 0 / 0.9);
+  --rs-color-overlay-white-a12: oklch(1 0 0 / 0.95);
 
   /* Additional Background Colors */
   --rs-color-background-neutral-primary: var(--rs-neutral-3);
@@ -108,7 +120,7 @@
   --rs-color-foreground-danger-emphasis: var(--rs-danger-contrast);
   --rs-color-foreground-attention-emphasis: var(--rs-attention-contrast);
   --rs-color-foreground-success-emphasis: var(--rs-success-contrast);
-  
+
   /* Visualization Colors */
   /* Sky */
   --rs-color-viz-sky-11: var(--rs-viz-sky-11);

--- a/packages/raystack/styles/primitives/appearance.css
+++ b/packages/raystack/styles/primitives/appearance.css
@@ -1,259 +1,282 @@
-/* 
- * Note: Do not use this file directly. 
- * It is used for generating the final colors file. 
+/*
+ * Note: Do not use this file directly.
+ * It is used for generating the final colors file.
  * All variables must be used from colors.css file only.
  */
 
 /* Light Theme Colors */
 :root {
-    /* Smooth theme switch transition */
-    transition: background-color 0.4s ease, color 0.4s ease;
+  /* Smooth theme switch transition */
+  transition:
+    background-color 0.4s ease,
+    color 0.4s ease;
 
-    /* Neutral Colors */
-    --rs-neutral-1: var(--rs-gray-1);
-    --rs-neutral-2: var(--rs-gray-2);
-    --rs-neutral-3: var(--rs-gray-3);
-    --rs-neutral-4: var(--rs-gray-4);
-    --rs-neutral-5: var(--rs-gray-5);
-    --rs-neutral-6: var(--rs-gray-6);
-    --rs-neutral-7: var(--rs-gray-7);
-    --rs-neutral-8: var(--rs-gray-8);
-    --rs-neutral-9: var(--rs-gray-9);
-    --rs-neutral-10: var(--rs-gray-10);
-    --rs-neutral-11: var(--rs-gray-11);
-    --rs-neutral-12: var(--rs-gray-12);
+  /* Neutral Colors */
+  --rs-neutral-1: var(--rs-gray-1);
+  --rs-neutral-2: var(--rs-gray-2);
+  --rs-neutral-3: var(--rs-gray-3);
+  --rs-neutral-4: var(--rs-gray-4);
+  --rs-neutral-5: var(--rs-gray-5);
+  --rs-neutral-6: var(--rs-gray-6);
+  --rs-neutral-7: var(--rs-gray-7);
+  --rs-neutral-8: var(--rs-gray-8);
+  --rs-neutral-9: var(--rs-gray-9);
+  --rs-neutral-10: var(--rs-gray-10);
+  --rs-neutral-11: var(--rs-gray-11);
+  --rs-neutral-12: var(--rs-gray-12);
 
+  /* Attention Colors */
+  --rs-attention-1: oklch(0.9943 0.0028 84.56);
+  --rs-attention-2: oklch(0.9835 0.0171 84.59);
+  --rs-attention-3: oklch(0.9678 0.0421 90.77);
+  --rs-attention-4: oklch(0.9467 0.0652 88.99);
+  --rs-attention-5: oklch(0.924 0.0878 87.29);
+  --rs-attention-6: oklch(0.8884 0.1073 80.68);
+  --rs-attention-7: oklch(0.8239 0.1234 76.15);
+  --rs-attention-8: oklch(0.7596 0.1524 69.5);
+  --rs-attention-9: oklch(0.8169 0.1639 75.84);
+  --rs-attention-10: oklch(0.7845 0.1678 66.73);
+  --rs-attention-11: oklch(0.5509 0.1374 54.39);
+  --rs-attention-12: oklch(0.3065 0.077 44.27);
 
-    /* Attention Colors */
-    --rs-attention-1: oklch(0.9943 0.0028 84.56);
-    --rs-attention-2: oklch(0.9835 0.0171 84.59);
-    --rs-attention-3: oklch(0.9678 0.0421 90.77);
-    --rs-attention-4: oklch(0.9467 0.0652 88.99);
-    --rs-attention-5: oklch(0.924 0.0878 87.29);
-    --rs-attention-6: oklch(0.8884 0.1073 80.68);
-    --rs-attention-7: oklch(0.8239 0.1234 76.15);
-    --rs-attention-8: oklch(0.7596 0.1524 69.5);
-    --rs-attention-9: oklch(0.8169 0.1639 75.84);
-    --rs-attention-10: oklch(0.7845 0.1678 66.73);
-    --rs-attention-11: oklch(0.5509 0.1374 54.39);
-    --rs-attention-12: oklch(0.3065 0.077 44.27);
+  /* Success Colors */
+  --rs-success-1: oklch(0.9942 0.0041 157.18);
+  --rs-success-2: oklch(0.9817 0.014 155.6);
+  --rs-success-3: oklch(0.9672 0.0222 155.93);
+  --rs-success-4: oklch(0.9439 0.0306 155.97);
+  --rs-success-5: oklch(0.9121 0.0423 157.18);
+  --rs-success-6: oklch(0.8657 0.0583 157.39);
+  --rs-success-7: oklch(0.8009 0.0784 159.16);
+  --rs-success-8: oklch(0.7158 0.1124 160.81);
+  --rs-success-9: oklch(0.6406 0.1329 157.68);
+  --rs-success-10: oklch(0.6025 0.1251 158.37);
+  --rs-success-11: oklch(0.5114 0.1102 158.44);
+  --rs-success-12: oklch(0.2903 0.0418 164.61);
 
-    /* Success Colors */
-    --rs-success-1: oklch(0.9942 0.0041 157.18);
-    --rs-success-2: oklch(0.9817 0.014 155.6);
-    --rs-success-3: oklch(0.9672 0.0222 155.93);
-    --rs-success-4: oklch(0.9439 0.0306 155.97);
-    --rs-success-5: oklch(0.9121 0.0423 157.18);
-    --rs-success-6: oklch(0.8657 0.0583 157.39);
-    --rs-success-7: oklch(0.8009 0.0784 159.16);
-    --rs-success-8: oklch(0.7158 0.1124 160.81);
-    --rs-success-9: oklch(0.6406 0.1329 157.68);
-    --rs-success-10: oklch(0.6025 0.1251 158.37);
-    --rs-success-11: oklch(0.5114 0.1102 158.44);
-    --rs-success-12: oklch(0.2903 0.0418 164.61);
+  /* Danger Colors */
+  --rs-danger-1: oklch(0.9934 0.0032 17.21);
+  --rs-danger-2: oklch(0.9845 0.0075 17.28);
+  --rs-danger-3: oklch(0.9648 0.0173 17.46);
+  --rs-danger-4: oklch(0.943 0.0286 17.67);
+  --rs-danger-5: oklch(0.9133 0.0414 17.93);
+  --rs-danger-6: oklch(0.8714 0.0583 18.33);
+  --rs-danger-7: oklch(0.816 0.0812 18.02);
+  --rs-danger-8: oklch(0.7479 0.1107 19.32);
+  --rs-danger-9: oklch(0.6256 0.1933 23.03);
+  --rs-danger-10: oklch(0.5982 0.1954 23.49);
+  --rs-danger-11: oklch(0.5545 0.1972 24.96);
+  --rs-danger-12: oklch(0.2462 0.0591 17.57);
 
-    /* Danger Colors */
-    --rs-danger-1: oklch(0.9934 0.0032 17.21);
-    --rs-danger-2: oklch(0.9845 0.0075 17.28);
-    --rs-danger-3: oklch(0.9648 0.0173 17.46);
-    --rs-danger-4: oklch(0.943 0.0286 17.67);
-    --rs-danger-5: oklch(0.9133 0.0414 17.93);
-    --rs-danger-6: oklch(0.8714 0.0583 18.33);
-    --rs-danger-7: oklch(0.816 0.0812 18.02);
-    --rs-danger-8: oklch(0.7479 0.1107 19.32);
-    --rs-danger-9: oklch(0.6256 0.1933 23.03);
-    --rs-danger-10: oklch(0.5982 0.1954 23.49);
-    --rs-danger-11: oklch(0.5545 0.1972 24.96);
-    --rs-danger-12: oklch(0.2462 0.0591 17.57);
+  /* Visualization Colors */
+  --rs-viz-sky-11: oklch(0.5255 0.1079 232.55);
+  --rs-viz-sky-9: oklch(0.8611 0.1027 217.8);
+  --rs-viz-sky-8: oklch(0.7283 0.0961 228.43);
+  --rs-viz-sky-6: oklch(0.8604 0.0571 223.65);
+  --rs-viz-mint-11: oklch(0.5117 0.0955 175.6);
+  --rs-viz-mint-9: oklch(0.8696 0.0999 177.98);
+  --rs-viz-mint-8: oklch(0.7221 0.1063 177.84);
+  --rs-viz-mint-6: oklch(0.8568 0.072 178.17);
+  --rs-viz-lime-11: oklch(0.5444 0.1114 128.6);
+  --rs-viz-lime-9: oklch(0.8874 0.1747 126.09);
+  --rs-viz-lime-8: oklch(0.725 0.1351 128.23);
+  --rs-viz-lime-6: oklch(0.8532 0.0991 123.29);
+  --rs-viz-grass-11: oklch(0.5262 0.1294 147.2);
+  --rs-viz-grass-9: oklch(0.6512 0.1468 147.39);
+  --rs-viz-grass-8: oklch(0.7174 0.1308 148.14);
+  --rs-viz-grass-6: oklch(0.8563 0.071 146.77);
+  --rs-viz-green-11: oklch(0.5435 0.1116 159.5);
+  --rs-viz-green-9: oklch(0.6406 0.1329 157.68);
+  --rs-viz-green-8: oklch(0.7156 0.1133 160.28);
+  --rs-viz-green-6: oklch(0.8558 0.0641 158.2);
+  --rs-viz-jade-11: oklch(0.5475 0.0983 170.05);
+  --rs-viz-jade-9: oklch(0.6422 0.115 170.73);
+  --rs-viz-jade-8: oklch(0.7214 0.1026 173.12);
+  --rs-viz-jade-6: oklch(0.8595 0.0601 166.24);
+  --rs-viz-cyan-11: oklch(0.547 0.0966 220.75);
+  --rs-viz-cyan-9: oklch(0.66 0.1217 221.74);
+  --rs-viz-cyan-8: oklch(0.7276 0.1102 211.93);
+  --rs-viz-cyan-6: oklch(0.8579 0.0659 208.14);
+  --rs-viz-blue-11: oklch(0.5558 0.1622 252.19);
+  --rs-viz-blue-9: oklch(0.6493 0.193 251.78);
+  --rs-viz-blue-8: oklch(0.7336 0.1214 243.09);
+  --rs-viz-blue-6: oklch(0.8633 0.0682 243.32);
+  --rs-viz-iris-11: oklch(0.5111 0.1739 279.84);
+  --rs-viz-iris-9: oklch(0.5403 0.1841 278.28);
+  --rs-viz-iris-8: oklch(0.7293 0.1182 281.44);
+  --rs-viz-iris-6: oklch(0.8634 0.0692 283.05);
+  --rs-viz-purple-11: oklch(0.5168 0.1733 305.88);
+  --rs-viz-purple-9: oklch(0.5556 0.1829 305.86);
+  --rs-viz-purple-8: oklch(0.7331 0.1225 307.97);
+  --rs-viz-purple-6: oklch(0.8592 0.0718 311.05);
+  --rs-viz-pink-11: oklch(0.5575 0.2069 347.32);
+  --rs-viz-pink-9: oklch(0.6168 0.2076 346);
+  --rs-viz-pink-8: oklch(0.7513 0.1071 341.48);
+  --rs-viz-pink-6: oklch(0.8558 0.0671 340.72);
+  --rs-viz-crimson-11: oklch(0.5522 0.2073 4.49);
+  --rs-viz-crimson-9: oklch(0.6341 0.213 1.28);
+  --rs-viz-crimson-8: oklch(0.7493 0.1002 354.02);
+  --rs-viz-crimson-6: oklch(0.8541 0.0653 355.16);
+  --rs-viz-orange-11: oklch(0.5855 0.1743 42.74);
+  --rs-viz-orange-9: oklch(0.6908 0.1909 45.02);
+  --rs-viz-orange-8: oklch(0.745 0.1322 54.68);
+  --rs-viz-orange-6: oklch(0.8537 0.1068 66.02);
+  --rs-viz-gold-11: oklch(0.5042 0.0395 78.26);
+  --rs-viz-gold-9: oklch(0.6204 0.0492 77.7);
+  --rs-viz-gold-8: oklch(0.739 0.0423 79.36);
+  --rs-viz-gold-6: oklch(0.8594 0.0247 85.79);
 
-    /* Visualization Colors */
-    --rs-viz-sky-11: oklch(0.5255 0.1079 232.55);
-    --rs-viz-sky-9: oklch(0.8611 0.1027 217.8);
-    --rs-viz-sky-8: oklch(0.7283 0.0961 228.43);
-    --rs-viz-sky-6: oklch(0.8604 0.0571 223.65);
-    --rs-viz-mint-11: oklch(0.5117 0.0955 175.6);
-    --rs-viz-mint-9: oklch(0.8696 0.0999 177.98);
-    --rs-viz-mint-8: oklch(0.7221 0.1063 177.84);
-    --rs-viz-mint-6: oklch(0.8568 0.072 178.17);
-    --rs-viz-lime-11: oklch(0.5444 0.1114 128.6);
-    --rs-viz-lime-9: oklch(0.8874 0.1747 126.09);
-    --rs-viz-lime-8: oklch(0.725 0.1351 128.23);
-    --rs-viz-lime-6: oklch(0.8532 0.0991 123.29);
-    --rs-viz-grass-11: oklch(0.5262 0.1294 147.2);
-    --rs-viz-grass-9: oklch(0.6512 0.1468 147.39);
-    --rs-viz-grass-8: oklch(0.7174 0.1308 148.14);
-    --rs-viz-grass-6: oklch(0.8563 0.071 146.77);
-    --rs-viz-green-11: oklch(0.5435 0.1116 159.5);
-    --rs-viz-green-9: oklch(0.6406 0.1329 157.68);
-    --rs-viz-green-8: oklch(0.7156 0.1133 160.28);
-    --rs-viz-green-6: oklch(0.8558 0.0641 158.2);
-    --rs-viz-jade-11: oklch(0.5475 0.0983 170.05);
-    --rs-viz-jade-9: oklch(0.6422 0.115 170.73);
-    --rs-viz-jade-8: oklch(0.7214 0.1026 173.12);
-    --rs-viz-jade-6: oklch(0.8595 0.0601 166.24);
-    --rs-viz-cyan-11: oklch(0.547 0.0966 220.75);
-    --rs-viz-cyan-9: oklch(0.66 0.1217 221.74);
-    --rs-viz-cyan-8: oklch(0.7276 0.1102 211.93);
-    --rs-viz-cyan-6: oklch(0.8579 0.0659 208.14);
-    --rs-viz-blue-11: oklch(0.5558 0.1622 252.19);
-    --rs-viz-blue-9: oklch(0.6493 0.193 251.78);
-    --rs-viz-blue-8: oklch(0.7336 0.1214 243.09);
-    --rs-viz-blue-6: oklch(0.8633 0.0682 243.32);
-    --rs-viz-iris-11: oklch(0.5111 0.1739 279.84);
-    --rs-viz-iris-9: oklch(0.5403 0.1841 278.28);
-    --rs-viz-iris-8: oklch(0.7293 0.1182 281.44);
-    --rs-viz-iris-6: oklch(0.8634 0.0692 283.05);
-    --rs-viz-purple-11: oklch(0.5168 0.1733 305.88);
-    --rs-viz-purple-9: oklch(0.5556 0.1829 305.86);
-    --rs-viz-purple-8: oklch(0.7331 0.1225 307.97);
-    --rs-viz-purple-6: oklch(0.8592 0.0718 311.05);
-    --rs-viz-pink-11: oklch(0.5575 0.2069 347.32);
-    --rs-viz-pink-9: oklch(0.6168 0.2076 346);
-    --rs-viz-pink-8: oklch(0.7513 0.1071 341.48);
-    --rs-viz-pink-6: oklch(0.8558 0.0671 340.72);
-    --rs-viz-crimson-11: oklch(0.5522 0.2073 4.49);
-    --rs-viz-crimson-9: oklch(0.6341 0.213 1.28);
-    --rs-viz-crimson-8: oklch(0.7493 0.1002 354.02);
-    --rs-viz-crimson-6: oklch(0.8541 0.0653 355.16);
-    --rs-viz-orange-11: oklch(0.5855 0.1743 42.74);
-    --rs-viz-orange-9: oklch(0.6908 0.1909 45.02);
-    --rs-viz-orange-8: oklch(0.745 0.1322 54.68);
-    --rs-viz-orange-6: oklch(0.8537 0.1068 66.02);
-    --rs-viz-gold-11: oklch(0.5042 0.0395 78.26);
-    --rs-viz-gold-9: oklch(0.6204 0.0492 77.7);
-    --rs-viz-gold-8: oklch(0.739 0.0423 79.36);
-    --rs-viz-gold-6: oklch(0.8594 0.0247 85.79);
+  /* Contrast Colors */
+  --rs-danger-contrast: oklch(1 0 0);
+  --rs-attention-contrast: oklch(0 0 0);
+  --rs-success-contrast: oklch(1 0 0);
 
-    /* Contrast Colors */
-    --rs-danger-contrast: oklch(1 0 0);
-    --rs-attention-contrast: oklch(0 0 0);
-    --rs-success-contrast: oklch(1 0 0);
-
-    /* Overlay color */
-    --rs-overlay-1: oklch(0 0 0 / 0.302); /* 30% opacity */
+  /* Alpha Colors */
+  --rs-alpha-a1: oklch(0 0 0 / 0.05);
+  --rs-alpha-a2: oklch(0 0 0 / 0.1);
+  --rs-alpha-a3: oklch(0 0 0 / 0.15);
+  --rs-alpha-a4: oklch(0 0 0 / 0.2);
+  --rs-alpha-a5: oklch(0 0 0 / 0.3);
+  --rs-alpha-a6: oklch(0 0 0 / 0.4);
+  --rs-alpha-a7: oklch(0 0 0 / 0.5);
+  --rs-alpha-a8: oklch(0 0 0 / 0.6);
+  --rs-alpha-a9: oklch(0 0 0 / 0.7);
+  --rs-alpha-a10: oklch(0 0 0 / 0.8);
+  --rs-alpha-a11: oklch(0 0 0 / 0.9);
+  --rs-alpha-a12: oklch(0 0 0 / 0.95);
 }
 
 /* Dark Theme Colors */
 html[data-theme="dark"] {
-    /* Neutral Colors */
-    --rs-neutral-1: var(--rs-gray-1);
-    --rs-neutral-2: var(--rs-gray-2);
-    --rs-neutral-3: var(--rs-gray-3);
-    --rs-neutral-4: var(--rs-gray-4);
-    --rs-neutral-5: var(--rs-gray-5);
-    --rs-neutral-6: var(--rs-gray-6);
-    --rs-neutral-7: var(--rs-gray-7);
-    --rs-neutral-8: var(--rs-gray-8);
-    --rs-neutral-9: var(--rs-gray-9);
-    --rs-neutral-10: var(--rs-gray-10);
-    --rs-neutral-11: var(--rs-gray-11);
-    --rs-neutral-12: var(--rs-gray-12);
+  /* Neutral Colors */
+  --rs-neutral-1: var(--rs-gray-1);
+  --rs-neutral-2: var(--rs-gray-2);
+  --rs-neutral-3: var(--rs-gray-3);
+  --rs-neutral-4: var(--rs-gray-4);
+  --rs-neutral-5: var(--rs-gray-5);
+  --rs-neutral-6: var(--rs-gray-6);
+  --rs-neutral-7: var(--rs-gray-7);
+  --rs-neutral-8: var(--rs-gray-8);
+  --rs-neutral-9: var(--rs-gray-9);
+  --rs-neutral-10: var(--rs-gray-10);
+  --rs-neutral-11: var(--rs-gray-11);
+  --rs-neutral-12: var(--rs-gray-12);
 
-    /* Attention Colors */
-    --rs-attention-1: oklch(0.1976 0.0409 80.17);
-    --rs-attention-2: oklch(0.2205 0.0465 75.26);
-    --rs-attention-3: oklch(0.2532 0.0561 66.67);
-    --rs-attention-4: oklch(0.2843 0.0638 64.91);
-    --rs-attention-5: oklch(0.3166 0.071 65.12);
-    --rs-attention-6: oklch(0.3574 0.0786 67.65);
-    --rs-attention-7: oklch(0.4086 0.0875 66.87);
-    --rs-attention-8: oklch(0.4733 0.1046 67.01);
-    --rs-attention-9: oklch(0.8169 0.1639 75.84);
-    --rs-attention-10: oklch(0.8659 0.1539 86.48);
-    --rs-attention-11: oklch(0.7693 0.1617 73.12);
-    --rs-attention-12: oklch(0.967 0.0312 84.59);
+  /* Attention Colors */
+  --rs-attention-1: oklch(0.1976 0.0409 80.17);
+  --rs-attention-2: oklch(0.2205 0.0465 75.26);
+  --rs-attention-3: oklch(0.2532 0.0561 66.67);
+  --rs-attention-4: oklch(0.2843 0.0638 64.91);
+  --rs-attention-5: oklch(0.3166 0.071 65.12);
+  --rs-attention-6: oklch(0.3574 0.0786 67.65);
+  --rs-attention-7: oklch(0.4086 0.0875 66.87);
+  --rs-attention-8: oklch(0.4733 0.1046 67.01);
+  --rs-attention-9: oklch(0.8169 0.1639 75.84);
+  --rs-attention-10: oklch(0.8659 0.1539 86.48);
+  --rs-attention-11: oklch(0.7693 0.1617 73.12);
+  --rs-attention-12: oklch(0.967 0.0312 84.59);
 
-    /* Success Colors */
-    --rs-success-1: oklch(0.1993 0.0223 158.02);
-    --rs-success-2: oklch(0.2174 0.0299 151.75);
-    --rs-success-3: oklch(0.254 0.0393 151.93);
-    --rs-success-4: oklch(0.282 0.0476 151.04);
-    --rs-success-5: oklch(0.3125 0.0574 150.09);
-    --rs-success-6: oklch(0.3494 0.0672 150.03);
-    --rs-success-7: oklch(0.4049 0.0815 149.47);
-    --rs-success-8: oklch(0.4832 0.1034 147.78);
-    --rs-success-9: oklch(0.6512 0.1468 147.39);
-    --rs-success-10: oklch(0.693 0.1434 147.93);
-    --rs-success-11: oklch(0.7339 0.1423 148.01);
-    --rs-success-12: oklch(0.9676 0.0313 154.18);
+  /* Success Colors */
+  --rs-success-1: oklch(0.1993 0.0223 158.02);
+  --rs-success-2: oklch(0.2174 0.0299 151.75);
+  --rs-success-3: oklch(0.254 0.0393 151.93);
+  --rs-success-4: oklch(0.282 0.0476 151.04);
+  --rs-success-5: oklch(0.3125 0.0574 150.09);
+  --rs-success-6: oklch(0.3494 0.0672 150.03);
+  --rs-success-7: oklch(0.4049 0.0815 149.47);
+  --rs-success-8: oklch(0.4832 0.1034 147.78);
+  --rs-success-9: oklch(0.6512 0.1468 147.39);
+  --rs-success-10: oklch(0.693 0.1434 147.93);
+  --rs-success-11: oklch(0.7339 0.1423 148.01);
+  --rs-success-12: oklch(0.9676 0.0313 154.18);
 
-    /* Danger Colors */
-    --rs-danger-1: oklch(0.2035 0.0202 7.98);
-    --rs-danger-2: oklch(0.2215 0.0346 17.2);
-    --rs-danger-3: oklch(0.2635 0.0568 18.35);
-    --rs-danger-4: oklch(0.289 0.0705 18.67);
-    --rs-danger-5: oklch(0.3129 0.0849 19.36);
-    --rs-danger-6: oklch(0.3527 0.1044 21.23);
-    --rs-danger-7: oklch(0.4057 0.1326 22.8);
-    --rs-danger-8: oklch(0.4843 0.1698 24.67);
-    --rs-danger-9: oklch(0.6256 0.1933 23.03);
-    --rs-danger-10: oklch(0.6625 0.1926 22.29);
-    --rs-danger-11: oklch(0.7013 0.1901 21.2);
-    --rs-danger-12: oklch(0.9579 0.0197 9.78);
+  /* Danger Colors */
+  --rs-danger-1: oklch(0.2035 0.0202 7.98);
+  --rs-danger-2: oklch(0.2215 0.0346 17.2);
+  --rs-danger-3: oklch(0.2635 0.0568 18.35);
+  --rs-danger-4: oklch(0.289 0.0705 18.67);
+  --rs-danger-5: oklch(0.3129 0.0849 19.36);
+  --rs-danger-6: oklch(0.3527 0.1044 21.23);
+  --rs-danger-7: oklch(0.4057 0.1326 22.8);
+  --rs-danger-8: oklch(0.4843 0.1698 24.67);
+  --rs-danger-9: oklch(0.6256 0.1933 23.03);
+  --rs-danger-10: oklch(0.6625 0.1926 22.29);
+  --rs-danger-11: oklch(0.7013 0.1901 21.2);
+  --rs-danger-12: oklch(0.9579 0.0197 9.78);
 
-    /* Visualization Colors */
-    --rs-viz-sky-11: oklch(0.7927 0.0991 231.61);
-    --rs-viz-sky-9: oklch(0.8611 0.1027 217.8);
-    --rs-viz-sky-8: oklch(0.5568 0.1145 237.44);
-    --rs-viz-sky-6: oklch(0.4262 0.0878 243.92);
-    --rs-viz-mint-11: oklch(0.7954 0.1181 176.46);
-    --rs-viz-mint-9: oklch(0.8696 0.0999 177.98);
-    --rs-viz-mint-8: oklch(0.5408 0.0853 179.23);
-    --rs-viz-mint-6: oklch(0.4106 0.0662 186.24);
-    --rs-viz-lime-11: oklch(0.8683 0.1552 124.74);
-    --rs-viz-lime-9: oklch(0.8874 0.1747 126.09);
-    --rs-viz-lime-8: oklch(0.5241 0.0945 130.63);
-    --rs-viz-lime-6: oklch(0.4103 0.0675 131.45);
-    --rs-viz-grass-11: oklch(0.7797 0.1419 148.48);
-    --rs-viz-grass-9: oklch(0.6512 0.1468 147.39);
-    --rs-viz-grass-8: oklch(0.5229 0.0973 148.32);
-    --rs-viz-grass-6: oklch(0.4164 0.0724 149.33);
-    --rs-viz-green-11: oklch(0.7794 0.1655 157.29);
-    --rs-viz-green-9: oklch(0.6406 0.1329 157.68);
-    --rs-viz-green-8: oklch(0.528 0.0963 159.39);
-    --rs-viz-green-6: oklch(0.4124 0.0721 160.95);
-    --rs-viz-jade-11: oklch(0.7852 0.1559 167.11);
-    --rs-viz-jade-9: oklch(0.6422 0.115 170.73);
-    --rs-viz-jade-8: oklch(0.5365 0.0875 172.23);
-    --rs-viz-jade-6: oklch(0.4127 0.0687 169.57);
-    --rs-viz-cyan-11: oklch(0.7854 0.1158 213.8);
-    --rs-viz-cyan-9: oklch(0.66 0.1217 221.74);
-    --rs-viz-cyan-8: oklch(0.5566 0.0985 221.11);
-    --rs-viz-cyan-6: oklch(0.4135 0.0747 221.5);
-    --rs-viz-blue-11: oklch(0.7642 0.1257 249.46);
-    --rs-viz-blue-9: oklch(0.6493 0.193 251.78);
-    --rs-viz-blue-8: oklch(0.5406 0.1395 253.17);
-    --rs-viz-blue-6: oklch(0.416 0.1133 252.01);
-    --rs-viz-iris-11: oklch(0.7743 0.1215 287.46);
-    --rs-viz-iris-9: oklch(0.5403 0.1841 278.28);
-    --rs-viz-iris-8: oklch(0.5068 0.1377 280.8);
-    --rs-viz-iris-6: oklch(0.4004 0.1117 279.45);
-    --rs-viz-purple-11: oklch(0.7807 0.1452 307.74);
-    --rs-viz-purple-9: oklch(0.5556 0.1829 305.86);
-    --rs-viz-purple-8: oklch(0.5412 0.1326 307.57);
-    --rs-viz-purple-6: oklch(0.3887 0.0964 309.45);
-    --rs-viz-pink-11: oklch(0.7846 0.155 346.97);
-    --rs-viz-pink-9: oklch(0.6168 0.2076 346);
-    --rs-viz-pink-8: oklch(0.5462 0.1449 343.97);
-    --rs-viz-pink-6: oklch(0.3884 0.1075 341.41);
-    --rs-viz-crimson-11: oklch(0.7825 0.1338 4.74);
-    --rs-viz-crimson-9: oklch(0.6341 0.213 1.28);
-    --rs-viz-crimson-8: oklch(0.5431 0.1479 358.72);
-    --rs-viz-crimson-6: oklch(0.3826 0.1079 355.87);
-    --rs-viz-orange-11: oklch(0.7888 0.1434 56.21);
-    --rs-viz-orange-9: oklch(0.6908 0.1909 45.02);
-    --rs-viz-orange-8: oklch(0.5406 0.1156 50.05);
-    --rs-viz-orange-6: oklch(0.3849 0.0867 54.98);
-    --rs-viz-gold-11: oklch(0.794 0.041 77.08);
-    --rs-viz-gold-9: oklch(0.6204 0.0492 77.7);
-    --rs-viz-gold-8: oklch(0.499 0.0205 81.26);
-    --rs-viz-gold-6: oklch(0.3732 0.0129 81.75);
+  /* Visualization Colors */
+  --rs-viz-sky-11: oklch(0.7927 0.0991 231.61);
+  --rs-viz-sky-9: oklch(0.8611 0.1027 217.8);
+  --rs-viz-sky-8: oklch(0.5568 0.1145 237.44);
+  --rs-viz-sky-6: oklch(0.4262 0.0878 243.92);
+  --rs-viz-mint-11: oklch(0.7954 0.1181 176.46);
+  --rs-viz-mint-9: oklch(0.8696 0.0999 177.98);
+  --rs-viz-mint-8: oklch(0.5408 0.0853 179.23);
+  --rs-viz-mint-6: oklch(0.4106 0.0662 186.24);
+  --rs-viz-lime-11: oklch(0.8683 0.1552 124.74);
+  --rs-viz-lime-9: oklch(0.8874 0.1747 126.09);
+  --rs-viz-lime-8: oklch(0.5241 0.0945 130.63);
+  --rs-viz-lime-6: oklch(0.4103 0.0675 131.45);
+  --rs-viz-grass-11: oklch(0.7797 0.1419 148.48);
+  --rs-viz-grass-9: oklch(0.6512 0.1468 147.39);
+  --rs-viz-grass-8: oklch(0.5229 0.0973 148.32);
+  --rs-viz-grass-6: oklch(0.4164 0.0724 149.33);
+  --rs-viz-green-11: oklch(0.7794 0.1655 157.29);
+  --rs-viz-green-9: oklch(0.6406 0.1329 157.68);
+  --rs-viz-green-8: oklch(0.528 0.0963 159.39);
+  --rs-viz-green-6: oklch(0.4124 0.0721 160.95);
+  --rs-viz-jade-11: oklch(0.7852 0.1559 167.11);
+  --rs-viz-jade-9: oklch(0.6422 0.115 170.73);
+  --rs-viz-jade-8: oklch(0.5365 0.0875 172.23);
+  --rs-viz-jade-6: oklch(0.4127 0.0687 169.57);
+  --rs-viz-cyan-11: oklch(0.7854 0.1158 213.8);
+  --rs-viz-cyan-9: oklch(0.66 0.1217 221.74);
+  --rs-viz-cyan-8: oklch(0.5566 0.0985 221.11);
+  --rs-viz-cyan-6: oklch(0.4135 0.0747 221.5);
+  --rs-viz-blue-11: oklch(0.7642 0.1257 249.46);
+  --rs-viz-blue-9: oklch(0.6493 0.193 251.78);
+  --rs-viz-blue-8: oklch(0.5406 0.1395 253.17);
+  --rs-viz-blue-6: oklch(0.416 0.1133 252.01);
+  --rs-viz-iris-11: oklch(0.7743 0.1215 287.46);
+  --rs-viz-iris-9: oklch(0.5403 0.1841 278.28);
+  --rs-viz-iris-8: oklch(0.5068 0.1377 280.8);
+  --rs-viz-iris-6: oklch(0.4004 0.1117 279.45);
+  --rs-viz-purple-11: oklch(0.7807 0.1452 307.74);
+  --rs-viz-purple-9: oklch(0.5556 0.1829 305.86);
+  --rs-viz-purple-8: oklch(0.5412 0.1326 307.57);
+  --rs-viz-purple-6: oklch(0.3887 0.0964 309.45);
+  --rs-viz-pink-11: oklch(0.7846 0.155 346.97);
+  --rs-viz-pink-9: oklch(0.6168 0.2076 346);
+  --rs-viz-pink-8: oklch(0.5462 0.1449 343.97);
+  --rs-viz-pink-6: oklch(0.3884 0.1075 341.41);
+  --rs-viz-crimson-11: oklch(0.7825 0.1338 4.74);
+  --rs-viz-crimson-9: oklch(0.6341 0.213 1.28);
+  --rs-viz-crimson-8: oklch(0.5431 0.1479 358.72);
+  --rs-viz-crimson-6: oklch(0.3826 0.1079 355.87);
+  --rs-viz-orange-11: oklch(0.7888 0.1434 56.21);
+  --rs-viz-orange-9: oklch(0.6908 0.1909 45.02);
+  --rs-viz-orange-8: oklch(0.5406 0.1156 50.05);
+  --rs-viz-orange-6: oklch(0.3849 0.0867 54.98);
+  --rs-viz-gold-11: oklch(0.794 0.041 77.08);
+  --rs-viz-gold-9: oklch(0.6204 0.0492 77.7);
+  --rs-viz-gold-8: oklch(0.499 0.0205 81.26);
+  --rs-viz-gold-6: oklch(0.3732 0.0129 81.75);
 
-    /* Contrast Colors */
-    --rs-danger-contrast: oklch(1 0 0);
-    --rs-attention-contrast: oklch(0 0 0);
-    --rs-success-contrast: oklch(1 0 0);
+  /* Contrast Colors */
+  --rs-danger-contrast: oklch(1 0 0);
+  --rs-attention-contrast: oklch(0 0 0);
+  --rs-success-contrast: oklch(1 0 0);
 
-    /* Overlay color */
-    --rs-overlay-1: oklch(1 0 0 / 0.302); /* 30% opacity */
+  /* Alpha Colors */
+  --rs-alpha-a1: oklch(1 0 0 / 0.05);
+  --rs-alpha-a2: oklch(1 0 0 / 0.1);
+  --rs-alpha-a3: oklch(1 0 0 / 0.15);
+  --rs-alpha-a4: oklch(1 0 0 / 0.2);
+  --rs-alpha-a5: oklch(1 0 0 / 0.3);
+  --rs-alpha-a6: oklch(1 0 0 / 0.4);
+  --rs-alpha-a7: oklch(1 0 0 / 0.5);
+  --rs-alpha-a8: oklch(1 0 0 / 0.6);
+  --rs-alpha-a9: oklch(1 0 0 / 0.7);
+  --rs-alpha-a10: oklch(1 0 0 / 0.8);
+  --rs-alpha-a11: oklch(1 0 0 / 0.9);
+  --rs-alpha-a12: oklch(1 0 0 / 0.95);
 }


### PR DESCRIPTION
## Summary

- Add 12-step `--rs-alpha-aN` primitives (theme-aware: black in light, white in dark) and expose them via `--rs-color-overlay-base-aN`.
- Normalize `--rs-color-overlay-black-aN` and `--rs-color-overlay-white-aN` alpha values to clean steps (e.g. `0.051 → 0.05`, `0.302 → 0.3`) per updated Figma tokens.
- Remove `--rs-color-overlay-base-primary`; migrate `Dialog`, `Drawer`, `Command` backdrops and the `ScrollArea` thumb to the new variables.
- Document the breaking change and replacement variables in `docs/V1-migration.md`.
- Update token reference page in the docs site to list the new `overlay-base-aN` family.