### PR TITLE
fix: Filterchip breaking input styles

### DIFF
--- a/packages/raystack/components/filter-chip/filter-chip.tsx
+++ b/packages/raystack/components/filter-chip/filter-chip.tsx
@@ -139,7 +139,7 @@ export const FilterChip = ({
               value={filterValue}
               onSelect={date => handleFilterValueChange(date)}
               showCalendarIcon={false}
-              inputProps={{ className: styles.dateField }}
+              inputProps={{ classNames: { container: styles.dateField } }}
             />
           </div>
         );
@@ -148,7 +148,7 @@ export const FilterChip = ({
           <div className={styles.inputFieldWrapper}>
             <Input
               variant={variant === 'text' ? 'borderless' : 'default'}
-              className={styles.inputField}
+              classNames={{ container: styles.inputField }}
               value={filterValue}
               onChange={e => handleFilterValueChange(e.target.value)}
             />

--- a/packages/raystack/components/input/input.tsx
+++ b/packages/raystack/components/input/input.tsx
@@ -35,6 +35,7 @@ export interface InputProps
   maxChipsVisible?: number;
   variant?: 'default' | 'borderless';
   containerRef?: RefObject<HTMLDivElement | null>;
+  classNames?: { container?: string };
 }
 
 export function Input({
@@ -51,6 +52,7 @@ export function Input({
   size,
   variant = 'default',
   containerRef,
+  classNames,
   required,
   ...props
 }: InputProps) {
@@ -61,7 +63,8 @@ export function Input({
     <div
       className={cx(
         inputWrapper({ size, variant }),
-        chips?.length && styles['has-chips']
+        chips?.length && styles['has-chips'],
+        classNames?.container
       )}
       data-disabled={disabled || undefined}
       style={{ width: width || '100%' }}


### PR DESCRIPTION
## Summary

- FilterChip's text and date inputs were passing `className` directly, which targeted the inner `<input>` element instead of the wrapper, breaking the chip's container styles.
- Add a `classNames.container` prop to `Input` so consumers can style the outer wrapper without overriding the input element itself.
- Update FilterChip to use `classNames={{ container: ... }}` for both the `Input` and `DatePicker`'s `inputProps`, restoring the intended chip layout.