### PR TITLE
fix: update calendar select dropdown height

### DIFF
--- a/packages/raystack/components/calendar/calendar.module.css
+++ b/packages/raystack/components/calendar/calendar.module.css
@@ -197,7 +197,7 @@
 }
 
 .dropdownContent {
-  max-height: 400px;
+  max-height: 260px;
 }
 
 .disabled {


### PR DESCRIPTION
## Summary

- Reduce calendar month/year dropdown `max-height` from 400px to 260px so the popover fits comfortably within the calendar surface and avoids overflowing.

<img width="293" height="408" alt="image" src="https://github.com/user-attachments/assets/d14b06b9-22a8-4214-ba73-edc125feb2a6" />
