### PR TITLE
fix(data-table): Header fixes

### DIFF
--- a/packages/raystack/components/data-table/components/virtualized-content.tsx
+++ b/packages/raystack/components/data-table/components/virtualized-content.tsx
@@ -332,11 +332,11 @@ export function VirtualizedContent({
       onScroll={handleVirtualScroll}
     >
       <div role='table' className={cx(styles.virtualTable, classNames.table)}>
-        <div ref={headerRef}>
-          <VirtualHeaders
-            headerGroups={headerGroups}
-            className={cx(styles.stickyHeader, classNames.header)}
-          />
+        <div
+          ref={headerRef}
+          className={cx(styles.stickyHeader, classNames.header)}
+        >
+          <VirtualHeaders headerGroups={headerGroups} />
         </div>
         {stickyGroupHeader && isGrouped && stickyGroup && (
           <div

--- a/packages/raystack/components/data-table/data-table.module.css
+++ b/packages/raystack/components/data-table/data-table.module.css
@@ -33,7 +33,7 @@
   min-width: 0;
 }
 
-.display-popover-properties-select > span {
+.display-popover-properties-select>span {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -81,6 +81,11 @@
 .contentRoot {
   height: 100%;
   overflow: auto;
+}
+
+.contentRoot table {
+  border-collapse: separate;
+  border-spacing: 0;
 }
 
 .row {

--- a/packages/raystack/components/data-table/data-table.module.css
+++ b/packages/raystack/components/data-table/data-table.module.css
@@ -186,7 +186,10 @@
   align-items: center;
   background: var(--rs-color-background-base-secondary);
   font-weight: var(--rs-font-weight-medium);
-  padding: var(--rs-space-3);
+  padding: 0 var(--rs-space-3);
+  height: var(--rs-space-10);
+  margin-bottom: calc(-1 * var(--rs-space-10));
+  box-sizing: border-box;
   border-bottom: 0.5px solid var(--rs-color-border-base-primary);
   box-shadow: 0 1px 0 0 var(--rs-color-border-base-primary);
 }
@@ -202,7 +205,7 @@
 /* Non-virtualized: sticky section header under table header */
 .stickySectionHeader {
   position: sticky;
-  top: var(--rs-space-10);
+  top: var(--rs-space-8);
   z-index: 1;
   background: var(--rs-color-background-base-secondary);
   box-shadow: 0 1px 0 0 var(--rs-color-border-base-primary);

--- a/packages/raystack/components/data-table/data-table.module.css
+++ b/packages/raystack/components/data-table/data-table.module.css
@@ -179,7 +179,9 @@
   display: flex;
   align-items: center;
   background: var(--rs-color-background-base-secondary);
+  font-size: var(--rs-font-size-small);
   font-weight: var(--rs-font-weight-medium);
+  line-height: var(--rs-line-height-small);
   padding: var(--rs-space-3);
 }
 
@@ -190,7 +192,9 @@
   display: flex;
   align-items: center;
   background: var(--rs-color-background-base-secondary);
+  font-size: var(--rs-font-size-small);
   font-weight: var(--rs-font-weight-medium);
+  line-height: var(--rs-line-height-small);
   padding: 0 var(--rs-space-3);
   height: var(--rs-space-10);
   margin-bottom: calc(-1 * var(--rs-space-10));


### PR DESCRIPTION
Bundles a few sticky-header / group-anchor fixes for `DataTable`.

- **Virtualized column header**: was drifting off after ~one row. Sticky class was on an inner element whose containing block was a one-row-tall wrapper. Moved it to the wrapper itself.
- **Non-virtualized section header gap**: `.stickySectionHeader` offset was `--rs-space-10` (40px), but the column header renders at ~32px. Changed to `--rs-space-8`.
- **Virtualized first group duplicated**: `.stickyGroupAnchor` was taking flex-column flow space, so the natural first group header rendered separately. Added explicit `height` + negative `margin-bottom` so it occupies zero flex space; the natural header lands behind it (covered via `z-index`).
- **Non-virtualized column header missing bottom border**: `border-collapse: collapse` + sticky `<th>` eats the `border-bottom`. Locally overridden to `border-collapse: separate; border-spacing: 0` for `DataTable.Content` only.
- **Virtualized group header font size too large**: `.virtualSectionHeader` and `.stickyGroupAnchor` had no font-size rule and inherited the document default (~16px), while non-virtualized renders at small (~12px) via the `<table>` cascade. Added `font-size` and `line-height` tokens to match.

## Test plan

- [ ] Virtualized: column header pinned for full scroll range.
- [ ] Virtualized + grouping: only one label at the top, group anchor stacks under column header while scrolling.
- [ ] Non-virtualized + grouping: section header flush under column header.
- [ ] Non-virtualized: bottom border visible on column header.
- [ ] Virtualized + grouping: group header text matches non-virtualized in size.