### PR TITLE
fix(data-table): make virtualized loader rows scroll with content

### DIFF
--- a/packages/raystack/components/data-table/components/virtualized-content.tsx
+++ b/packages/raystack/components/data-table/components/virtualized-content.tsx
@@ -169,7 +169,7 @@ function VirtualLoaderRows({
   count: number;
 }) {
   return (
-    <div className={styles.stickyLoaderContainer}>
+    <div role='rowgroup' className={styles.loaderContainer}>
       {Array.from({ length: count }).map((_, rowIndex) => (
         <div
           role='row'

--- a/packages/raystack/components/data-table/data-table.module.css
+++ b/packages/raystack/components/data-table/data-table.module.css
@@ -191,10 +191,7 @@
   box-shadow: 0 1px 0 0 var(--rs-color-border-base-primary);
 }
 
-.stickyLoaderContainer {
-  position: sticky;
-  bottom: 0;
-  z-index: 1;
+.loaderContainer {
   background: var(--rs-color-background-base-primary);
 }
 


### PR DESCRIPTION
## Summary

Loader skeleton rows in `DataTable.VirtualizedContent` were pinned to the bottom via `position: sticky`. They should scroll with the list and render at the end of the loaded rows.

## Test plan

- [ ] Open the virtualized DataTable example, trigger load-more, and confirm skeleton rows appear at the end of the list and scroll with the content (no longer pinned to the viewport bottom).