### PR TITLE
fix(alert-dialog): remove footer border and default showCloseButton to false

### DIFF
--- a/apps/www/src/content/docs/components/alert-dialog/props.ts
+++ b/apps/www/src/content/docs/components/alert-dialog/props.ts
@@ -12,7 +12,7 @@ export interface AlertDialogContentProps {
 
   /**
    * Controls whether to show the close button
-   * @default true
+   * @default false
    */
   showCloseButton?: boolean;
 

--- a/packages/raystack/components/alert-dialog/__tests__/alert-dialog.test.tsx
+++ b/packages/raystack/components/alert-dialog/__tests__/alert-dialog.test.tsx
@@ -22,7 +22,7 @@ const BasicAlertDialog = ({
 }) => (
   <AlertDialog open={open} onOpenChange={onOpenChange} {...props}>
     <AlertDialog.Trigger>{TRIGGER_TEXT}</AlertDialog.Trigger>
-    <AlertDialog.Content>
+    <AlertDialog.Content showCloseButton>
       <AlertDialog.Header>
         <AlertDialog.Title>{ALERT_TITLE}</AlertDialog.Title>
       </AlertDialog.Header>

--- a/packages/raystack/components/alert-dialog/alert-dialog-content.tsx
+++ b/packages/raystack/components/alert-dialog/alert-dialog-content.tsx
@@ -20,7 +20,7 @@ export interface AlertDialogContentProps
 export const AlertDialogContent = ({
   className,
   children,
-  showCloseButton = true,
+  showCloseButton = false,
   overlay,
   width,
   style,

--- a/packages/raystack/components/alert-dialog/alert-dialog-misc.tsx
+++ b/packages/raystack/components/alert-dialog/alert-dialog-misc.tsx
@@ -6,6 +6,7 @@ import { cx } from 'class-variance-authority';
 import { type ComponentProps } from 'react';
 import styles from '../dialog/dialog.module.css';
 import { Flex } from '../flex';
+import alertDialogStyles from './alert-dialog.module.css';
 
 export const AlertDialogHeader = ({
   className,
@@ -42,7 +43,7 @@ export const AlertDialogBody = ({
   <Flex
     direction='column'
     gap={3}
-    className={cx(styles.body, className)}
+    className={cx(styles.body, alertDialogStyles.body, className)}
     {...props}
   />
 );

--- a/packages/raystack/components/alert-dialog/alert-dialog.module.css
+++ b/packages/raystack/components/alert-dialog/alert-dialog.module.css
@@ -1,0 +1,3 @@
+.body {
+  border-bottom: none;
+}


### PR DESCRIPTION
## Summary

- Removes the footer border on `AlertDialog.Body` via a new local `alert-dialog.module.css` (overrides the inherited `dialog` body `border-bottom`).
- **BREAKING:** flips the default of `AlertDialog.Content`'s `showCloseButton` prop from `true` to `false`. Existing consumers relying on the close button rendering by default must now opt in by passing `showCloseButton`. Please call this out in the changelog / release notes.
- Updates the docs prop table (`@default false`) and the existing test to explicitly opt into `showCloseButton` so test coverage of the close button is preserved.

## Test plan

- [ ] `pnpm test` (alert-dialog suite) passes
- [ ] Verify visually in the playground that `AlertDialog.Body` no longer has a bottom border
- [ ] Verify that `AlertDialog.Content` renders without a close button by default and that `<AlertDialog.Content showCloseButton>` still renders one
- [ ] Confirm the breaking change is documented in the changelog / release notes before publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)