### PR TITLE
fix(tabs): set default size to medium

### DIFF
--- a/packages/raystack/components/tabs/__tests__/tabs.test.tsx
+++ b/packages/raystack/components/tabs/__tests__/tabs.test.tsx
@@ -319,7 +319,7 @@ describe('Tabs', () => {
   });
 
   describe('Sizes', () => {
-    it('defaults to large size class', () => {
+    it('defaults to medium size class', () => {
       render(
         <Tabs defaultValue='tab1'>
           <Tabs.List>
@@ -332,7 +332,7 @@ describe('Tabs', () => {
       const tablist = screen.getByRole('tablist');
       const root = tablist.closest(`.${styles.root}`);
       expect(root).not.toBeNull();
-      expect(root).toHaveClass(styles['size-large']);
+      expect(root).toHaveClass(styles['size-medium']);
     });
 
     it('applies small size class', () => {

--- a/packages/raystack/components/tabs/tabs.tsx
+++ b/packages/raystack/components/tabs/tabs.tsx
@@ -18,7 +18,7 @@ const tabsRoot = cva(styles.root, {
   },
   defaultVariants: {
     variant: 'segmented',
-    size: 'large'
+    size: 'medium'
   }
 });
 


### PR DESCRIPTION
## Summary
- Tabs default `size` flipped from `large` to `medium` to align with the design specification.
- Updates `defaultVariants.size` in `tabs.tsx` and adjusts the corresponding test assertions.

## Test plan
- [ ] `pnpm test -- packages/raystack/components/tabs` passes
- [ ] Visual check: default `<Tabs>` renders at medium size in playground/storybook

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>