### PR TITLE
fix(data-table): correct toolbar horizontal padding

### DIFF
--- a/packages/raystack/components/data-table/components/filters.tsx
+++ b/packages/raystack/components/data-table/components/filters.tsx
@@ -130,7 +130,11 @@ export function Filters<TData, TValue>({
     }) || [];
 
   return (
-    <Flex gap={3} className={className}>
+    <Flex
+      gap={3}
+      className={className}
+      data-has-filter-chips={appliedFilters.length > 0 || undefined}
+    >
       {appliedFilters.length > 0 && (
         <Flex gap={3} className={classNames?.container}>
           {appliedFilters.map(filter => (

--- a/packages/raystack/components/data-table/data-table.module.css
+++ b/packages/raystack/components/data-table/data-table.module.css
@@ -1,9 +1,14 @@
 .toolbar {
-  padding: var(--rs-space-3);
+  padding: var(--rs-space-3) var(--rs-space-7) var(--rs-space-3)
+    var(--rs-space-5);
   align-self: stretch;
 
   border-bottom: 0.5px solid var(--rs-color-border-base-primary);
   background: var(--rs-color-background-base-primary);
+}
+
+.toolbar:has([data-has-filter-chips]) {
+  padding-left: var(--rs-space-7);
 }
 
 .display-popover-content {


### PR DESCRIPTION
## Summary
- DataTable Toolbar uses asymmetric horizontal padding: 16px left, 24px right, with 8px vertical preserved (previously a uniform 8px on all sides).
- When filter chips are shown, the toolbar's left padding bumps to 24px so its left content aligns with the table header. Filters tags its container with `data-has-filter-chips` and Toolbar uses a `:has()` selector to react.