### PR TITLE
fix(tabs): set default size to medium

### DIFF
--- a/apps/www/src/content/docs/components/tabs/props.ts
+++ b/apps/www/src/content/docs/components/tabs/props.ts
@@ -14,7 +14,10 @@ export interface TabsRootProps {
   /** Visual variant for how tabs are rendered. */
   variant?: 'segmented' | 'standalone' | 'plain';
 
-  /** Size variant applied to all tab triggers. */
+  /**
+   * Size variant applied to all tab triggers.
+   * @default 'medium'
+   */
   size?: 'small' | 'medium' | 'large';
 
   /** Additional CSS class names. */

--- a/docs/V1-migration.md
+++ b/docs/V1-migration.md
@@ -1656,7 +1656,7 @@ Key changes:
 #### New Features
 
 - Three variants: `segmented` (default), `standalone`, `plain`
-- Three sizes: `small`, `medium`, `large`
+- Three sizes: `small`, `medium` (default), `large`
 
 ```tsx
 <Tabs variant="standalone" size="small" defaultValue="tab1">

--- a/packages/raystack/components/tabs/__tests__/tabs.test.tsx
+++ b/packages/raystack/components/tabs/__tests__/tabs.test.tsx
@@ -319,7 +319,7 @@ describe('Tabs', () => {
   });
 
   describe('Sizes', () => {
-    it('defaults to large size class', () => {
+    it('defaults to medium size class', () => {
       render(
         <Tabs defaultValue='tab1'>
           <Tabs.List>
@@ -332,7 +332,7 @@ describe('Tabs', () => {
       const tablist = screen.getByRole('tablist');
       const root = tablist.closest(`.${styles.root}`);
       expect(root).not.toBeNull();
-      expect(root).toHaveClass(styles['size-large']);
+      expect(root).toHaveClass(styles['size-medium']);
     });
 
     it('applies small size class', () => {

--- a/packages/raystack/components/tabs/tabs.tsx
+++ b/packages/raystack/components/tabs/tabs.tsx
@@ -18,7 +18,7 @@ const tabsRoot = cva(styles.root, {
   },
   defaultVariants: {
     variant: 'segmented',
-    size: 'large'
+    size: 'medium'
   }
 });
 


### PR DESCRIPTION
## Summary
- Tabs `defaultVariants.size` flipped from `large` to `medium`.