### PR TITLE
fix(input): hide placeholder when chips are present

### DIFF
--- a/packages/raystack/components/combobox/__tests__/combobox.test.tsx
+++ b/packages/raystack/components/combobox/__tests__/combobox.test.tsx
@@ -184,6 +184,52 @@ describe('Combobox', () => {
 
       expect(screen.getByRole('listbox')).toBeInTheDocument();
     });
+
+    it('hides placeholder once an item is selected in multi-select mode', async () => {
+      const user = userEvent.setup();
+      render(<BasicCombobox multiple />);
+
+      const input = screen.getByRole('combobox');
+      expect(input).toHaveAttribute('placeholder', PLACEHOLDER_TEXT);
+
+      await user.click(input);
+
+      const bananaOption = await screen.findByText('Banana');
+      await clickOption(bananaOption);
+
+      await waitFor(() => {
+        expect(input).not.toHaveAttribute('placeholder');
+      });
+    });
+
+    it('keeps placeholder in single-select mode even after selection', async () => {
+      const user = userEvent.setup();
+      render(<BasicCombobox />);
+
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+
+      const bananaOption = await screen.findByText('Banana');
+      await clickOption(bananaOption);
+
+      expect(input).toHaveAttribute('placeholder', PLACEHOLDER_TEXT);
+    });
+
+    it('restores placeholder when all selected items are removed in multi-select mode', async () => {
+      const user = userEvent.setup();
+      render(<BasicCombobox multiple defaultValue={['banana']} />);
+
+      const input = screen.getByRole('combobox');
+      expect(input).not.toHaveAttribute('placeholder');
+
+      await user.click(input);
+      const bananaOption = await screen.findByText('Banana');
+      await clickOption(bananaOption);
+
+      await waitFor(() => {
+        expect(input).toHaveAttribute('placeholder', PLACEHOLDER_TEXT);
+      });
+    });
   });
 
   describe('Keyboard Navigation', () => {

--- a/packages/raystack/components/input/input.tsx
+++ b/packages/raystack/components/input/input.tsx
@@ -102,7 +102,7 @@ export function Input({
             suffix && styles['has-suffix'],
             className
           )}
-          placeholder={placeholder}
+          placeholder={chips?.length ? undefined : placeholder}
           disabled={disabled}
           required={resolvedRequired}
           {...props}


### PR DESCRIPTION
## Summary
- `Input` now hides its placeholder when chips are rendered, preventing overlap with selection chips.
- Combobox in `multiple` mode auto-benefits since it renders selected values as chips on the underlying Input. Removing all chips restores the placeholder.