### PR TITLE
fix(sidebar): align spacing and tooltip offset with design

### DIFF
--- a/apps/www/src/content/docs/components/sidebar/demo.ts
+++ b/apps/www/src/content/docs/components/sidebar/demo.ts
@@ -402,6 +402,39 @@ export const collapsibleGroupDemo = {
   style: styleDemo
 };
 
+export const groupIconDemo = {
+  type: 'code',
+  code: sidebarLayout(`<Sidebar defaultOpen>
+          <Sidebar.Header>
+            <Flex align="center" gap={3}>
+              <IconButton size={4} aria-label="Logo">
+                <BellIcon width={24} height={24} />
+              </IconButton>
+              <Text size={4} weight="medium" data-collapse-hidden>Apsara</Text>
+            </Flex>
+          </Sidebar.Header>
+          <Sidebar.Main>
+            <Sidebar.Group label="Workspace" leadingIcon={<OrganizationIcon width={16} height={16} />}>
+              <Sidebar.Item href="#" leadingIcon={<BellIcon width={16} height={16} />} active>
+                Dashboard
+              </Sidebar.Item>
+              <Sidebar.Item href="#" leadingIcon={<FilterIcon width={16} height={16} />}>
+                Analytics
+              </Sidebar.Item>
+            </Sidebar.Group>
+            <Sidebar.Group label="Resources" leadingIcon={<FilterIcon width={16} height={16} />}>
+              <Sidebar.Item href="#" leadingIcon={<OrganizationIcon width={16} height={16} />}>
+                Reports
+              </Sidebar.Item>
+              <Sidebar.Item href="#" leadingIcon={<BellIcon width={16} height={16} />}>
+                Activities
+              </Sidebar.Item>
+            </Sidebar.Group>
+          </Sidebar.Main>
+        </Sidebar>`),
+  style: styleDemo
+};
+
 export const moreDemo = {
   type: 'code',
   code: sidebarLayout(`<Sidebar defaultOpen>

--- a/apps/www/src/content/docs/components/sidebar/index.mdx
+++ b/apps/www/src/content/docs/components/sidebar/index.mdx
@@ -9,6 +9,7 @@ import {
   positionDemo,
   variantDemo,
   collapsibleGroupDemo,
+  groupIconDemo,
   stateDemo,
   tooltipDemo,
   collapsibleDemo,
@@ -122,6 +123,12 @@ Set `collapsible={false}` to hide the resize handle and prevent the sidebar from
 Set `hideCollapsedItemTooltip` to disable tooltips on navigation items when the sidebar is collapsed. Useful when item labels are redundant with the collapse tooltip or you want a cleaner collapsed state.
 
 <Demo data={hideTooltipDemo} />
+
+### Group with icon
+
+Pass `leadingIcon` to `Sidebar.Group` to render an icon next to the section label.
+
+<Demo data={groupIconDemo} />
 
 ### Collapsible Group
 

--- a/docs/V1-migration.md
+++ b/docs/V1-migration.md
@@ -1506,6 +1506,8 @@ If you were attaching refs to `Sidebar`, `Sidebar.Header`, `Sidebar.Main`, `Side
 
 7. **`Sidebar.Footer` role changed: `group` -> `list`**
 
+8. **Spacing tightened to match Figma.** The gap between sidebar groups is now `var(--rs-space-6)` (20px, was 4px), and `.nav-group` / `.nav-group-header` no longer apply a `margin-top`. Collapsed `Sidebar.Item` and `Sidebar.More` tooltips now render with a 16px `sideOffset` for clearance from the rail. If you were overriding sidebar group spacing or tooltip positioning, expect slightly different vertical rhythm.
+
 **Full before/after example:**
 
 ```tsx

--- a/packages/raystack/components/sidebar/sidebar-item.tsx
+++ b/packages/raystack/components/sidebar/sidebar-item.tsx
@@ -101,7 +101,9 @@ export function SidebarItem({
     return (
       <Tooltip>
         <Tooltip.Trigger render={content} />
-        <Tooltip.Content side='right'>{children}</Tooltip.Content>
+        <Tooltip.Content side='right' sideOffset={16}>
+          {children}
+        </Tooltip.Content>
       </Tooltip>
     );
   }

--- a/packages/raystack/components/sidebar/sidebar-more.tsx
+++ b/packages/raystack/components/sidebar/sidebar-more.tsx
@@ -63,7 +63,10 @@ export function SidebarMore({
       {isCollapsed && !hideCollapsedItemTooltip ? (
         <Tooltip>
           <Tooltip.Trigger render={<Menu.Trigger render={triggerContent} />} />
-          <Tooltip.Content side={position === 'left' ? 'right' : 'left'}>
+          <Tooltip.Content
+            side={position === 'left' ? 'right' : 'left'}
+            sideOffset={16}
+          >
             {label}
           </Tooltip.Content>
         </Tooltip>

--- a/packages/raystack/components/sidebar/sidebar.module.css
+++ b/packages/raystack/components/sidebar/sidebar.module.css
@@ -54,7 +54,7 @@
   flex: 1;
   overflow-y: auto;
   width: 100%;
-  gap: var(--rs-space-2);
+  gap: var(--rs-space-6);
   align-items: flex-start;
 }
 
@@ -235,7 +235,6 @@
   flex-direction: column;
   align-items: flex-start;
   width: 100%;
-  margin-top: var(--rs-space-3);
 }
 
 .root[data-closed] .nav-group {
@@ -247,11 +246,9 @@
   height: var(--rs-space-7);
   padding: var(--rs-space-2) var(--rs-space-3);
   margin-bottom: var(--rs-space-1);
-  justify-content: space-between;
   align-items: center;
   align-self: stretch;
   color: var(--rs-color-foreground-base-secondary);
-  margin-top: var(--rs-space-4);
   border-radius: var(--rs-radius-2);
 }
 
@@ -265,10 +262,6 @@
 
 .nav-group-accordion-item .nav-group-header {
   padding: 0;
-}
-
-.nav-group-header:first-child {
-  margin-top: 0;
 }
 
 .nav-group-label {


### PR DESCRIPTION
## Summary
- Tooltip `sideOffset` set to 16px on collapsed `Sidebar.Item` and `Sidebar.More` triggers
- Increased `.main` gap between sidebar groups from `--rs-space-2` (4px) to `--rs-space-6` (20px)
- Removed `margin-top` from `.nav-group` and `.nav-group-header` (and the dead `:first-child` reset)
- Removed `justify-content: space-between` from `.nav-group-header`
- Docs: added a "Group with icon" example showing `leadingIcon` passed to `Sidebar.Group`