### PR TITLE
fix(toast): bump viewport edge offset to 24px

### DIFF
--- a/packages/raystack/components/toast/toast.module.css
+++ b/packages/raystack/components/toast/toast.module.css
@@ -10,35 +10,35 @@
 
 /* Position variants */
 .viewport-top-left {
-  top: var(--rs-space-5);
-  left: var(--rs-space-5);
+  top: var(--rs-space-7);
+  left: var(--rs-space-7);
 }
 
 .viewport-top-center {
-  top: var(--rs-space-5);
+  top: var(--rs-space-7);
   left: 50%;
   transform: translateX(-50%);
 }
 
 .viewport-top-right {
-  top: var(--rs-space-5);
-  right: var(--rs-space-5);
+  top: var(--rs-space-7);
+  right: var(--rs-space-7);
 }
 
 .viewport-bottom-left {
-  bottom: var(--rs-space-5);
-  left: var(--rs-space-5);
+  bottom: var(--rs-space-7);
+  left: var(--rs-space-7);
 }
 
 .viewport-bottom-center {
-  bottom: var(--rs-space-5);
+  bottom: var(--rs-space-7);
   left: 50%;
   transform: translateX(-50%);
 }
 
 .viewport-bottom-right {
-  bottom: var(--rs-space-5);
-  right: var(--rs-space-5);
+  bottom: var(--rs-space-7);
+  right: var(--rs-space-7);
 }
 
 /* ===== Toast Root (stacking) ===== */
@@ -160,11 +160,11 @@
 
 /* ===== Enter animations ===== */
 .root[data-position*="bottom"][data-starting-style] {
-  transform: translateY(calc(100% + var(--rs-space-5)));
+  transform: translateY(calc(100% + var(--rs-space-7)));
 }
 
 .root[data-position*="top"][data-starting-style] {
-  transform: translateY(calc(-100% - var(--rs-space-5)));
+  transform: translateY(calc(-100% - var(--rs-space-7)));
 }
 
 /* ===== Limited state ===== */
@@ -179,11 +179,11 @@
 
 /* Default exit (no swipe) */
 .root[data-position*="bottom"][data-ending-style]:not([data-swipe-direction]) {
-  transform: translateY(calc(100% + var(--rs-space-5)));
+  transform: translateY(calc(100% + var(--rs-space-7)));
 }
 
 .root[data-position*="top"][data-ending-style]:not([data-swipe-direction]) {
-  transform: translateY(calc(-100% - var(--rs-space-5)));
+  transform: translateY(calc(-100% - var(--rs-space-7)));
 }
 
 /* Swipe exit directions */


### PR DESCRIPTION
## Summary
- Bumped all four Toast viewport edge offsets from `--rs-space-5` (16px) to `--rs-space-7` (24px) on all six position variants.
- Matching `data-starting-style` / `data-ending-style` slide-in/out transform updates so the toast still animates clear of the edge.
- `max-width: calc(100vw - var(--rs-space-10))` unchanged.