### PR TITLE
NumberInput current format demo update

### DIFF
--- a/apps/www/src/app/examples/page.tsx
+++ b/apps/www/src/app/examples/page.tsx
@@ -286,7 +286,7 @@ const Page = () => {
                   required: true,
                   selected: new Date()
                 }}
-                inputFieldProps={{
+                inputProps={{
                   size: 'small'
                 }}
               />
@@ -315,7 +315,7 @@ const Page = () => {
                   endMonth: dayjs('2027-12-01').toDate(),
                   defaultMonth: dayjs('2027-11-01').toDate()
                 }}
-                inputFieldsProps={{
+                inputsProps={{
                   startDate: {
                     size: 'small'
                   },

--- a/apps/www/src/content/docs/components/number-field/demo.ts
+++ b/apps/www/src/content/docs/components/number-field/demo.ts
@@ -53,8 +53,18 @@ export const composedDemo = {
 
 export const formatDemo = {
   type: 'code',
-  code: `<NumberField
-  defaultValue={1000}
-  format={{ style: 'currency', currency: 'USD' }}
-/>`
+  tabs: [
+    {
+      name: 'System locale (default)',
+      code: `<NumberField defaultValue={1000} format={{ style: 'currency', currency: 'USD' }} />`
+    },
+    {
+      name: 'Pinned to en-US',
+      code: `<NumberField defaultValue={1000} locale="en-US" format={{ style: 'currency', currency: 'USD' }} />`
+    },
+    {
+      name: 'Pinned to de-DE',
+      code: `<NumberField defaultValue={1000} locale="de-DE" format={{ style: 'currency', currency: 'EUR' }} />`
+    }
+  ]
 };

--- a/apps/www/src/content/docs/components/number-field/index.mdx
+++ b/apps/www/src/content/docs/components/number-field/index.mdx
@@ -110,7 +110,9 @@ Full control with scrub area for drag-to-adjust interaction.
 
 ### Formatted
 
-Number field with currency formatting.
+Number field with currency formatting, powered by `Intl.NumberFormat` internally.
+
+`format` sets what to format (currency, decimals); `locale` sets how it's written. Pin `locale` when the output should be stable across different users. 
 
 <Demo data={formatDemo} />
 

--- a/apps/www/src/content/docs/components/number-field/props.ts
+++ b/apps/www/src/content/docs/components/number-field/props.ts
@@ -41,6 +41,15 @@ export interface NumberFieldProps {
    */
   required?: boolean;
 
+  /**
+   * BCP 47 locale tag (or array). Controls separators, grouping, and currency
+   * symbol placement when used with `format`. Defaults to the user's runtime locale,
+   * which means rendered output varies by browser. Pass an explicit value when
+   * deterministic formatting is required.
+   * @defaultValue runtime locale
+   */
+  locale?: Intl.LocalesArgument;
+
   /** Number formatting options (Intl.NumberFormatOptions). */
   format?: Intl.NumberFormatOptions;
 


### PR DESCRIPTION
## Description

Clarifies how `locale` and `format` interact in NumberField and surfaces the previously undocumented locale prop. The currency demo was misleading: the same currency: 'USD' setting rendered differently across users' runtime locales (separators, symbol position, currency name vs. code), and the docs didn't explain that locale is the lever to pin output.
                                                                                                                                                
## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update

## How Has This Been Tested?

  - Built the docs site locally and viewed the Number Field page:                                                                                
    - The new locale row appears in the Root props table.
    - The "Formatted" section renders the new copy and the tabbed demo.                                                                          
    - Switching between System locale, en-US, and de-DE tabs shows the rendered currency string change as expected ($1,000.00, 1.000,00 €, etc.).
  - Verified the Examples page renders DatePicker / RangePicker without console warnings about unknown props.                                    
  - No code paths in packages/raystack/components/number-field/ were touched, so existing unit tests (__tests__/number-field.test.tsx) are unaffected. 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (.mdx files)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

N/A

## Related Issues

#736 
