### PR TITLE
feat: add render prop for custom element rendering in Link

### DIFF
--- a/apps/www/src/content/docs/components/link/index.mdx
+++ b/apps/www/src/content/docs/components/link/index.mdx
@@ -56,6 +56,16 @@ Additional style variations including underlined and external links.
 
 <Demo data={styleDemo} />
 
+### Custom render
+
+Use the `render` prop to render as a custom element such as a router `Link`. All props (including `external`, `download`, and ARIA attributes) are forwarded to the provided element.
+
+```tsx
+import { Link as RouterLink } from "react-router-dom";
+
+<Link render={<RouterLink to="/about" />}>About</Link>
+```
+
 ## Accessibility
 
 The Link component follows accessibility best practices:

--- a/apps/www/src/content/docs/components/link/props.ts
+++ b/apps/www/src/content/docs/components/link/props.ts
@@ -1,12 +1,24 @@
+import type { ReactElement } from 'react';
+
 export interface LinkProps {
-  /** The URL that the link points to. (Required) */
-  href: string;
+  /** The URL that the link points to. */
+  href?: string;
 
   /** Whether the link should open in a new tab. */
   external?: boolean;
 
   /** Whether the link should be downloadable or a string for the filename. */
   download?: boolean | string;
+
+  /**
+   * Custom element used to render the Link.
+   *
+   * All props are forwarded to the specified element. Useful for integrating
+   * with router libraries (e.g. `<NextLink />`, `<RouterLink />`).
+   *
+   * @default "<a />"
+   */
+  render?: ReactElement;
 
   /** Additional CSS class names. */
   className?: string;

--- a/packages/raystack/components/link/__tests__/link.test.tsx
+++ b/packages/raystack/components/link/__tests__/link.test.tsx
@@ -77,6 +77,47 @@ describe('Link', () => {
     });
   });
 
+  describe('Custom render', () => {
+    it('renders as the element provided via render prop', () => {
+      render(
+        <Link href='/test' render={<button type='button' />}>
+          Custom
+        </Link>
+      );
+      const link = screen.getByRole('link');
+      expect(link.tagName).toBe('BUTTON');
+      expect(link).toHaveAttribute('type', 'button');
+    });
+
+    it('forwards Link props to the custom rendered element', () => {
+      render(
+        <Link
+          href='https://example.com'
+          external
+          render={<a data-custom='yes' />}
+        >
+          External
+        </Link>
+      );
+      const link = screen.getByRole('link');
+      expect(link).toHaveAttribute('href', 'https://example.com');
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+      expect(link).toHaveAttribute('data-custom', 'yes');
+    });
+
+    it('preserves the link className on the custom rendered element', () => {
+      render(
+        <Link href='/test' render={<div />}>
+          Custom
+        </Link>
+      );
+      const link = screen.getByRole('link');
+      expect(link.tagName).toBe('DIV');
+      expect(link).toHaveClass(styles.link);
+    });
+  });
+
   describe('HTML Attributes', () => {
     it('supports title attribute', () => {
       render(

--- a/packages/raystack/components/link/link.tsx
+++ b/packages/raystack/components/link/link.tsx
@@ -1,10 +1,11 @@
+import { useRender } from '@base-ui/react';
 import { cx } from 'class-variance-authority';
-import { ComponentProps } from 'react';
 import { Text, type TextBaseProps } from '../text';
 import styles from './link.module.css';
 
-export interface LinkProps extends TextBaseProps, ComponentProps<'a'> {
-  href: string;
+export interface LinkProps
+  extends TextBaseProps,
+    useRender.ComponentProps<'a'> {
   external?: boolean;
   download?: boolean | string;
 }
@@ -16,6 +17,7 @@ export function Link({
   size = 'small',
   external,
   download,
+  render = <a />,
   ...props
 }: LinkProps) {
   const externalProps = external
@@ -42,7 +44,7 @@ export function Link({
       {...externalProps}
       {...downloadProps}
       {...props}
-      render={<a />}
+      render={render}
     >
       {children}
     </Text>


### PR DESCRIPTION
## Summary

- Add `render` prop to `Link`, forwarded to the underlying `Text`/`useRender`, so consumers can swap the rendered element (e.g. router `Link`) instead of always emitting `<a/>`.
- Type `LinkProps` against `useRender.ComponentProps<'a'>` and drop the required `href` (custom render targets may handle navigation themselves); default render remains `<a />`.
- Document the new prop in `props.ts` and add a "Custom render" example to the Link docs page.
- Cover the new behavior with tests verifying tag swap, prop forwarding (href, external → target/rel, custom data attrs), and class preservation.