### PR TITLE
fix(select): set positioner background to prevent overscroll bleed

### DIFF
--- a/packages/raystack/components/select/select.module.css
+++ b/packages/raystack/components/select/select.module.css
@@ -1,5 +1,6 @@
 .positioner {
   z-index: var(--rs-z-index-portal);
+  background-color: var(--rs-color-background-base-primary);
 }
 
 .content {


### PR DESCRIPTION
## Description

The positioner element was transparent, so during touch-overscroll bounce the page's  background (or whatever sits behind the popover) showed through the dropdown's edges. It was highly visible in the dark-theme, multiselect example.
Setting it to --rs-color-background-base-primary make the layer opaque so overscroll bouncing no longer reveals what's behind.   

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

visually tested.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (.mdx files)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

N/A

## Related Issues

#736 
