### PR TITLE
fix(playground): wrap text/number controls in Field so labels render

### DIFF
--- a/apps/www/src/components/demo/demo-controls.tsx
+++ b/apps/www/src/components/demo/demo-controls.tsx
@@ -6,6 +6,7 @@ import {
   UploadIcon
 } from '@radix-ui/react-icons';
 import {
+  Field,
   Flex,
   IconButton,
   Input,
@@ -151,10 +152,9 @@ export default function DemoControls({
 
         // For text and number types
         return (
-          <div key={prop} className={styles.controlField}>
+          <Field key={prop} label={propLabel} className={styles.inputLabel}>
             <Input
               size='small'
-              label={propLabel}
               value={
                 control.type === 'number'
                   ? String(Number(propValue))
@@ -170,9 +170,9 @@ export default function DemoControls({
               type={control.type === 'number' ? 'number' : 'text'}
               min={control.min}
               max={control.max}
-              className={cx(styles.noShadow, styles.inputLabel)}
+              className={styles.noShadow}
             />
-          </div>
+          </Field>
         );
       })}
     </div>


### PR DESCRIPTION
## Description

Fixes labels not rendering above text and number controls in the docs playground (e.g. the Number Field, Amount, and any other component pages with text/number controls).  

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

Labels match the prop name

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (.mdx files)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

N/A

## Related Issues

N/A
