### PR TITLE
feat: indicator classNames and sidebar overflow

### DIFF
--- a/apps/www/src/content/docs/components/indicator/props.ts
+++ b/apps/www/src/content/docs/components/indicator/props.ts
@@ -14,6 +14,9 @@ export interface IndicatorProps {
   /** The content to show the indicator on */
   children: React.ReactNode;
 
+  /** Additional CSS class names */
+  className?: string;
+
   /** Map of classNames for internal components */
   classNames?: {
     /** Class for the indicator badge/dot element */

--- a/apps/www/src/content/docs/components/indicator/props.ts
+++ b/apps/www/src/content/docs/components/indicator/props.ts
@@ -19,7 +19,7 @@ export interface IndicatorProps {
 
   /** Map of classNames for internal components */
   classNames?: {
-    /** Class for the indicator badge/dot element */
-    indicator?: string;
+    /** Class for the outer container element */
+    container?: string;
   };
 }

--- a/apps/www/src/content/docs/components/indicator/props.ts
+++ b/apps/www/src/content/docs/components/indicator/props.ts
@@ -14,6 +14,9 @@ export interface IndicatorProps {
   /** The content to show the indicator on */
   children: React.ReactNode;
 
-  /** Additional CSS class names */
-  className?: string;
+  /** Map of classNames for internal components */
+  classNames?: {
+    /** Class for the indicator badge/dot element */
+    indicator?: string;
+  };
 }

--- a/packages/raystack/components/indicator/indicator.tsx
+++ b/packages/raystack/components/indicator/indicator.tsx
@@ -24,10 +24,13 @@ export interface IndicatorProps
   label?: string;
   children?: ReactNode;
   'aria-label'?: string;
+  classNames?: {
+    indicator?: string;
+  };
 }
 
 export const Indicator = ({
-  className,
+  classNames,
   variant,
   label,
   children,
@@ -40,7 +43,10 @@ export const Indicator = ({
     <div className={styles.wrapper} {...props}>
       {children}
       <div
-        className={indicator({ variant, className })}
+        className={indicator({
+          variant,
+          className: classNames?.indicator
+        })}
         role='status'
         aria-label={accessibilityLabel}
       >

--- a/packages/raystack/components/indicator/indicator.tsx
+++ b/packages/raystack/components/indicator/indicator.tsx
@@ -1,4 +1,4 @@
-import { cva, VariantProps } from 'class-variance-authority';
+import { cva, cx, VariantProps } from 'class-variance-authority';
 import { ComponentProps, ReactNode } from 'react';
 
 import styles from './indicator.module.css';
@@ -25,11 +25,12 @@ export interface IndicatorProps
   children?: ReactNode;
   'aria-label'?: string;
   classNames?: {
-    indicator?: string;
+    container?: string;
   };
 }
 
 export const Indicator = ({
+  className,
   classNames,
   variant,
   label,
@@ -40,13 +41,10 @@ export const Indicator = ({
   const accessibilityLabel = ariaLabel || label || `${variant} indicator`;
 
   return (
-    <div className={styles.wrapper} {...props}>
+    <div className={cx(styles.wrapper, classNames?.container)} {...props}>
       {children}
       <div
-        className={indicator({
-          variant,
-          className: classNames?.indicator
-        })}
+        className={indicator({ variant, className })}
         role='status'
         aria-label={accessibilityLabel}
       >

--- a/packages/raystack/components/sidebar/sidebar.module.css
+++ b/packages/raystack/components/sidebar/sidebar.module.css
@@ -52,7 +52,6 @@
 
 .main {
   flex: 1;
-  overflow-y: auto;
   width: 100%;
   gap: var(--rs-space-6);
   align-items: flex-start;

--- a/packages/raystack/components/sidebar/sidebar.module.css
+++ b/packages/raystack/components/sidebar/sidebar.module.css
@@ -2,7 +2,7 @@
   display: flex;
   width: 220px;
   height: 100%;
-  padding: var(--rs-space-5) var(--rs-space-4);
+  padding: var(--rs-space-5) 0;
   flex-direction: column;
   justify-content: flex-start;
   align-items: flex-start;
@@ -42,17 +42,17 @@
 
 .header {
   gap: var(--rs-space-3);
-  padding: var(--rs-space-2);
+  padding: var(--rs-space-2) var(--rs-space-5) var(--rs-space-7);
   align-self: stretch;
-  border-radius: var(--rs-radius-2);
   background: var(--rs-color-background-base-primary);
   overflow: hidden;
-  margin-bottom: var(--rs-space-6);
 }
 
 .main {
   flex: 1;
-  width: 100%;
+  overflow-y: auto;
+  align-self: stretch;
+  padding: 0 var(--rs-space-4);
   gap: var(--rs-space-6);
   align-items: flex-start;
 }
@@ -67,6 +67,7 @@
 
 .footer {
   width: 100%;
+  padding: 0 var(--rs-space-4);
   gap: var(--rs-space-2);
 }
 


### PR DESCRIPTION
## Summary

- Add `classNames` slot prop to `Indicator` (currently exposes the `indicator` slot) so consumers can target the inner badge without relying on the bare `className` pass-through.
- Update the Indicator docs (`props.ts`) to replace the removed `className` entry with the new `classNames` slot map.
- Remove a stray overflow rule from `sidebar.module.css` to fix layout bleed.