### PR TITLE
fix(www): size 404 Headlines to content so the row centers

### DIFF
--- a/apps/www/src/app/not-found.tsx
+++ b/apps/www/src/app/not-found.tsx
@@ -9,11 +9,11 @@ export default function NotFound() {
       width='full'
       style={{ height: '100vh' }}
     >
-      <Headline size='t3' weight='medium'>
+      <Headline size='t3' weight='medium' style={{ width: 'auto' }}>
         404
       </Headline>
       <Separator orientation='vertical' style={{ height: '48px' }} />
-      <Headline size='t1' weight='regular'>
+      <Headline size='t1' weight='regular' style={{ width: 'auto' }}>
         This page could not be found.
       </Headline>
     </Flex>


### PR DESCRIPTION
## Description

fix(www): size 404 Headlines to content so the row centers

fixing the 404 page where Headline's built-in `width:100%` breaks the centered layout, and the consumer-site fix in `not-found.tsx` using style `width:auto`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

<img width="1512" height="982" alt="Screenshot 2026-05-12 at 3 34 07 PM" src="https://github.com/user-attachments/assets/03b8ccbf-9613-4afa-b4e3-df0ef0616334" />

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (.mdx files)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

<img width="1512" height="982" alt="Screenshot 2026-05-12 at 3 32 56 PM" src="https://github.com/user-attachments/assets/b4fdd5c5-382d-48c2-972d-325e66df6e92" />


## Related Issues
N/A