### PR TITLE
fix(drawer): restore transition by default; opt-out via prefers-reduced-motion: reduce

### DIFF
--- a/packages/raystack/components/drawer/drawer.module.css
+++ b/packages/raystack/components/drawer/drawer.module.css
@@ -73,6 +73,7 @@
 .drawerPopup-right {
   width: 250px;
   height: 100%;
+  transition: transform 450ms cubic-bezier(0.32, 0.72, 0, 1);
   transform: translateX(var(--drawer-swipe-movement-x));
 }
 
@@ -89,6 +90,7 @@
 .drawerPopup-left {
   width: 250px;
   height: 100%;
+  transition: transform 450ms cubic-bezier(0.32, 0.72, 0, 1);
   transform: translateX(var(--drawer-swipe-movement-x));
 }
 
@@ -105,6 +107,7 @@
 .drawerPopup-top {
   width: 100%;
   height: 300px;
+  transition: transform 450ms cubic-bezier(0.32, 0.72, 0, 1);
   transform: translateY(var(--drawer-swipe-movement-y));
 }
 
@@ -121,6 +124,7 @@
 .drawerPopup-bottom {
   width: 100%;
   height: 300px;
+  transition: transform 450ms cubic-bezier(0.32, 0.72, 0, 1);
   transform: translateY(var(--drawer-swipe-movement-y));
 }
 
@@ -197,11 +201,9 @@
   border-top: 1px solid var(--rs-color-border-base-primary);
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  .drawerPopup-right,
-  .drawerPopup-left,
-  .drawerPopup-top,
-  .drawerPopup-bottom {
-    transition: transform 450ms cubic-bezier(0.32, 0.72, 0, 1);
+@media (prefers-reduced-motion: reduce) {
+  .drawerPopup,
+  .backdrop {
+    transition: none;
   }
 }


### PR DESCRIPTION
## Description

#717 moved the per-side `transition: transform` rules out of `.drawerPopup-{right,left,top,bottom}` and into `@media (prefers-reduced-motion: no-preference)`, switching the pattern from "default-on, opt-out for reduce" to "opt-in only when no-preference matches."

That's brittle: when the browser doesn't reliably report `no-preference`, the transition never registers, so the drawer snaps in/out instead of sliding. The bug only affects the four side popups; the backdrop kept its unconditional `transition: opacity` and continued to animate.

This PR restores the pre-#717 pattern:
- `transition: transform 450ms cubic-bezier(...)` declared inline on each `.drawerPopup-{side}` rule
- A single `@media (prefers-reduced-motion: reduce)` block at the bottom that disables transitions for `.drawerPopup` and `.backdrop`

Same a11y intent as #717, more robust default. Matches the pattern used by Dialog (whose transitions are also unconditional with no reduce opt-out today — separate question whether to add one there).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- Built the package and consumed in a downstream Vite app where the right-side drawer previously snapped in. After this change it slides in over ~450ms with the same easing curve as the existing backdrop fade.
- Verified the `prefers-reduced-motion: reduce` override still disables transitions (tested via Chrome DevTools > Rendering > Emulate CSS media feature).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Related Issues

Regression introduced by #717.

🤖 Generated with [Claude Code](https://claude.com/claude-code)