### PR TITLE
fix: replace focus-visible outline with subtle background

### DIFF
--- a/packages/raystack/components/sidebar/sidebar.module.css
+++ b/packages/raystack/components/sidebar/sidebar.module.css
@@ -107,6 +107,12 @@
   color: var(--rs-color-foreground-base-primary);
 }
 
+.nav-item:focus-visible {
+  outline: none;
+  background-color: var(--rs-color-background-base-primary-hover);
+  color: var(--rs-color-foreground-base-primary);
+}
+
 /* keep item highlighted when menu is open */
 .more-trigger[aria-expanded="true"] {
   background-color: var(--rs-color-background-base-primary-hover);


### PR DESCRIPTION
## Summary
- Remove the default browser focus-visible outline on `Sidebar.Item` (`.nav-item`).
- Apply `--rs-color-background-base-primary-hover` (neutral-3) as the focus-visible background — one shade lighter than the active state's neutral-4.
- Source order keeps the active style winning when an item is both active and focused.