### PR TITLE
fix: clear button rendering + input trailing-icon transition

### DIFF
--- a/apps/www/src/components/datatable-demo.tsx
+++ b/apps/www/src/components/datatable-demo.tsx
@@ -146,4 +146,27 @@ const DataTableVirtualizedDemo = () => {
   );
 };
 
-export { DataTableDemo, DataTableVirtualizedDemo };
+const DataTableSearchDemo = () => {
+  const data = useMemo(() => generateData(50), []);
+
+  return (
+    <Flex
+      direction='column'
+      gap={4}
+      width='full'
+      style={{ height: 400, padding: '20px' }}
+    >
+      <DataTable
+        data={data}
+        mode='client'
+        columns={columns}
+        defaultSort={{ name: 'email', order: 'asc' }}
+      >
+        <DataTable.Search placeholder='Search payments…' showClearButton />
+        <DataTable.Content />
+      </DataTable>
+    </Flex>
+  );
+};
+
+export { DataTableDemo, DataTableSearchDemo, DataTableVirtualizedDemo };

--- a/apps/www/src/components/demo/demo.tsx
+++ b/apps/www/src/components/demo/demo.tsx
@@ -36,7 +36,11 @@ import dayjs from 'dayjs';
 import { Home, Info, Laugh, X } from 'lucide-react';
 import NextLink from 'next/link';
 import { Suspense } from 'react';
-import { DataTableDemo, DataTableVirtualizedDemo } from '../datatable-demo';
+import {
+  DataTableDemo,
+  DataTableSearchDemo,
+  DataTableVirtualizedDemo
+} from '../datatable-demo';
 import DataTableSelectionDemo from '../datatable-selection-demo';
 import ChipInputDemo from '../inputfield-chip-demo';
 import LinearMenuDemo from '../linear-dropdown-demo';
@@ -56,6 +60,7 @@ export default function Demo(props: DemoProps) {
       OrganizationIcon,
       SidebarIcon,
       DataTableDemo,
+      DataTableSearchDemo,
       DataTableVirtualizedDemo,
       ChipInputDemo,
       DataTableSelectionDemo,

--- a/apps/www/src/content/docs/components/datatable/demo.ts
+++ b/apps/www/src/content/docs/components/datatable/demo.ts
@@ -49,6 +49,29 @@ export const virtualizedPreview = {
   ]
 };
 
+export const searchPreview = {
+  type: 'code',
+  style: {
+    padding: 0
+  },
+  previewCode: false,
+  code: `<DataTableSearchDemo />`,
+  codePreview: [
+    {
+      label: 'index.tsx',
+      code: `
+      <DataTable
+        data={data}
+        mode="client"
+        columns={columns}
+        defaultSort={{ name: "email", order: "asc" }}>
+        <DataTable.Search placeholder="Search payments…" />
+        <DataTable.Content />
+      </DataTable>`
+    }
+  ]
+};
+
 export const rowSelectionDemo = {
   type: 'code',
   previewCode: false,

--- a/apps/www/src/content/docs/components/datatable/index.mdx
+++ b/apps/www/src/content/docs/components/datatable/index.mdx
@@ -4,7 +4,7 @@ description: An advanced React table that supports filtering, sorting, and pagin
 source: packages/raystack/components/datatable
 ---
 
-import { preview, virtualizedPreview, rowSelectionDemo } from "./demo.ts";
+import { preview, virtualizedPreview, searchPreview, rowSelectionDemo } from "./demo.ts";
 
 <Demo data={preview} />
 
@@ -328,6 +328,8 @@ onColumnVisibilityChange={handleColumnVisibilityChange}>
 ### Using DataTable Search
 
 The `DataTable.Search` component provides search functionality that automatically integrates with the table query. By default, it is disabled in zero state (when no data and no filters/search applied).
+
+<Demo data={searchPreview} />
 
 ```tsx
 <DataTable

--- a/packages/raystack/components/data-table/__tests__/data-table.test.tsx
+++ b/packages/raystack/components/data-table/__tests__/data-table.test.tsx
@@ -187,6 +187,27 @@ describe('DataTable', () => {
 
       expect(screen.getByLabelText('Search')).toBeInTheDocument();
     });
+
+    it('clears the search input when the clear button is clicked', async () => {
+      const user = userEvent.setup();
+      render(
+        <DataTable
+          data={mockData}
+          columns={mockColumns}
+          defaultSort={{ name: 'name', order: 'asc' }}
+        >
+          <DataTable.Search showClearButton />
+          <DataTable.Content />
+        </DataTable>
+      );
+
+      const input = screen.getByLabelText('Search') as HTMLInputElement;
+      await user.type(input, 'hello');
+      expect(input.value).toBe('hello');
+
+      await user.click(screen.getByLabelText('Clear search'));
+      expect(input.value).toBe('');
+    });
   });
 
   describe('Zero State and Empty State', () => {

--- a/packages/raystack/components/data-table/components/search.tsx
+++ b/packages/raystack/components/data-table/components/search.tsx
@@ -54,7 +54,7 @@ export function TableSearch({
     <Search
       {...props}
       onChange={handleSearch}
-      value={tableQuery?.search}
+      value={tableQuery?.search ?? ''}
       onClear={handleClear}
       disabled={isDisabled}
     />

--- a/packages/raystack/components/data-view-beta/components/search.tsx
+++ b/packages/raystack/components/data-view-beta/components/search.tsx
@@ -54,7 +54,7 @@ export function DataViewSearch({
     <Search
       {...props}
       onChange={handleSearch}
-      value={tableQuery?.search}
+      value={tableQuery?.search ?? ''}
       onClear={handleClear}
       disabled={isDisabled}
     />

--- a/packages/raystack/components/input/input.module.css
+++ b/packages/raystack/components/input/input.module.css
@@ -87,7 +87,6 @@
 
 .input-field:focus {
   border-color: var(--rs-color-border-accent-emphasis);
-  background: var(--rs-color-background-base-primary);
 }
 
 .input-field[data-disabled] {

--- a/packages/raystack/components/search/__tests__/search.test.tsx
+++ b/packages/raystack/components/search/__tests__/search.test.tsx
@@ -85,9 +85,9 @@ describe('Search', () => {
       expect(screen.getByLabelText('Clear search')).toBeInTheDocument();
     });
 
-    it('hides clear button when no value', () => {
+    it('renders clear button regardless of value (CSS hides it when empty)', () => {
       render(<Search showClearButton value='' />);
-      expect(screen.queryByLabelText('Clear search')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('Clear search')).toBeInTheDocument();
     });
 
     it('calls onClear when clear button clicked', () => {

--- a/packages/raystack/components/search/search.module.css
+++ b/packages/raystack/components/search/search.module.css
@@ -13,6 +13,10 @@
   justify-content: center;
 }
 
+.container:has(input:placeholder-shown) .clearButtonWrapper {
+  display: none;
+}
+
 .clearButton {
   color: var(--rs-color-foreground-base-tertiary);
 }

--- a/packages/raystack/components/search/search.tsx
+++ b/packages/raystack/components/search/search.tsx
@@ -24,25 +24,24 @@ export function Search({
   variant = 'default',
   ...props
 }: SearchProps) {
-  const trailingIconWithClear =
-    showClearButton && value ? (
-      <div className={styles.clearButtonWrapper}>
-        <IconButton
-          size={size === 'small' ? 2 : 3}
-          onClick={e => {
-            e.stopPropagation();
-            if (!disabled && onClear) {
-              onClear();
-            }
-          }}
-          disabled={disabled}
-          aria-label='Clear search'
-          className={styles.clearButton}
-        >
-          <CrossCircledIcon />
-        </IconButton>
-      </div>
-    ) : undefined;
+  const trailingIconWithClear = showClearButton ? (
+    <div className={styles.clearButtonWrapper}>
+      <IconButton
+        size={size === 'small' ? 2 : 3}
+        onClick={e => {
+          e.stopPropagation();
+          if (!disabled && onClear) {
+            onClear();
+          }
+        }}
+        disabled={disabled}
+        aria-label='Clear search'
+        className={styles.clearButton}
+      >
+        <CrossCircledIcon />
+      </IconButton>
+    </div>
+  ) : undefined;
 
   return (
     <div className={styles.container} role='search' style={{ width }}>


### PR DESCRIPTION
## Summary

- Always render the Search clear button when `showClearButton` is set; CSS (`:has(input:placeholder-shown)`) hides it while the field is empty, avoiding mount/unmount flicker as the user types.
- Default `value` to `''` in `DataTable.Search` and `DataViewSearch` so the underlying `Search` stays controlled even before any input.
- Drop the redundant `background` on `.input-field:focus`; the wrapper already animates the focused background via `:focus-within`, so the trailing-icon area no longer lags behind the input during the hover → focus transition.
- Add a `DataTable.Search` live example to the docs (demo component, preview export, MDX section).