### PR TITLE
fix: sidebar spacing and group margin

### DIFF
--- a/apps/www/src/content/docs/components/sidebar/demo.ts
+++ b/apps/www/src/content/docs/components/sidebar/demo.ts
@@ -23,7 +23,7 @@ export const preview = {
   code: sidebarLayout(`
   <Sidebar defaultOpen>
     <Sidebar.Header>
-      <Flex align="center" gap={3}>
+      <Flex align="center" gap={3} style={{padding:"4px"}}>
         <IconButton size={4} aria-label="Logo">
           <BellIcon width={24} height={24} />
         </IconButton>
@@ -71,7 +71,7 @@ export const positionDemo = {
       code: sidebarLayout(`
       <Sidebar open={true} position="left">
           <Sidebar.Header>
-            <Flex align="center" gap={3}>
+            <Flex align="center" gap={3} style={{padding:"4px"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -96,7 +96,7 @@ export const positionDemo = {
       code: sidebarLayoutRight(`
       <Sidebar open={true} position="right">
           <Sidebar.Header>
-            <Flex align="center" gap={3}>
+            <Flex align="center" gap={3} style={{padding:"4px"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -128,7 +128,7 @@ export const variantDemo = {
       code: sidebarLayout(`
       <Sidebar open={true} variant="plain">
           <Sidebar.Header>
-            <Flex align="center" gap={3}>
+            <Flex align="center" gap={3} style={{padding:"4px"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -149,7 +149,7 @@ export const variantDemo = {
       code: sidebarLayout(`
       <Sidebar open={true} variant="floating">
           <Sidebar.Header>
-            <Flex align="center" gap={3}>
+            <Flex align="center" gap={3} style={{padding:"4px"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -170,7 +170,7 @@ export const variantDemo = {
       code: sidebarLayout(`
       <Sidebar open={true} variant="inset">
           <Sidebar.Header>
-            <Flex align="center" gap={3}>
+            <Flex align="center" gap={3} style={{padding:"4px"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -197,7 +197,7 @@ export const stateDemo = {
       name: 'Expanded',
       code: sidebarLayout(`<Sidebar open={true}>
           <Sidebar.Header>
-            <Flex align="center" gap={3}>
+            <Flex align="center" gap={3} style={{padding:"4px"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -221,7 +221,7 @@ export const stateDemo = {
       name: 'Collapsed',
       code: sidebarLayout(`<Sidebar open={false}>
           <Sidebar.Header>
-            <Flex align="center" gap={3}>
+            <Flex align="center" gap={3} style={{padding:"4px"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -245,7 +245,7 @@ export const stateDemo = {
       name: 'Uncontrolled',
       code: sidebarLayout(`<Sidebar>
           <Sidebar.Header>
-            <Flex align="center" gap={3}>
+            <Flex align="center" gap={3} style={{padding:"4px"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -269,7 +269,7 @@ export const stateDemo = {
       name: 'Uncontrolled (default open)',
       code: sidebarLayout(`<Sidebar defaultOpen>
           <Sidebar.Header>
-            <Flex align="center" gap={3}>
+            <Flex align="center" gap={3} style={{padding:"4px"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -300,7 +300,7 @@ export const tooltipDemo = {
           tooltipMessage="Toggle navigation"
         >
           <Sidebar.Header>
-            <Flex align="center" gap={3}>
+            <Flex align="center" gap={3} style={{padding:"4px"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -326,7 +326,7 @@ export const collapsibleDemo = {
   type: 'code',
   code: sidebarLayout(`<Sidebar defaultOpen collapsible={false}>
           <Sidebar.Header>
-            <Flex align="center" gap={3}>
+            <Flex align="center" gap={3} style={{padding:"4px"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -348,7 +348,7 @@ export const hideTooltipDemo = {
   type: 'code',
   code: sidebarLayout(`<Sidebar defaultOpen={false} hideCollapsedItemTooltip>
           <Sidebar.Header>
-            <Flex align="center" gap={3}>
+            <Flex align="center" gap={3} style={{padding:"4px"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -373,7 +373,7 @@ export const collapsibleGroupDemo = {
   type: 'code',
   code: sidebarLayout(`<Sidebar defaultOpen>
           <Sidebar.Header>
-            <Flex align="center" gap={3}>
+            <Flex align="center" gap={3} style={{padding:"4px"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -412,7 +412,7 @@ export const controlledGroupDemo = {
           return (
             ${sidebarLayout(`<Sidebar defaultOpen>
               <Sidebar.Header>
-                <Flex align="center" gap={3}>
+                <Flex align="center" gap={3} style={{padding:"4px"}}>
                   <IconButton size={4} aria-label="Logo">
                     <BellIcon width={24} height={24} />
                   </IconButton>
@@ -459,7 +459,7 @@ export const groupIconDemo = {
   type: 'code',
   code: sidebarLayout(`<Sidebar defaultOpen>
           <Sidebar.Header>
-            <Flex align="center" gap={3}>
+            <Flex align="center" gap={3} style={{padding:"4px"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -492,7 +492,7 @@ export const moreDemo = {
   type: 'code',
   code: sidebarLayout(`<Sidebar defaultOpen>
           <Sidebar.Header>
-            <Flex align="center" gap={3}>
+            <Flex align="center" gap={3} style={{padding:"4px"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>

--- a/apps/www/src/content/docs/components/sidebar/demo.ts
+++ b/apps/www/src/content/docs/components/sidebar/demo.ts
@@ -23,7 +23,7 @@ export const preview = {
   code: sidebarLayout(`
   <Sidebar defaultOpen>
     <Sidebar.Header>
-      <Flex align="center" gap={3} style={{padding:"4px"}}>
+      <Flex align="center" gap={3} style={{padding:"var(--rs-space-2)"}}>
         <IconButton size={4} aria-label="Logo">
           <BellIcon width={24} height={24} />
         </IconButton>
@@ -33,6 +33,9 @@ export const preview = {
     <Sidebar.Main>
       <Sidebar.Item href="#" leadingIcon={<OrganizationIcon width={16} height={16} />}>
         Overview
+      </Sidebar.Item>
+      <Sidebar.Item href="#" leadingIcon={<OrganizationIcon width={16} height={16} />}>
+        Preview
       </Sidebar.Item>
       <Sidebar.Group label="Main">
         <Sidebar.Item href="#" leadingIcon={<BellIcon width={16} height={16} />} active>
@@ -71,7 +74,7 @@ export const positionDemo = {
       code: sidebarLayout(`
       <Sidebar open={true} position="left">
           <Sidebar.Header>
-            <Flex align="center" gap={3} style={{padding:"4px"}}>
+            <Flex align="center" gap={3} style={{padding:"var(--rs-space-2)"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -96,7 +99,7 @@ export const positionDemo = {
       code: sidebarLayoutRight(`
       <Sidebar open={true} position="right">
           <Sidebar.Header>
-            <Flex align="center" gap={3} style={{padding:"4px"}}>
+            <Flex align="center" gap={3} style={{padding:"var(--rs-space-2)"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -128,7 +131,7 @@ export const variantDemo = {
       code: sidebarLayout(`
       <Sidebar open={true} variant="plain">
           <Sidebar.Header>
-            <Flex align="center" gap={3} style={{padding:"4px"}}>
+            <Flex align="center" gap={3} style={{padding:"var(--rs-space-2)"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -149,7 +152,7 @@ export const variantDemo = {
       code: sidebarLayout(`
       <Sidebar open={true} variant="floating">
           <Sidebar.Header>
-            <Flex align="center" gap={3} style={{padding:"4px"}}>
+            <Flex align="center" gap={3} style={{padding:"var(--rs-space-2)"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -170,7 +173,7 @@ export const variantDemo = {
       code: sidebarLayout(`
       <Sidebar open={true} variant="inset">
           <Sidebar.Header>
-            <Flex align="center" gap={3} style={{padding:"4px"}}>
+            <Flex align="center" gap={3} style={{padding:"var(--rs-space-2)"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -197,7 +200,7 @@ export const stateDemo = {
       name: 'Expanded',
       code: sidebarLayout(`<Sidebar open={true}>
           <Sidebar.Header>
-            <Flex align="center" gap={3} style={{padding:"4px"}}>
+            <Flex align="center" gap={3} style={{padding:"var(--rs-space-2)"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -221,7 +224,7 @@ export const stateDemo = {
       name: 'Collapsed',
       code: sidebarLayout(`<Sidebar open={false}>
           <Sidebar.Header>
-            <Flex align="center" gap={3} style={{padding:"4px"}}>
+            <Flex align="center" gap={3} style={{padding:"var(--rs-space-2)"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -245,7 +248,7 @@ export const stateDemo = {
       name: 'Uncontrolled',
       code: sidebarLayout(`<Sidebar>
           <Sidebar.Header>
-            <Flex align="center" gap={3} style={{padding:"4px"}}>
+            <Flex align="center" gap={3} style={{padding:"var(--rs-space-2)"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -269,7 +272,7 @@ export const stateDemo = {
       name: 'Uncontrolled (default open)',
       code: sidebarLayout(`<Sidebar defaultOpen>
           <Sidebar.Header>
-            <Flex align="center" gap={3} style={{padding:"4px"}}>
+            <Flex align="center" gap={3} style={{padding:"var(--rs-space-2)"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -300,7 +303,7 @@ export const tooltipDemo = {
           tooltipMessage="Toggle navigation"
         >
           <Sidebar.Header>
-            <Flex align="center" gap={3} style={{padding:"4px"}}>
+            <Flex align="center" gap={3} style={{padding:"var(--rs-space-2)"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -326,7 +329,7 @@ export const collapsibleDemo = {
   type: 'code',
   code: sidebarLayout(`<Sidebar defaultOpen collapsible={false}>
           <Sidebar.Header>
-            <Flex align="center" gap={3} style={{padding:"4px"}}>
+            <Flex align="center" gap={3} style={{padding:"var(--rs-space-2)"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -348,7 +351,7 @@ export const hideTooltipDemo = {
   type: 'code',
   code: sidebarLayout(`<Sidebar defaultOpen={false} hideCollapsedItemTooltip>
           <Sidebar.Header>
-            <Flex align="center" gap={3} style={{padding:"4px"}}>
+            <Flex align="center" gap={3} style={{padding:"var(--rs-space-2)"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -373,7 +376,7 @@ export const collapsibleGroupDemo = {
   type: 'code',
   code: sidebarLayout(`<Sidebar defaultOpen>
           <Sidebar.Header>
-            <Flex align="center" gap={3} style={{padding:"4px"}}>
+            <Flex align="center" gap={3} style={{padding:"var(--rs-space-2)"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -412,7 +415,7 @@ export const controlledGroupDemo = {
           return (
             ${sidebarLayout(`<Sidebar defaultOpen>
               <Sidebar.Header>
-                <Flex align="center" gap={3} style={{padding:"4px"}}>
+                <Flex align="center" gap={3} style={{padding:"var(--rs-space-2)"}}>
                   <IconButton size={4} aria-label="Logo">
                     <BellIcon width={24} height={24} />
                   </IconButton>
@@ -459,7 +462,7 @@ export const groupIconDemo = {
   type: 'code',
   code: sidebarLayout(`<Sidebar defaultOpen>
           <Sidebar.Header>
-            <Flex align="center" gap={3} style={{padding:"4px"}}>
+            <Flex align="center" gap={3} style={{padding:"var(--rs-space-2)"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>
@@ -492,7 +495,7 @@ export const moreDemo = {
   type: 'code',
   code: sidebarLayout(`<Sidebar defaultOpen>
           <Sidebar.Header>
-            <Flex align="center" gap={3} style={{padding:"4px"}}>
+            <Flex align="center" gap={3} style={{padding:"var(--rs-space-2)"}}>
               <IconButton size={4} aria-label="Logo">
                 <BellIcon width={24} height={24} />
               </IconButton>

--- a/packages/raystack/components/sidebar/sidebar-main.tsx
+++ b/packages/raystack/components/sidebar/sidebar-main.tsx
@@ -14,7 +14,7 @@ export function SidebarMain({
       className={cx(styles.main, className)}
       direction='column'
       role='group'
-      gap={3}
+      gap={2}
       aria-label='Main navigation'
       {...props}
     />

--- a/packages/raystack/components/sidebar/sidebar-main.tsx
+++ b/packages/raystack/components/sidebar/sidebar-main.tsx
@@ -14,6 +14,7 @@ export function SidebarMain({
       className={cx(styles.main, className)}
       direction='column'
       role='group'
+      gap={3}
       aria-label='Main navigation'
       {...props}
     />

--- a/packages/raystack/components/sidebar/sidebar.module.css
+++ b/packages/raystack/components/sidebar/sidebar.module.css
@@ -9,6 +9,7 @@
   flex-shrink: 0;
   background: var(--rs-color-background-base-primary);
   position: relative;
+  gap: var(--rs-space-6);
 }
 
 .root[data-position="left"] {
@@ -42,7 +43,7 @@
 
 .header {
   gap: var(--rs-space-3);
-  padding: var(--rs-space-2) var(--rs-space-5) var(--rs-space-7);
+  padding: 0 var(--rs-space-4);
   align-self: stretch;
   background: var(--rs-color-background-base-primary);
   overflow: hidden;
@@ -53,7 +54,6 @@
   overflow-y: auto;
   align-self: stretch;
   padding: 0 var(--rs-space-4);
-  gap: var(--rs-space-6);
   align-items: flex-start;
 }
 
@@ -241,6 +241,10 @@
   flex-direction: column;
   align-items: flex-start;
   width: 100%;
+}
+
+.main .nav-group:not(:first-child) {
+  margin-top: var(--rs-space-4);
 }
 
 .root[data-closed] .nav-group {


### PR DESCRIPTION
## Summary
- Add `gap: var(--rs-space-6)` on sidebar root and remove the gap from `.main` so layout regions space themselves consistently.
- Switch `.header` padding to `0 var(--rs-space-4)` to align with the new root gap.
- Set `SidebarMain` to `gap={3}` so items inside main use 8px spacing.
- Add `margin-top: var(--rs-space-4)` (12px) to `.nav-group` inside `.main`, skipping the first child so a leading group sits flush at the top.