### PR TITLE
fix: icon button styles

### DIFF
--- a/packages/raystack/components/icon-button/icon-button.module.css
+++ b/packages/raystack/components/icon-button/icon-button.module.css
@@ -6,23 +6,21 @@
   background-color: transparent;
   border-radius: var(--rs-radius-1);
   border: none;
-  color: var(--rs-color-foreground-base-primary);
+  color: var(--rs-color-foreground-base-secondary);
   cursor: pointer;
   transition: var(--rs-transition-interactive);
   padding: var(--rs-space-1);
 }
 
-.iconButton:hover:not(:disabled) {
+.iconButton:hover:not(:disabled),
+.iconButton:active:not(:disabled) {
   background-color: var(--rs-color-background-base-primary-hover);
+  color: var(--rs-color-foreground-base-primary);
 }
 
 .iconButton:disabled {
   opacity: 0.5;
   cursor: default;
-}
-
-.iconButton:active:not(:disabled) {
-  background-color: var(--rs-color-background-neutral-primary);
 }
 
 .iconButton-size-1 {


### PR DESCRIPTION
## Summary
- Default `IconButton` color now uses `--rs-color-foreground-base-secondary` so the icon reads as a quieter affordance at rest.
- Hover and active states share the same treatment: primary foreground color on top of the primary hover background.
- Removed the separate `:active` background override that previously swapped to `--rs-color-background-neutral-primary`.