### PR TITLE
chore: drop redundant aria-invalid / aria-required on Input & TextArea

### DIFF
--- a/packages/raystack/components/input/input.tsx
+++ b/packages/raystack/components/input/input.tsx
@@ -54,12 +54,10 @@ export function Input({
   containerRef,
   classNames,
   required,
-  'aria-invalid': ariaInvalid,
   ...props
 }: InputProps) {
   const fieldContext = useFieldContext();
   const resolvedRequired = required ?? fieldContext?.required;
-  const resolvedInvalid = ariaInvalid ?? fieldContext?.invalid ?? undefined;
 
   return (
     <div
@@ -109,8 +107,6 @@ export function Input({
           placeholder={chips?.length ? undefined : placeholder}
           disabled={disabled}
           required={resolvedRequired}
-          aria-invalid={resolvedInvalid}
-          aria-required={resolvedRequired || undefined}
           {...props}
         />
       </div>

--- a/packages/raystack/components/text-area/text-area.tsx
+++ b/packages/raystack/components/text-area/text-area.tsx
@@ -48,12 +48,10 @@ export function TextArea({
   required,
   size,
   variant,
-  'aria-invalid': ariaInvalid,
   ...props
 }: TextAreaProps) {
   const fieldContext = useFieldContext();
   const resolvedRequired = required ?? fieldContext?.required;
-  const resolvedInvalid = ariaInvalid ?? fieldContext?.invalid ?? undefined;
 
   const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
     onChange?.(event);
@@ -73,8 +71,6 @@ export function TextArea({
       disabled={disabled}
       placeholder={placeholder}
       required={resolvedRequired}
-      aria-invalid={resolvedInvalid}
-      aria-required={resolvedRequired || undefined}
       style={{ ...style, width }}
       {...props}
     />


### PR DESCRIPTION
## Summary

- Revert the explicit `aria-invalid` / `aria-required` plumbing added to `Input` and `TextArea` in #805 — both attributes were already being applied correctly.
- `@base-ui/react/input` is just `Field.Control` under the hood, and `Field.Control` auto-emits `aria-invalid="true"` from `Field.Root.invalid` via `getInputValidationProps()`. The Apsara `FieldRoot` already passes `invalid` into `<FieldPrimitive.Root>`, so the explicit `aria-invalid={resolvedInvalid}` was a duplicate of what Base UI was emitting.
- `TextArea` opts into the same Base UI behavior via `<FieldPrimitive.Control render={textarea} />` whenever `fieldContext` is present, so it inherited the same redundancy.
- The native HTML `required` attribute (already set via `required={resolvedRequired}`) carries the ARIA "required" semantic by itself; per WAI-ARIA, `aria-required` shouldn't be set on top of native `required`. Also dropped the `resolvedRequired || undefined` ternary, which would have lost the ability to express `aria-required="false"` explicitly.
- Net effect: `-8` lines, no behavior change for screen readers — Base UI / native HTML continue to expose the same a11y contract.