### PR TITLE
chore: forward props in drawer header

### DIFF
--- a/packages/raystack/components/drawer/drawer-misc.tsx
+++ b/packages/raystack/components/drawer/drawer-misc.tsx
@@ -2,16 +2,15 @@
 
 import { Drawer as DrawerPrimitive } from '@base-ui/react/drawer';
 import { cx } from 'class-variance-authority';
-import { ComponentProps, type ReactNode } from 'react';
+import { ComponentProps } from 'react';
 import styles from './drawer.module.css';
 
 export const DrawerHeader = ({
-  children,
-  className
-}: {
-  children: ReactNode;
-  className?: string;
-}) => <div className={cx(styles.header, className)}>{children}</div>;
+  className,
+  ...props
+}: ComponentProps<'div'>) => (
+  <div className={cx(styles.header, className)} {...props} />
+);
 DrawerHeader.displayName = 'Drawer.Header';
 
 export function DrawerTitle({

--- a/packages/raystack/components/spinner/spinner.module.css
+++ b/packages/raystack/components/spinner/spinner.module.css
@@ -1,5 +1,4 @@
 .spinner {
-  display: inline-block;
   position: relative;
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Summary

- Spread native `div` props onto `Drawer.Header` so callers can pass `id`, `role`, `aria-*`, event handlers, etc.
- Replace the bespoke `{ children, className }` prop type with `ComponentProps<'div'>` for full HTML compatibility.
- Drop the now-unused `ReactNode` import.