### PR TITLE
fix(data-table): show skeleton on first load in virtualized tables

### DIFF
--- a/packages/raystack/components/data-table/components/virtualized-content.tsx
+++ b/packages/raystack/components/data-table/components/virtualized-content.tsx
@@ -167,13 +167,11 @@ function VirtualRows<TData>({
 
 function VirtualLoaderRows({
   columns,
-  rowHeight,
   count
 }: {
   columns: ReturnType<
     ReturnType<typeof useDataTable>['table']['getVisibleLeafColumns']
   >;
-  rowHeight: number;
   count: number;
 }) {
   return (
@@ -183,7 +181,6 @@ function VirtualLoaderRows({
           role='row'
           key={'loading-row-' + rowIndex}
           className={cx(styles.virtualRow, styles['row'], styles.loaderRow)}
-          style={{ height: rowHeight }}
         >
           {columns.map((col, colIndex) => {
             const columnDef = col.columnDef as DataTableColumnDef<
@@ -267,7 +264,7 @@ export function VirtualizedContent({
     return list;
   }, [rows, groupHeaderHeight, rowHeight]);
 
-  const showLoaderRows = isLoading && rows.length > 0;
+  const showLoaderRows = isLoading;
 
   const virtualizer = useVirtualizer({
     count: rows.length,
@@ -386,7 +383,6 @@ export function VirtualizedContent({
       {showLoaderRows && (
         <VirtualLoaderRows
           columns={visibleColumns}
-          rowHeight={rowHeight}
           count={loadingRowCount}
         />
       )}

--- a/packages/raystack/components/data-view-beta/components/virtualized-content.tsx
+++ b/packages/raystack/components/data-view-beta/components/virtualized-content.tsx
@@ -187,12 +187,10 @@ function VirtualRows<TData, TValue>({
 function VirtualLoaderRows<TData, TValue>({
   renderedAccessors,
   columnMap,
-  rowHeight,
   count
 }: {
   renderedAccessors: string[];
   columnMap: Map<string, DataViewTableColumn<TData, TValue>>;
-  rowHeight: number;
   count: number;
 }) {
   return (
@@ -202,7 +200,6 @@ function VirtualLoaderRows<TData, TValue>({
           role='row'
           key={'loading-row-' + rowIndex}
           className={cx(styles.virtualRow, styles['row'], styles.loaderRow)}
-          style={{ height: rowHeight }}
         >
           {renderedAccessors.map(accessor => {
             const spec = columnMap.get(accessor);
@@ -302,7 +299,7 @@ export function VirtualizedContent<TData, TValue = unknown>({
     return list;
   }, [rows]);
 
-  const showLoaderRows = isLoading && rows.length > 0;
+  const showLoaderRows = isLoading;
 
   const virtualizer = useVirtualizer({
     count: rows.length,
@@ -421,7 +418,6 @@ export function VirtualizedContent<TData, TValue = unknown>({
         <VirtualLoaderRows
           renderedAccessors={renderedAccessors}
           columnMap={columnMap}
-          rowHeight={rowHeight}
           count={loadingRowCount}
         />
       )}


### PR DESCRIPTION
## Summary

`DataTable.VirtualizedContent` (and `DataView` beta) was not rendering the skeleton loader on initial load. The guard

```ts
const showLoaderRows = isLoading && rows.length > 0;
```

required existing rows for the skeleton to render, which only ever fires on pagination/refetch — never on first load (`rows.length === 0`). Consumers saw an empty table body under the headers until data arrived. The non-virtualized `DataTable.Content` does not have this gap.

Drop `&& rows.length > 0` so the skeleton renders for both first-load and refetch cases. Also remove the explicit `height: rowHeight` from each loader row so it sizes from intrinsic cell padding — matching the height of the non-virtualized `LoaderRows`. Same change applied to `data-view-beta`.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| First load (cold) | Blank body | Skeleton renders |
| Pagination / infinite-scroll fetch | Skeleton at bottom | Skeleton at bottom (unchanged) |
| Refetch with existing rows | Skeleton at bottom | Skeleton at bottom (unchanged) |
| Search returning 0 results, mid-fetch | Blank briefly → empty state | Skeleton briefly → empty state |

Only the last row is a visible behavior change, and arguably an improvement (signals "we're fetching" instead of flashing blank).

## Test plan

- [ ] In `apps/www` `/examples/datatable-virtual`, refresh — skeleton should appear on first load
- [ ] Trigger a paginated fetch — skeleton still appears below existing rows
- [ ] Compare loader row height with `DataTable.Content` (non-virtualized) loader — should match