### PR TITLE
fix(filterChip): fix for breaking date type filterchip, width wrapping, and text value date

### DIFF
--- a/apps/www/src/app/examples/datatable/page.tsx
+++ b/apps/www/src/app/examples/datatable/page.tsx
@@ -423,10 +423,24 @@ const columns: DataTableColumnDef<(typeof sampleData)[number], unknown>[] = [
   {
     accessorKey: 'team',
     header: 'Team',
+    enableColumnFilter: true,
+    filterType: 'multiselect' as const,
     enableGrouping: true,
     showGroupCount: true,
     enableSorting: true,
-    enableHiding: true
+    enableHiding: true,
+    filterOptions: [
+      { value: 'Frontend', label: 'Frontend' },
+      { value: 'Backend', label: 'Backend' },
+      { value: 'Design', label: 'Design' },
+      { value: 'DevOps', label: 'DevOps' },
+      { value: 'Content', label: 'Content' },
+      { value: 'Growth', label: 'Growth' },
+      { value: 'East', label: 'East' },
+      { value: 'West', label: 'West' },
+      { value: 'Tier 1', label: 'Tier 1' },
+      { value: 'Tier 2', label: 'Tier 2' }
+    ]
   },
   {
     accessorKey: 'location',

--- a/apps/www/src/app/examples/page.tsx
+++ b/apps/www/src/app/examples/page.tsx
@@ -274,17 +274,19 @@ const Page = () => {
                 dateFormat='D MMM YYYY'
                 value={dayjs().add(16, 'year').toDate()}
                 onSelect={(value: Date) => console.log(value)}
-                calendarProps={{
-                  captionLayout: 'dropdown',
-                  startMonth: dayjs().add(3, 'month').toDate(),
-                  endMonth: dayjs().add(4, 'year').toDate(),
-                  disabled: {
-                    before: dayjs().add(3, 'month').toDate(),
-                    after: dayjs().add(3, 'year').toDate()
+                slotProps={{
+                  calendar: {
+                    captionLayout: 'dropdown',
+                    startMonth: dayjs().add(3, 'month').toDate(),
+                    endMonth: dayjs().add(4, 'year').toDate(),
+                    disabled: {
+                      before: dayjs().add(3, 'month').toDate(),
+                      after: dayjs().add(3, 'year').toDate()
+                    }
+                  },
+                  input: {
+                    size: 'small'
                   }
-                }}
-                inputProps={{
-                  size: 'small'
                 }}
               />
 
@@ -297,18 +299,18 @@ const Page = () => {
                     to: range.to ?? new Date()
                   })
                 }
-                calendarProps={{
-                  captionLayout: 'dropdown',
-                  numberOfMonths: 2,
-                  startMonth: dayjs('2024-01-01').toDate(),
-                  endMonth: dayjs('2027-12-01').toDate(),
-                  defaultMonth: dayjs('2027-11-01').toDate()
-                }}
-                inputsProps={{
-                  startDate: {
+                slotProps={{
+                  calendar: {
+                    captionLayout: 'dropdown',
+                    numberOfMonths: 2,
+                    startMonth: dayjs('2024-01-01').toDate(),
+                    endMonth: dayjs('2027-12-01').toDate(),
+                    defaultMonth: dayjs('2027-11-01').toDate()
+                  },
+                  startInput: {
                     size: 'small'
                   },
-                  endDate: {
+                  endInput: {
                     size: 'small'
                   }
                 }}
@@ -323,8 +325,10 @@ const Page = () => {
               />
 
               <DatePicker
-                calendarProps={{
-                  captionLayout: 'dropdown'
+                slotProps={{
+                  calendar: {
+                    captionLayout: 'dropdown'
+                  }
                 }}
               />
 

--- a/apps/www/src/app/examples/page.tsx
+++ b/apps/www/src/app/examples/page.tsx
@@ -46,6 +46,7 @@ import {
 import dayjs from 'dayjs';
 import React, { useState } from 'react';
 
+/** Kitchen-sink examples route rendering Apsara components for manual QA. */
 const Page = () => {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [nestedDialogOpen, setNestedDialogOpen] = useState(false);

--- a/apps/www/src/components/playground/calendar-examples.tsx
+++ b/apps/www/src/components/playground/calendar-examples.tsx
@@ -3,6 +3,7 @@
 import { Calendar, DatePicker, Flex, RangePicker } from '@raystack/apsara';
 import PlaygroundLayout from './playground-layout';
 
+/** Playground showcase for `Calendar`, `DatePicker`, and `RangePicker` using the `slotProps` API. */
 export function CalendarExamples() {
   return (
     <PlaygroundLayout title='Calendar'>

--- a/apps/www/src/components/playground/calendar-examples.tsx
+++ b/apps/www/src/components/playground/calendar-examples.tsx
@@ -8,8 +8,8 @@ export function CalendarExamples() {
     <PlaygroundLayout title='Calendar'>
       <Flex gap={5} direction='column'>
         <Calendar numberOfMonths={2} />
-        <RangePicker inputsProps={{ startDate: { size: 'small' } }} />
-        <DatePicker inputProps={{ size: 'small' }} />
+        <RangePicker slotProps={{ startInput: { size: 'small' } }} />
+        <DatePicker slotProps={{ input: { size: 'small' } }} />
       </Flex>
     </PlaygroundLayout>
   );

--- a/apps/www/src/components/playground/filter-chip-examples.tsx
+++ b/apps/www/src/components/playground/filter-chip-examples.tsx
@@ -17,9 +17,19 @@ export function FilterChipExamples() {
             { label: 'Inactive', value: 'inactive' }
           ]}
         />
-        <FilterChip label='Date' leadingIcon={<Info />} columnType='date' />
-        <FilterChip label='Date' leadingIcon={<Info />} columnType='string' />
-        <FilterChip label='Date' leadingIcon={<Info />} columnType='number' />
+        <FilterChip
+          label='Team'
+          leadingIcon={<Info />}
+          columnType='multiselect'
+          options={[
+            { label: 'Frontend', value: 'frontend' },
+            { label: 'Backend', value: 'backend' },
+            { label: 'Design', value: 'design' }
+          ]}
+        />
+        <FilterChip label='Created' leadingIcon={<Info />} columnType='date' />
+        <FilterChip label='Name' leadingIcon={<Info />} columnType='string' />
+        <FilterChip label='Amount' leadingIcon={<Info />} columnType='number' />
       </Flex>
     </PlaygroundLayout>
   );

--- a/apps/www/src/content/docs/components/calendar/props.ts
+++ b/apps/www/src/content/docs/components/calendar/props.ts
@@ -146,7 +146,7 @@ export interface RangePickerProps {
    * - With spaces: "DD MMM YYYY", "MMM DD YYYY", "YYYY MMM DD"
    * - With full month: "DD MMMM YYYY", "MMMM DD YYYY", "YYYY MMMM DD"
    * - For more supported formats, refer to https://day.js.org/docs/en/display/format
-   * @defaultValue "DD/MM/YYYY"
+   * @defaultValue "DD MMM YYYY"
    */
   dateFormat?: string;
 
@@ -229,7 +229,7 @@ export interface DatePickerProps {
    * - With dots: "DD.MM.YYYY", "MM.DD.YYYY", "YYYY.MM.DD"
    * - With spaces: "DD MMM YYYY", "MMM DD YYYY", "YYYY MMM DD"
    * - With full month: "DD MMMM YYYY", "MMMM DD YYYY", "YYYY MMMM DD"
-   * @defaultValue "DD/MM/YYYY"
+   * @defaultValue "DD MMM YYYY"
    */
   dateFormat?: string;
 

--- a/apps/www/src/content/docs/components/datatable/index.mdx
+++ b/apps/www/src/content/docs/components/datatable/index.mdx
@@ -159,7 +159,8 @@ interface DataTableColumnDef<TData, TValue> {
   enableColumnFilter?: boolean; // Enable filtering
   enableHiding?: boolean; // Enable column visibility toggle
   enableGrouping?: boolean; // Enable grouping
-  filterOptions?: FilterSelectOption[]; // Options for select filter
+  filterType?: "string" | "number" | "select" | "multiselect" | "date"; // Filter input type
+  filterOptions?: FilterSelectOption[]; // Options for select/multiselect filters
   defaultHidden?: boolean; // Hide column by default
 }
 ```
@@ -174,6 +175,7 @@ Filter types:
 - Number: equals, not equals, less than, less than or equal, greater than, greater than or equal
 - Date: equals, not equals, before, on or before, after, on or after
 - Select: equals, not equals
+- Multiselect: is any of, is none of (value is a `string[]`)
 
 ### Sorting
 

--- a/apps/www/src/content/docs/components/datatable/props.ts
+++ b/apps/www/src/content/docs/components/datatable/props.ts
@@ -92,7 +92,12 @@ export interface DataTableColumnDef<TData, TValue> {
   /** Enable grouping */
   enableGrouping?: boolean;
 
-  /** Options for select filter */
+  /** Type of filter input rendered in the filter chip
+   * @default "string"
+   */
+  filterType?: 'string' | 'number' | 'select' | 'multiselect' | 'date';
+
+  /** Options for select and multiselect filters */
   filterOptions?: FilterSelectOption[];
 
   /** Props forwarded to filter components by type. Refer to Select and DatePicker for full props lists. */
@@ -136,6 +141,16 @@ export interface FiltersProps {
         availableFilters: DataTableColumn<TData, TValue>[];
         appliedFilters: Set<string>;
       }) => ReactNode);
+
+  /** Additional CSS class names for the filters container */
+  className?: string;
+
+  /** Class names for inner elements. `addFilter` applies to the default
+   * add-filter triggers only — a custom `trigger` styles itself. */
+  classNames?: {
+    filterChips?: string;
+    addFilter?: string;
+  };
 }
 export interface DataTableContentProps {
   /**

--- a/apps/www/src/content/docs/components/datatable/props.ts
+++ b/apps/www/src/content/docs/components/datatable/props.ts
@@ -95,7 +95,7 @@ export interface DataTableColumnDef<TData, TValue> {
   /** Options for select filter */
   filterOptions?: FilterSelectOption[];
 
-  /** Props forwarded to filter components by type. Refer to Select component for full props list. */
+  /** Props forwarded to filter components by type. Refer to Select and DatePicker for full props lists. */
   filterProps?: {
     select?: {
       autocomplete?: boolean;
@@ -103,6 +103,16 @@ export interface DataTableColumnDef<TData, TValue> {
       onSearch?: (value: string) => void;
       searchValue?: string;
       defaultSearchValue?: string;
+    };
+    calendar?: {
+      dateFormat?: string;
+      showCalendarIcon?: boolean;
+      timeZone?: string;
+      slotProps?: {
+        input?: Record<string, unknown>;
+        calendar?: Record<string, unknown>;
+        popover?: Record<string, unknown>;
+      };
     };
   };
 

--- a/apps/www/src/content/docs/components/filter-chip/demo.ts
+++ b/apps/www/src/content/docs/components/filter-chip/demo.ts
@@ -62,22 +62,6 @@ export const inputDemo = {
 />`
     },
     {
-      name: 'Select with Autocomplete',
-      code: `
-<FilterChip
-  label="Status"
-  leadingIcon={<Info />}
-  columnType="select"
-  options={[
-    { label: "Active", value: "active" },
-    { label: "Inactive", value: "inactive" },
-    { label: "Pending", value: "pending" },
-    { label: "Archived", value: "archived" }
-  ]}
-  selectProps={{ autocomplete: true }}
-/>`
-    },
-    {
       name: 'Multiselect',
       code: `
 <FilterChip
@@ -98,21 +82,6 @@ export const inputDemo = {
   label="Created"
   leadingIcon={<Info />}
   columnType="date"
-/>`
-    },
-    {
-      name: 'Date with calendarProps',
-      code: `
-<FilterChip
-  label="Created"
-  leadingIcon={<Info />}
-  columnType="date"
-  calendarProps={{
-    dateFormat: "YYYY-MM-DD",
-    slotProps: {
-      calendar: { captionLayout: "dropdown" }
-    }
-  }}
 />`
     },
     {

--- a/apps/www/src/content/docs/components/filter-chip/demo.ts
+++ b/apps/www/src/content/docs/components/filter-chip/demo.ts
@@ -7,7 +7,7 @@ export const getCode = (props: ComponentPropsType) => {
   const { onRemove, ...rest } = props;
   const onRemoveProp = onRemove ? `onRemove={() => alert("Removed")}` : '';
 
-  if (props.columnType === 'select')
+  if (props.columnType === 'select' || props.columnType === 'multiselect')
     return `
     <FilterChip${getPropsString(rest)}
       options={[
@@ -24,7 +24,7 @@ export const playground = {
   controls: {
     columnType: {
       type: 'select',
-      options: ['select', 'date', 'string', 'number'],
+      options: ['select', 'multiselect', 'date', 'string', 'number'],
       defaultValue: 'string'
     },
     variant: {
@@ -75,6 +75,20 @@ export const inputDemo = {
     { label: "Archived", value: "archived" }
   ]}
   selectProps={{ autocomplete: true }}
+/>`
+    },
+    {
+      name: 'Multiselect',
+      code: `
+<FilterChip
+  label="Status"
+  leadingIcon={<Info />}
+  columnType="multiselect"
+  options={[
+    { label: "Active", value: "active" },
+    { label: "Inactive", value: "inactive" },
+    { label: "Pending", value: "pending" }
+  ]}
 />`
     },
     {

--- a/apps/www/src/content/docs/components/filter-chip/demo.ts
+++ b/apps/www/src/content/docs/components/filter-chip/demo.ts
@@ -87,6 +87,21 @@ export const inputDemo = {
 />`
     },
     {
+      name: 'Date with calendarProps',
+      code: `
+<FilterChip
+  label="Created"
+  leadingIcon={<Info />}
+  columnType="date"
+  calendarProps={{
+    dateFormat: "YYYY-MM-DD",
+    slotProps: {
+      calendar: { captionLayout: "dropdown" }
+    }
+  }}
+/>`
+    },
+    {
       name: 'String',
       code: `
 <FilterChip
@@ -121,6 +136,21 @@ export const autocompleteDemo = {
     { label: "Archived", value: "archived" }
   ]}
   selectProps={{ autocomplete: true }}
+/>`
+};
+export const calendarPropsDemo = {
+  type: 'code',
+  code: `
+<FilterChip
+  label="Created"
+  leadingIcon={<Info />}
+  columnType="date"
+  calendarProps={{
+    dateFormat: "YYYY-MM-DD",
+    slotProps: {
+      calendar: { captionLayout: "dropdown" }
+    }
+  }}
 />`
 };
 export const iconDemo = {

--- a/apps/www/src/content/docs/components/filter-chip/index.mdx
+++ b/apps/www/src/content/docs/components/filter-chip/index.mdx
@@ -4,7 +4,7 @@ description: A compact, interactive element for filtering data with various inpu
 source: packages/raystack/components/filter-chip
 ---
 
-import { playground, inputDemo, autocompleteDemo, iconDemo, actionDemo, operationsDemo } from "./demo.ts";
+import { playground, inputDemo, autocompleteDemo, calendarPropsDemo, iconDemo, actionDemo, operationsDemo } from "./demo.ts";
 
 <Demo data={playground} />
 
@@ -37,6 +37,12 @@ FilterChip supports four different input types to handle various filtering needs
 Use `selectProps` to enable autocomplete search on select and multiselect filter types. This renders a search input inside the dropdown for filtering options.
 
 <Demo data={autocompleteDemo} />
+
+### Date with calendarProps
+
+Use `calendarProps` to forward DatePicker options — `dateFormat`, `timeZone`, `slotProps.calendar`, etc. — to the chip's date control. `value`, `onSelect`, and `defaultValue` are owned by `FilterChip`, and `children` is excluded so the chip's input trigger isn't replaced.
+
+<Demo data={calendarPropsDemo} />
 
 ### With Leading Icon
 

--- a/apps/www/src/content/docs/components/filter-chip/index.mdx
+++ b/apps/www/src/content/docs/components/filter-chip/index.mdx
@@ -28,7 +28,7 @@ Renders an interactive chip for filtering content.
 
 ### Input Types
 
-FilterChip supports four different input types to handle various filtering needs.
+FilterChip supports five input types — `select`, `multiselect`, `date`, `string`, and `number` — to handle various filtering needs. `multiselect` takes a `string[]` value and summarizes two or more selections as "N selected".
 
 <Demo data={inputDemo} />
 

--- a/apps/www/src/content/docs/components/filter-chip/props.ts
+++ b/apps/www/src/content/docs/components/filter-chip/props.ts
@@ -10,6 +10,11 @@ export interface FilterChipProps {
    */
   columnType?: 'select' | 'date' | 'string' | 'number';
 
+  /** Date display/parse format for `columnType="date"`, forwarded to the underlying DatePicker.
+   * @default "DD MMM YYYY"
+   */
+  dateFormat?: string;
+
   /** Filterchip variant
    * @default "default"
    */

--- a/apps/www/src/content/docs/components/filter-chip/props.ts
+++ b/apps/www/src/content/docs/components/filter-chip/props.ts
@@ -10,11 +10,6 @@ export interface FilterChipProps {
    */
   columnType?: 'select' | 'date' | 'string' | 'number';
 
-  /** Date display/parse format for `columnType="date"`, forwarded to the underlying DatePicker.
-   * @default "DD MMM YYYY"
-   */
-  dateFormat?: string;
-
   /** Filterchip variant
    * @default "default"
    */
@@ -45,6 +40,18 @@ export interface FilterChipProps {
     onSearch?: (value: string) => void;
     searchValue?: string;
     defaultSearchValue?: string;
+  };
+
+  /** Props forwarded to the underlying DatePicker for `columnType="date"`. Refer to DatePicker for full props list. `dateFormat` defaults to `"DD MMM YYYY"`. */
+  calendarProps?: {
+    dateFormat?: string;
+    showCalendarIcon?: boolean;
+    timeZone?: string;
+    slotProps?: {
+      input?: Record<string, unknown>;
+      calendar?: Record<string, unknown>;
+      popover?: Record<string, unknown>;
+    };
   };
 
   /** Additional CSS class names */

--- a/apps/www/src/content/docs/components/filter-chip/props.ts
+++ b/apps/www/src/content/docs/components/filter-chip/props.ts
@@ -2,27 +2,31 @@ export interface FilterChipProps {
   /** Text label for the filter (required) */
   label: string;
 
-  /** Current value of the filter */
-  value?: string;
+  /** Current value of the filter. `multiselect` takes a `string[]`; `date`
+   * takes a `Date` (a string or epoch number is parsed for you). */
+  value?: string | string[] | number | Date;
 
   /** Type of input for the filter
    * @default "string"
    */
-  columnType?: 'select' | 'date' | 'string' | 'number';
+  columnType?: 'select' | 'multiselect' | 'date' | 'string' | 'number';
 
   /** Filterchip variant
    * @default "default"
    */
   variant?: 'default' | 'text';
 
-  /** Array of options for the select type input */
+  /** Array of options for the select and multiselect type inputs */
   options?: { label: string; value: string }[];
 
-  /** Optional array of operations for the type of filter oepration */
+  /** Optional array of operations for the type of filter operation */
   operations?: { label: string; value: string }[];
 
-  /** Callback when the filter value changes */
-  onValueChange?: (value: string) => void;
+  /** Callback when the filter value changes; receives the value and the active operation */
+  onValueChange?: (
+    value: string | string[] | number | Date,
+    operation: string
+  ) => void;
 
   /** Callback when the filter operation changes */
   onOperationChange?: (operation: string) => void;

--- a/docs/V1-migration.md
+++ b/docs/V1-migration.md
@@ -22,6 +22,7 @@ This guide covers all breaking changes when upgrading from the last stable Radix
     - [Avatar](#avatar)
     - [Breadcrumb](#breadcrumb)
     - [Button](#button)
+    - [Calendar, DatePicker & RangePicker](#calendar-datepicker--rangepicker)
     - [Chip](#chip)
     - [Checkbox](#checkbox)
       - [New: `Checkbox.Group`](#new-checkboxgroup)
@@ -35,6 +36,7 @@ This guide covers all breaking changes when upgrading from the last stable Radix
       - [New Features](#new-features-3)
     - [DropdownMenu -\> Menu](#dropdownmenu---menu)
       - [New Features](#new-features-4)
+    - [FilterChip](#filterchip)
     - [Flex](#flex)
     - [Grid](#grid)
     - [Headline](#headline)
@@ -434,6 +436,72 @@ Unchanged: `size`, `radius`, `variant`, `color`, `fallback`, `src`, `alt`, `clas
 // After
 <Button render={<Link to="/settings" />}>Settings</Button>
 ```
+
+---
+
+### Calendar, DatePicker & RangePicker
+
+The three calendar surfaces were overhauled (see the package CHANGELOG, PR #819). The consumer-facing migration items:
+
+1. **`slotProps` replaces the per-slot props.** `inputProps`, `calendarProps`, `popoverProps` (and `RangePicker`'s `inputsProps`) are now `@deprecated` — they still work, but `slotProps` wins when both are set. Migrate to the consolidated shape:
+
+```tsx
+// Before
+<DatePicker
+  inputProps={{ size: "small" }}
+  calendarProps={{ captionLayout: "dropdown" }}
+  popoverProps={{ side: "bottom" }}
+/>
+
+// After
+<DatePicker
+  slotProps={{
+    input: { size: "small" },
+    calendar: { captionLayout: "dropdown" },
+    popover: { side: "bottom" }
+  }}
+/>
+```
+
+`RangePicker` splits its two inputs explicitly:
+
+```tsx
+// Before
+<RangePicker inputsProps={{ startDate: { size: "small" }, endDate: { size: "small" } }} />
+
+// After
+<RangePicker slotProps={{ startInput: { size: "small" }, endInput: { size: "small" } }} />
+```
+
+2. **`DatePicker` no longer defaults to today.** Previously `value` defaulted to `new Date()`, so the picker always rendered with today selected. It now starts **unselected** when neither `value` nor `defaultValue` is passed, and honors the "Select date" placeholder. If you relied on the today-default, opt in explicitly:
+
+```tsx
+// Before — implicitly selected today
+<DatePicker onSelect={setDate} />
+
+// After — opt in to the old behavior
+<DatePicker defaultValue={new Date()} onSelect={setDate} />
+```
+
+`RangePicker` likewise drops its `{ from: today, to: today }` default and starts empty.
+
+3. **`value` requires a real `Date` (or `undefined`).** Both pickers are now strict about their controlled value and sync on its timestamp — passing a string or other non-`Date` will throw. Coerce before passing:
+
+```tsx
+// Before — a string happened to coerce via dayjs
+<DatePicker value={isoString} />
+
+// After
+<DatePicker value={isoString ? new Date(isoString) : undefined} />
+```
+
+4. **`onSelect` only fires with a defined date.** It stays typed `(date: Date) => void` and no longer fires with `undefined` (e.g. on deselect). Use `defaultValue` for uncontrolled initialization instead of relying on `onSelect` firing on mount.
+
+5. **`value` is now reactive.** Controlled changes — form resets, preset buttons, URL-driven updates — propagate to the input on both pickers (previously the input could go stale).
+
+6. **Calendar date-bound props renamed.** `fromYear` / `toYear` / `fromMonth` / `toMonth` / `fromDate` / `toDate` are superseded by `startMonth` / `endMonth` (bounds) and `hidden` (disable specific days). See the Calendar docs.
+
+7. **New public types.** `CalendarProps`, `CalendarPropsExtended`, and `DateRange` are now re-exported from `@raystack/apsara`.
 
 ---
 
@@ -1018,6 +1086,22 @@ import { Menu } from '@raystack/apsara';
 - Menubar integration
 - `defaultOpen` for uncontrolled open state
 - `modal` prop (default `true`) to toggle focus trap / outside-interaction blocking
+
+---
+
+### FilterChip
+
+**Date columns now require a real `Date` value.** `FilterChip` forwards its value to the overhauled `DatePicker` (see [Calendar, DatePicker & RangePicker](#calendar-datepicker--rangepicker)), which is now strict about its `value` type. Previously a string was loosely coerced; now a non-`Date` value (including the empty-string default) starts the date field **unselected** instead of erroring. If you drive a `columnType="date"` chip with a controlled value, pass a `Date`:
+
+```tsx
+// Before — string value
+<FilterChip label="Created" columnType="date" value="2024-01-01" />
+
+// After — pass a Date
+<FilterChip label="Created" columnType="date" value={new Date("2024-01-01")} />
+```
+
+`onValueChange` for date columns receives a `Date` as before, and non-date column types are unaffected.
 
 ---
 

--- a/docs/V1-migration.md
+++ b/docs/V1-migration.md
@@ -501,7 +501,7 @@ The three calendar surfaces were overhauled (see the package CHANGELOG, PR #819)
 
 6. **Calendar date-bound props renamed.** `fromYear` / `toYear` / `fromMonth` / `toMonth` / `fromDate` / `toDate` are superseded by `startMonth` / `endMonth` (bounds) and `hidden` (disable specific days). See the Calendar docs.
 
-7. **New public types.** `CalendarProps`, `CalendarPropsExtended`, and `DateRange` are now re-exported from `@raystack/apsara`.
+7. **New public types.** `CalendarProps`, `CalendarPropsExtended`, `DateRange`, `DatePickerProps`, `DatePickerSlotProps`, `FilterChipProps`, `FilterChipValue`, and `FilterChipCalendarProps` are now re-exported from `@raystack/apsara`.
 8. **`dateFormat` default is now `"DD MMM YYYY"`.** Both `DatePicker` and `RangePicker` now render text-based months (e.g. "27 May 2026") by default instead of the locale-ambiguous "27/05/2026". If you rely on the slash format, opt in explicitly:
 
 ```tsx
@@ -1110,13 +1110,11 @@ import { Menu } from '@raystack/apsara';
 
 ### FilterChip
 
-**Date columns now require a real `Date` value.** `FilterChip` forwards its value to the overhauled `DatePicker` (see [Calendar, DatePicker & RangePicker](#calendar-datepicker--rangepicker)), which is now strict about its `value` type. Previously a string was loosely coerced; now a non-`Date` value (including the empty-string default) starts the date field **unselected** instead of erroring. If you drive a `columnType="date"` chip with a controlled value, pass a `Date`:
+**Date column values are parsed, not forwarded raw.** `FilterChip` forwards its value to the overhauled `DatePicker` (see [Calendar, DatePicker & RangePicker](#calendar-datepicker--rangepicker)), which is now strict about its `value` type — but the chip shields you from that: a `Date` passes through, and a string or epoch number (e.g. filter state hydrated from a URL or serialized query) is parsed for you. Only an unparseable value starts the date field **unselected** instead of erroring.
 
 ```tsx
-// Before — string value
+// All equivalent
 <FilterChip label="Created" columnType="date" value="2024-01-01" />
-
-// After — pass a Date
 <FilterChip label="Created" columnType="date" value={new Date("2024-01-01")} />
 ```
 

--- a/docs/V1-migration.md
+++ b/docs/V1-migration.md
@@ -502,6 +502,25 @@ The three calendar surfaces were overhauled (see the package CHANGELOG, PR #819)
 6. **Calendar date-bound props renamed.** `fromYear` / `toYear` / `fromMonth` / `toMonth` / `fromDate` / `toDate` are superseded by `startMonth` / `endMonth` (bounds) and `hidden` (disable specific days). See the Calendar docs.
 
 7. **New public types.** `CalendarProps`, `CalendarPropsExtended`, and `DateRange` are now re-exported from `@raystack/apsara`.
+8. **`dateFormat` default is now `"DD MMM YYYY"`.** Both `DatePicker` and `RangePicker` now render text-based months (e.g. "27 May 2026") by default instead of the locale-ambiguous "27/05/2026". If you rely on the slash format, opt in explicitly:
+
+```tsx
+// Before — implicit DD/MM/YYYY default
+<DatePicker value={date} />
+
+// After — same display
+<DatePicker dateFormat="DD/MM/YYYY" value={date} />
+```
+
+`FilterChip`'s `columnType="date"` inherits this new default directly (its prior internal override is dropped). To restore slash-format inside a chip, pass it via `calendarProps`:
+
+```tsx
+<FilterChip
+  label="Created"
+  columnType="date"
+  calendarProps={{ dateFormat: "DD/MM/YYYY" }}
+/>
+```
 
 ---
 
@@ -1102,6 +1121,29 @@ import { Menu } from '@raystack/apsara';
 ```
 
 `onValueChange` for date columns receives a `Date` as before, and non-date column types are unaffected.
+
+**New: `calendarProps` forwards arbitrary `DatePicker` props.** Mirrors the existing `selectProps` pattern. Use it to set `dateFormat` (defaults to `"DD MMM YYYY"`), `timeZone`, `slotProps.calendar`, etc. on the chip's date control. `value`, `onSelect`, `defaultValue`, and `children` stay owned by `FilterChip`.
+
+```tsx
+<FilterChip
+  label="Created"
+  columnType="date"
+  calendarProps={{
+    dateFormat: "YYYY-MM-DD",
+    slotProps: { calendar: { captionLayout: "dropdown" } }
+  }}
+/>
+```
+
+In `DataTable` / `DataView`, column-level `filterProps` gains a parallel `calendar` slot alongside `select`:
+
+```tsx
+{
+  accessorKey: "created_at",
+  filterType: "date",
+  filterProps: { calendar: { dateFormat: "YYYY-MM-DD" } }
+}
+```
 
 ---
 

--- a/packages/raystack/CHANGELOG.md
+++ b/packages/raystack/CHANGELOG.md
@@ -86,6 +86,21 @@ API added, and the three legacy prop names (`inputProps`,
   non-`Date` values to `undefined` (the date field starts unselected)
   and uses the new `slotProps.input` API instead of the deprecated
   `inputProps`.
+- **FilterChip `calendarProps`** — mirrors the existing `selectProps`
+  pattern: forwards arbitrary props (e.g. `dateFormat`, `timeZone`,
+  `slotProps.calendar`) to the underlying `DatePicker` for
+  `columnType="date"`. `value`/`onSelect`/`defaultValue`/`children`
+  remain owned by `FilterChip`. The standalone `dateFormat` prop is
+  removed — pass `calendarProps={{ dateFormat: '…' }}` instead.
+  `DataTable` / `DataView` columns gain a parallel `filterProps.calendar`
+  slot alongside `filterProps.select`.
+- **`DatePicker` / `RangePicker` `dateFormat` default is now
+  `"DD MMM YYYY"`** (previously `"DD/MM/YYYY"`). Text-based months
+  (e.g. "27 May 2026") avoid the DD/MM vs MM/DD ambiguity that
+  showed up in mixed-locale screenshots. Consumers who relied on
+  the slash default must pass `dateFormat="DD/MM/YYYY"` explicitly.
+  `FilterChip`'s `columnType="date"` inherits the new default
+  directly — its prior internal override is removed.
 
 #### Code-review and audit follow-ups
 

--- a/packages/raystack/CHANGELOG.md
+++ b/packages/raystack/CHANGELOG.md
@@ -78,6 +78,14 @@ API added, and the three legacy prop names (`inputProps`,
   `fill="none"` on stroke-based icons (lucide) and filling the
   outline paths solid. `color` alone now carries the selected style
   via `currentColor` for both stroke- and fill-based icon libraries.
+- **FilterChip date column no longer crashes** — the stricter
+  `DatePicker` `value?: Date` contract above surfaced a latent bug:
+  `FilterChip` seeded its value with `''` and forwarded that string
+  straight to the picker, so the new controlled-sync effect's
+  `valueProp?.getTime()` threw `TypeError`. `FilterChip` now coerces
+  non-`Date` values to `undefined` (the date field starts unselected)
+  and uses the new `slotProps.input` API instead of the deprecated
+  `inputProps`.
 
 #### Code-review and audit follow-ups
 

--- a/packages/raystack/CHANGELOG.md
+++ b/packages/raystack/CHANGELOG.md
@@ -196,13 +196,12 @@ for the tz-aware `dateKey` fix.
 - **DataTable: adding a `select` filter with no `filterOptions` no
   longer crashes** (`options[0].value` → `options[0]?.value`, parity
   with DataView).
-- **DataTable: `multiselect` filters default to `[]`** instead of
+- **DataTable: `multiselect` filters preselect the first option**
+  (matching `select`; `[]` when there are no options) instead of
   falling through to `''` — the chip's multi-`Select` expects an
   array value.
 - **DataTable: `classNames.addFilter` is now applied** to the default
   add-filter triggers (it was accepted and silently dropped).
-- **DataTable: add-filter `IconButton` is `size={4}`** (was `3`) —
-  matches the FilterChip height and DataView.
 - **FilterChip: removed a dead `selectColumn` class reference** left
   behind by #810; the chip's `border-radius` + `overflow: clip`
   already rounds the select trigger.

--- a/packages/raystack/CHANGELOG.md
+++ b/packages/raystack/CHANGELOG.md
@@ -82,10 +82,10 @@ API added, and the three legacy prop names (`inputProps`,
   `DatePicker` `value?: Date` contract above surfaced a latent bug:
   `FilterChip` seeded its value with `''` and forwarded that string
   straight to the picker, so the new controlled-sync effect's
-  `valueProp?.getTime()` threw `TypeError`. `FilterChip` now coerces
-  non-`Date` values to `undefined` (the date field starts unselected)
-  and uses the new `slotProps.input` API instead of the deprecated
-  `inputProps`.
+  `valueProp?.getTime()` threw `TypeError`. `FilterChip` now parses
+  string and epoch-number values into a `Date` (unparseable values
+  start the field unselected) and uses the new `slotProps.input` API
+  instead of the deprecated `inputProps`.
 - **FilterChip `calendarProps`** — mirrors the existing `selectProps`
   pattern: forwards arbitrary props (e.g. `dateFormat`, `timeZone`,
   `slotProps.calendar`) to the underlying `DatePicker` for
@@ -93,7 +93,10 @@ API added, and the three legacy prop names (`inputProps`,
   remain owned by `FilterChip`. The standalone `dateFormat` prop is
   removed — pass `calendarProps={{ dateFormat: '…' }}` instead.
   `DataTable` / `DataView` columns gain a parallel `filterProps.calendar`
-  slot alongside `filterProps.select`.
+  slot alongside `filterProps.select`. The supporting types —
+  `FilterChipProps`, `FilterChipCalendarProps`, `FilterChipValue`,
+  `DatePickerProps`, `DatePickerSlotProps` — are exported from the
+  package root.
 - **`DatePicker` / `RangePicker` `dateFormat` default is now
   `"DD MMM YYYY"`** (previously `"DD/MM/YYYY"`). Text-based months
   (e.g. "27 May 2026") avoid the DD/MM vs MM/DD ambiguity that
@@ -176,6 +179,33 @@ for the tz-aware `dateKey` fix.
 - `dayjs` bumped to `^1.11.20` (was `^1.11.11`) for the strict-parse
   + tz plugins.
 
+### FilterChip & filter toolbar fixes (PR #821)
+
+#### Fixes
+
+- **FilterChip values truncate instead of clipping** — the value
+  input hugs its content (`field-sizing: content`, `width: auto`
+  fallback), caps at 200px, and under toolbar resize pressure shrinks
+  with a visible ellipsis and intact side padding (previously the
+  wrapper clipped the input, hiding both). An empty value keeps a
+  50px clickable floor — the whole visible value area now focuses the
+  input.
+- **Applied filter chips wrap to the panel** — `DataTable`'s
+  `.filterContainer` and `DataView`'s filters row fill the toolbar,
+  wrap, and let chips shrink instead of overflowing in a single row.
+- **DataTable: adding a `select` filter with no `filterOptions` no
+  longer crashes** (`options[0].value` → `options[0]?.value`, parity
+  with DataView).
+- **DataTable: `multiselect` filters default to `[]`** instead of
+  falling through to `''` — the chip's multi-`Select` expects an
+  array value.
+- **DataTable: `classNames.addFilter` is now applied** to the default
+  add-filter triggers (it was accepted and silently dropped).
+- **DataTable: add-filter `IconButton` is `size={4}`** (was `3`) —
+  matches the FilterChip height and DataView.
+- **FilterChip: removed a dead `selectColumn` class reference** left
+  behind by #810; the chip's `border-radius` + `overflow: clip`
+  already rounds the select trigger.
 
 ## 0.11.3
 

--- a/packages/raystack/components/calendar/__tests__/date-picker.test.tsx
+++ b/packages/raystack/components/calendar/__tests__/date-picker.test.tsx
@@ -161,6 +161,18 @@ describe('DatePicker', () => {
     });
   });
 
+  describe('default dateFormat', () => {
+    // Default is `DD MMM YYYY` (text-based month) so the input reads
+    // "27 May 2026" instead of the locale-ambiguous "27/05/2026".
+    it('renders a controlled Date in the DD MMM YYYY format by default', () => {
+      render(<DatePicker value={new Date(2026, 4, 27)} />);
+      const input = screen.getByPlaceholderText(
+        'Select date'
+      ) as HTMLInputElement;
+      expect(input.value).toBe('27 May 2026');
+    });
+  });
+
   describe('value prop is reactive', () => {
     /*
      * Earlier the picker only used `value` as the initial useState seed, so
@@ -173,10 +185,10 @@ describe('DatePicker', () => {
       const input = screen.getByPlaceholderText(
         'Select date'
       ) as HTMLInputElement;
-      expect(input.value).toBe('01/01/2026');
+      expect(input.value).toBe('01 Jan 2026');
 
       rerender(<DatePicker value={new Date(2026, 5, 15)} />);
-      expect(input.value).toBe('15/06/2026');
+      expect(input.value).toBe('15 Jun 2026');
     });
   });
 
@@ -224,7 +236,7 @@ describe('DatePicker', () => {
       const input = screen.getByPlaceholderText(
         'Select date'
       ) as HTMLInputElement;
-      expect(input.value).toBe('15/06/2024');
+      expect(input.value).toBe('15 Jun 2024');
     });
 
     it('value prop takes precedence over defaultValue', () => {
@@ -237,7 +249,7 @@ describe('DatePicker', () => {
       const input = screen.getByPlaceholderText(
         'Select date'
       ) as HTMLInputElement;
-      expect(input.value).toBe('01/01/2025');
+      expect(input.value).toBe('01 Jan 2025');
     });
 
     it('defaultValue is only honored at mount, not on later rerenders', () => {
@@ -247,12 +259,12 @@ describe('DatePicker', () => {
       const input = screen.getByPlaceholderText(
         'Select date'
       ) as HTMLInputElement;
-      expect(input.value).toBe('15/06/2024');
+      expect(input.value).toBe('15 Jun 2024');
 
       // Changing defaultValue after mount should NOT update the input
       // (uncontrolled semantics).
       rerender(<DatePicker defaultValue={new Date(2030, 0, 1)} />);
-      expect(input.value).toBe('15/06/2024');
+      expect(input.value).toBe('15 Jun 2024');
     });
   });
 
@@ -264,7 +276,7 @@ describe('DatePicker', () => {
      */
     it('Enter after typing a valid date fires onSelect exactly once', () => {
       const onSelect = vi.fn();
-      render(<DatePicker onSelect={onSelect} />);
+      render(<DatePicker dateFormat='DD/MM/YYYY' onSelect={onSelect} />);
 
       const input = screen.getByPlaceholderText(
         'Select date'
@@ -287,7 +299,7 @@ describe('DatePicker', () => {
      * are now allowed; bounds come from `startMonth` / `endMonth`.
      */
     it('accepts a future date when no calendarProps bounds are set', () => {
-      render(<DatePicker />);
+      render(<DatePicker dateFormat='DD/MM/YYYY' />);
 
       const input = screen.getByPlaceholderText(
         'Select date'
@@ -299,7 +311,10 @@ describe('DatePicker', () => {
 
     it('accepts a future date within endMonth', () => {
       render(
-        <DatePicker calendarProps={{ endMonth: new Date(2099, 11, 31) }} />
+        <DatePicker
+          dateFormat='DD/MM/YYYY'
+          calendarProps={{ endMonth: new Date(2099, 11, 31) }}
+        />
       );
 
       const input = screen.getByPlaceholderText(
@@ -311,7 +326,10 @@ describe('DatePicker', () => {
 
     it('rejects a date past endMonth', () => {
       render(
-        <DatePicker calendarProps={{ endMonth: new Date(2026, 11, 31) }} />
+        <DatePicker
+          dateFormat='DD/MM/YYYY'
+          calendarProps={{ endMonth: new Date(2026, 11, 31) }}
+        />
       );
 
       const input = screen.getByPlaceholderText(
@@ -323,7 +341,10 @@ describe('DatePicker', () => {
 
     it('rejects a date before startMonth', () => {
       render(
-        <DatePicker calendarProps={{ startMonth: new Date(2026, 0, 1) }} />
+        <DatePicker
+          dateFormat='DD/MM/YYYY'
+          calendarProps={{ startMonth: new Date(2026, 0, 1) }}
+        />
       );
 
       const input = screen.getByPlaceholderText(
@@ -345,7 +366,13 @@ describe('DatePicker', () => {
     it('does not commit partial single-digit input as a date', () => {
       const onSelect = vi.fn();
       const initial = new Date(2026, 4, 20); // 20/05/2026
-      render(<DatePicker value={initial} onSelect={onSelect} />);
+      render(
+        <DatePicker
+          dateFormat='DD/MM/YYYY'
+          value={initial}
+          onSelect={onSelect}
+        />
+      );
 
       const input = screen.getByPlaceholderText(
         'Select date'
@@ -365,7 +392,7 @@ describe('DatePicker', () => {
 
     it('does not commit partial multi-char input that V8 would lenient-parse', () => {
       const initial = new Date(2026, 4, 20);
-      render(<DatePicker value={initial} />);
+      render(<DatePicker dateFormat='DD/MM/YYYY' value={initial} />);
 
       const input = screen.getByPlaceholderText(
         'Select date'
@@ -377,7 +404,7 @@ describe('DatePicker', () => {
     });
 
     it('accepts a fully-typed valid date matching dateFormat', () => {
-      render(<DatePicker />);
+      render(<DatePicker dateFormat='DD/MM/YYYY' />);
 
       const input = screen.getByPlaceholderText(
         'Select date'
@@ -395,7 +422,13 @@ describe('DatePicker', () => {
      */
     it('keeps typed characters visible while typing a full date one char at a time', () => {
       const onSelect = vi.fn();
-      render(<DatePicker value={new Date(2026, 4, 20)} onSelect={onSelect} />);
+      render(
+        <DatePicker
+          dateFormat='DD/MM/YYYY'
+          value={new Date(2026, 4, 20)}
+          onSelect={onSelect}
+        />
+      );
 
       const input = screen.getByPlaceholderText(
         'Select date'
@@ -422,7 +455,7 @@ describe('DatePicker', () => {
 
     it('does not fire onSelect while typing — partial stays uncommitted, valid waits for commit (Enter/blur/outside-click)', () => {
       const onSelect = vi.fn();
-      render(<DatePicker onSelect={onSelect} />);
+      render(<DatePicker dateFormat='DD/MM/YYYY' onSelect={onSelect} />);
 
       const input = screen.getByPlaceholderText(
         'Select date'
@@ -523,6 +556,7 @@ describe('DatePicker', () => {
        */
       render(
         <DatePicker
+          dateFormat='DD/MM/YYYY'
           calendarProps={{
             startMonth: new Date(2020, 0, 1),
             endMonth: new Date(2030, 0, 1)
@@ -544,7 +578,7 @@ describe('DatePicker', () => {
        * Covers the no-bounds path — past regression had an unconditional
        * `isSameOrBefore(dayjs())` that threw without the plugin extended.
        */
-      render(<DatePicker />);
+      render(<DatePicker dateFormat='DD/MM/YYYY' />);
 
       const input = screen.getByPlaceholderText(
         'Select date'

--- a/packages/raystack/components/calendar/__tests__/range-picker.test.tsx
+++ b/packages/raystack/components/calendar/__tests__/range-picker.test.tsx
@@ -75,8 +75,8 @@ describe('RangePicker', () => {
         'Select end date'
       ) as HTMLInputElement;
 
-      expect(startInput.value).toBe('01/01/2026');
-      expect(endInput.value).toBe('15/01/2026');
+      expect(startInput.value).toBe('01 Jan 2026');
+      expect(endInput.value).toBe('15 Jan 2026');
     });
 
     it('does not crash when value is undefined and no defaultValue', () => {
@@ -227,7 +227,7 @@ describe('RangePicker', () => {
       const endInput = screen.getByPlaceholderText(
         'Select end date'
       ) as HTMLInputElement;
-      expect(startInput.value).toBe('15/01/2026');
+      expect(startInput.value).toBe('15 Jan 2026');
       expect(endInput.value).toBe('');
 
       /*
@@ -264,8 +264,8 @@ describe('RangePicker', () => {
       const endInput = screen.getByPlaceholderText(
         'Select end date'
       ) as HTMLInputElement;
-      expect(startInput.value).toBe('15/01/2026');
-      expect(endInput.value).toBe('20/01/2026');
+      expect(startInput.value).toBe('15 Jan 2026');
+      expect(endInput.value).toBe('20 Jan 2026');
 
       /*
        * Popover should have closed -> Calendar unmounted. A tight call-count
@@ -299,7 +299,7 @@ describe('RangePicker', () => {
       const endInput = screen.getByPlaceholderText(
         'Select end date'
       ) as HTMLInputElement;
-      expect(startInput.value).toBe('10/01/2026');
+      expect(startInput.value).toBe('10 Jan 2026');
       expect(endInput.value).toBe(''); // to cleared
       expect(endInput.getAttribute('data-active')).toBe('true'); // still on 'to'
     });
@@ -325,7 +325,7 @@ describe('RangePicker', () => {
       const endInput = screen.getByPlaceholderText(
         'Select end date'
       ) as HTMLInputElement;
-      expect(startInput.value).toBe('01/02/2026');
+      expect(startInput.value).toBe('01 Feb 2026');
       expect(endInput.value).toBe('');
       expect(endInput.getAttribute('data-active')).toBe('true');
     });

--- a/packages/raystack/components/calendar/date-picker.tsx
+++ b/packages/raystack/components/calendar/date-picker.tsx
@@ -27,13 +27,13 @@ dayjs.extend(isSameOrBefore);
  */
 type DatePickerCalendarSlot = Omit<PropsBase, 'mode'> & CalendarPropsExtended;
 
-interface DatePickerSlotProps {
+export interface DatePickerSlotProps {
   input?: InputProps;
   calendar?: DatePickerCalendarSlot;
   popover?: PopoverContentProps;
 }
 
-interface DatePickerProps {
+export interface DatePickerProps {
   dateFormat?: string;
   /**
    * Props for each picker slot. When both this and the legacy
@@ -57,7 +57,7 @@ interface DatePickerProps {
 }
 
 export function DatePicker({
-  dateFormat = 'DD/MM/YYYY',
+  dateFormat = 'DD MMM YYYY',
   slotProps,
   inputProps: legacyInputProps,
   calendarProps: legacyCalendarProps,

--- a/packages/raystack/components/calendar/index.tsx
+++ b/packages/raystack/components/calendar/index.tsx
@@ -1,5 +1,6 @@
 export type { DateRange } from 'react-day-picker';
 export type { CalendarProps, CalendarPropsExtended } from './calendar';
 export { Calendar } from './calendar';
+export type { DatePickerProps, DatePickerSlotProps } from './date-picker';
 export { DatePicker } from './date-picker';
 export { RangePicker } from './range-picker';

--- a/packages/raystack/components/calendar/range-picker.tsx
+++ b/packages/raystack/components/calendar/range-picker.tsx
@@ -56,7 +56,7 @@ interface RangePickerProps {
 type RangeFields = keyof DateRange;
 
 export function RangePicker({
-  dateFormat = 'DD/MM/YYYY',
+  dateFormat = 'DD MMM YYYY',
   slotProps,
   inputsProps: legacyInputsProps = {},
   calendarProps: legacyCalendarProps,

--- a/packages/raystack/components/data-table/components/filters.tsx
+++ b/packages/raystack/components/data-table/components/filters.tsx
@@ -50,7 +50,7 @@ function AddFilter<TData, TValue>({
     else if (children) return children;
     else if (appliedFiltersSet.size > 0)
       return (
-        <IconButton size={4} className={className}>
+        <IconButton size={3} className={className}>
           <FilterIcon />
         </IconButton>
       );

--- a/packages/raystack/components/data-table/components/filters.tsx
+++ b/packages/raystack/components/data-table/components/filters.tsx
@@ -29,13 +29,16 @@ interface AddFilterProps<TData, TValue> {
   appliedFiltersSet: Set<string>;
   onAddFilter: (column: DataTableColumn<TData, TValue>) => void;
   children?: Trigger<TData, TValue>;
+  /** Applied to the default triggers; custom `children` triggers style themselves. */
+  className?: string;
 }
 
 function AddFilter<TData, TValue>({
   columnList = [],
   appliedFiltersSet,
   onAddFilter,
-  children
+  children,
+  className
 }: AddFilterProps<TData, TValue>) {
   const availableFilters = columnList?.filter(
     col => !appliedFiltersSet.has(col.id)
@@ -47,7 +50,7 @@ function AddFilter<TData, TValue>({
     else if (children) return children;
     else if (appliedFiltersSet.size > 0)
       return (
-        <IconButton size={3}>
+        <IconButton size={4} className={className}>
           <FilterIcon />
         </IconButton>
       );
@@ -58,11 +61,12 @@ function AddFilter<TData, TValue>({
           size='small'
           leadingIcon={<FilterIcon />}
           color='neutral'
+          className={className}
         >
           Filter
         </Button>
       );
-  }, [children, appliedFiltersSet, availableFilters]);
+  }, [children, appliedFiltersSet, availableFilters, className]);
 
   return availableFilters.length > 0 ? (
     <Menu>
@@ -162,6 +166,7 @@ export function Filters<TData, TValue>({
         columnList={columnList}
         appliedFiltersSet={appliedFiltersSet}
         onAddFilter={onAddFilter}
+        className={classNames?.addFilter}
       >
         {trigger}
       </AddFilter>

--- a/packages/raystack/components/data-table/components/filters.tsx
+++ b/packages/raystack/components/data-table/components/filters.tsx
@@ -126,6 +126,7 @@ export function Filters<TData, TValue>({
         label: (columnDef?.header as string) || '',
         options: columnDef?.filterOptions || [],
         selectProps: columnDef?.filterProps?.select,
+        calendarProps: columnDef?.filterProps?.calendar,
         ...filter
       };
     }) || [];
@@ -153,6 +154,7 @@ export function Filters<TData, TValue>({
           columnType={filter.filterType}
           options={filter.options}
           selectProps={filter.selectProps}
+          calendarProps={filter.calendarProps}
           className={classNames?.filterChips}
         />
       ))}

--- a/packages/raystack/components/data-table/data-table.module.css
+++ b/packages/raystack/components/data-table/data-table.module.css
@@ -238,4 +238,8 @@
 
 .filterContainer {
   flex-wrap: wrap;
+  /* Fill the toolbar and shrink below content width so FilterChips truncate to
+   * the panel (resolve their `max-width: 100%`) instead of overflowing it. */
+  flex: 1;
+  min-width: 0;
 }

--- a/packages/raystack/components/data-table/data-table.types.tsx
+++ b/packages/raystack/components/data-table/data-table.types.tsx
@@ -11,6 +11,7 @@ import type {
   FilterTypes,
   FilterValueType
 } from '~/types/filters';
+import type { FilterChipCalendarProps } from '../filter-chip';
 import type { BaseSelectProps } from '../select/select-root';
 
 export type DataTableMode = 'client' | 'server';
@@ -84,6 +85,7 @@ export type DataTableColumnDef<TData, TValue> = ColumnDef<TData, TValue> & {
   defaultFilterValue?: unknown;
   filterProps?: {
     select?: BaseSelectProps;
+    calendar?: FilterChipCalendarProps;
   };
   classNames?: {
     cell?: string;

--- a/packages/raystack/components/data-table/hooks/useFilters.tsx
+++ b/packages/raystack/components/data-table/hooks/useFilters.tsx
@@ -24,7 +24,10 @@ export function useFilters<TData, TValue>() {
         : filterType === FilterType.select
           ? options[0]?.value
           : filterType === FilterType.multiselect
-            ? []
+            ? // first option preselected like select; [] when there are no options
+              options
+                .slice(0, 1)
+                .map(opt => opt.value)
             : '');
 
     updateTableQuery(query => {

--- a/packages/raystack/components/data-table/hooks/useFilters.tsx
+++ b/packages/raystack/components/data-table/hooks/useFilters.tsx
@@ -22,15 +22,16 @@ export function useFilters<TData, TValue>() {
       (filterType === FilterType.date
         ? new Date()
         : filterType === FilterType.select
-          ? options[0].value
-          : '');
+          ? options[0]?.value
+          : filterType === FilterType.multiselect
+            ? []
+            : '');
 
     updateTableQuery(query => {
       return {
         ...query,
         filters: [
           ...(query.filters || []),
-          // TODO: Add default filter value in column definition
           {
             _dataType: dataType,
             _type: filterType,

--- a/packages/raystack/components/data-view-beta/components/filters.tsx
+++ b/packages/raystack/components/data-view-beta/components/filters.tsx
@@ -114,6 +114,7 @@ export function Filters<TData>({
         label: field?.label || '',
         options: field?.filterOptions || [],
         selectProps: field?.filterProps?.select,
+        calendarProps: field?.filterProps?.calendar,
         ...filter
       };
     }) || [];
@@ -140,6 +141,7 @@ export function Filters<TData>({
               columnType={filter.filterType}
               options={filter.options}
               selectProps={filter.selectProps}
+              calendarProps={filter.calendarProps}
               className={classNames?.filterChips}
             />
           ))}

--- a/packages/raystack/components/data-view-beta/components/filters.tsx
+++ b/packages/raystack/components/data-view-beta/components/filters.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { cx } from 'class-variance-authority';
 import { isValidElement, ReactNode, useMemo } from 'react';
 import { FilterIcon } from '~/icons';
 import { FilterOperatorTypes, FilterType } from '~/types/filters';
@@ -8,6 +9,7 @@ import { FilterChip } from '../../filter-chip';
 import { Flex } from '../../flex';
 import { IconButton } from '../../icon-button';
 import { Menu } from '../../menu';
+import styles from '../data-view.module.css';
 import { DataViewField } from '../data-view.types';
 import { useDataView } from '../hooks/useDataView';
 import { useFilters } from '../hooks/useFilters';
@@ -120,9 +122,12 @@ export function Filters<TData>({
     }) || [];
 
   return (
-    <Flex gap={3} className={className}>
+    <Flex gap={3} className={cx(styles.filters, className)}>
       {appliedFilters.length > 0 && (
-        <Flex gap={3} className={classNames?.container}>
+        <Flex
+          gap={3}
+          className={cx(styles.appliedFilters, classNames?.container)}
+        >
           {appliedFilters.map(filter => (
             <FilterChip
               key={filter.name}

--- a/packages/raystack/components/data-view-beta/data-view.module.css
+++ b/packages/raystack/components/data-view-beta/data-view.module.css
@@ -6,6 +6,19 @@
   background: var(--rs-color-background-base-primary);
 }
 
+/* Fill the toolbar and let the applied FilterChips wrap/shrink to the panel
+ * instead of overflowing in a single row. */
+.filters {
+  flex: 1;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.appliedFilters {
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
 .display-popover-content {
   padding: 0px;
   /* Todo: var does not exist for 300px */

--- a/packages/raystack/components/data-view-beta/data-view.types.tsx
+++ b/packages/raystack/components/data-view-beta/data-view.types.tsx
@@ -6,6 +6,7 @@ import type {
   FilterTypes,
   FilterValueType
 } from '~/types/filters';
+import type { FilterChipCalendarProps } from '../filter-chip';
 import type { BaseSelectProps } from '../select/select-root';
 
 export type DataViewMode = 'client' | 'server';
@@ -80,6 +81,7 @@ export interface DataViewField<TData = any> {
   defaultFilterValue?: unknown;
   filterProps?: {
     select?: BaseSelectProps;
+    calendar?: FilterChipCalendarProps;
   };
 
   // ordering / grouping / visibility capability

--- a/packages/raystack/components/filter-chip/__tests__/filter-chip.test.tsx
+++ b/packages/raystack/components/filter-chip/__tests__/filter-chip.test.tsx
@@ -163,13 +163,15 @@ describe('FilterChip', () => {
       expect(screen.getByDisplayValue('27 May 2026')).toBeInTheDocument();
     });
 
-    it('honors a custom dateFormat', () => {
+    it('forwards calendarProps to the underlying DatePicker', () => {
+      // dateFormat is the easiest forwarded prop to observe — the formatted
+      // string in the input changes when it lands on DatePicker.
       render(
         <FilterChip
           label='Created'
           columnType={FilterType.date}
           value={new Date(2026, 4, 27)}
-          dateFormat='DD/MM/YYYY'
+          calendarProps={{ dateFormat: 'DD/MM/YYYY' }}
         />
       );
       expect(screen.getByDisplayValue('27/05/2026')).toBeInTheDocument();

--- a/packages/raystack/components/filter-chip/__tests__/filter-chip.test.tsx
+++ b/packages/raystack/components/filter-chip/__tests__/filter-chip.test.tsx
@@ -179,20 +179,24 @@ describe('FilterChip', () => {
   });
 
   describe('Content-fit width', () => {
-    it('sizes the string input container to its content', () => {
+    // The value hug lives on the input itself (`field-sizing: content` in
+    // `.chip input`) — jsdom computes no layout, so these only pin the
+    // containers to the default fluid width that lets the input shrink and
+    // ellipsize under pressure instead of being clipped by the wrapper.
+    it('keeps the string input container fluid so the input can shrink', () => {
       const { container } = render(
         <FilterChip label='Name' columnType={FilterType.string} />
       );
       const inputContainer = container.querySelector(`.${styles.inputField}`);
-      expect(inputContainer).toHaveStyle({ width: 'fit-content' });
+      expect(inputContainer).toHaveStyle({ width: '100%' });
     });
 
-    it('sizes the date field container to its content', () => {
+    it('keeps the date field container fluid so the input can shrink', () => {
       const { container } = render(
         <FilterChip label='Created' columnType={FilterType.date} />
       );
       const dateContainer = container.querySelector(`.${styles.dateField}`);
-      expect(dateContainer).toHaveStyle({ width: 'fit-content' });
+      expect(dateContainer).toHaveStyle({ width: '100%' });
     });
   });
 

--- a/packages/raystack/components/filter-chip/__tests__/filter-chip.test.tsx
+++ b/packages/raystack/components/filter-chip/__tests__/filter-chip.test.tsx
@@ -136,15 +136,36 @@ describe('FilterChip', () => {
       expect(screen.getByPlaceholderText('Select date')).toBeInTheDocument();
     });
 
-    it('coerces a non-Date value to unselected instead of crashing', () => {
-      // FilterChipValue allows string, but a date column needs a real Date —
-      // strings must start the field unselected, not throw.
+    it('parses a serialized string date value instead of rendering blank', () => {
+      render(
+        <FilterChip
+          label='Created'
+          columnType={FilterType.date}
+          value='2026-05-27'
+        />
+      );
+      expect(screen.getByDisplayValue('27 May 2026')).toBeInTheDocument();
+    });
+
+    it('parses an epoch number value', () => {
+      // Local-component Date so the timestamp is timezone-stable.
+      render(
+        <FilterChip
+          label='Created'
+          columnType={FilterType.date}
+          value={new Date(2026, 4, 27).getTime()}
+        />
+      );
+      expect(screen.getByDisplayValue('27 May 2026')).toBeInTheDocument();
+    });
+
+    it('coerces an unparseable value to unselected instead of crashing', () => {
       expect(() =>
         render(
           <FilterChip
             label='Created'
             columnType={FilterType.date}
-            value='2026-05-27'
+            value='not-a-date'
           />
         )
       ).not.toThrow();
@@ -179,10 +200,8 @@ describe('FilterChip', () => {
   });
 
   describe('Content-fit width', () => {
-    // The value hug lives on the input itself (`field-sizing: content` in
-    // `.chip input`) — jsdom computes no layout, so these only pin the
-    // containers to the default fluid width that lets the input shrink and
-    // ellipsize under pressure instead of being clipped by the wrapper.
+    // The value hug lives on the input (`field-sizing` in `.chip input`);
+    // these pin the containers to the fluid width that lets the input shrink.
     it('keeps the string input container fluid so the input can shrink', () => {
       const { container } = render(
         <FilterChip label='Name' columnType={FilterType.string} />

--- a/packages/raystack/components/filter-chip/__tests__/filter-chip.test.tsx
+++ b/packages/raystack/components/filter-chip/__tests__/filter-chip.test.tsx
@@ -125,6 +125,75 @@ describe('FilterChip', () => {
     });
   });
 
+  describe('Date Filter Type', () => {
+    it('renders the date picker without crashing when no value is set', () => {
+      // Regression: an unset date chip seeds its value with '' and forwarded
+      // that string to DatePicker, whose controlled-sync effect ran
+      // `valueProp?.getTime()` → "getTime is not a function".
+      expect(() =>
+        render(<FilterChip label='Created' columnType={FilterType.date} />)
+      ).not.toThrow();
+      expect(screen.getByPlaceholderText('Select date')).toBeInTheDocument();
+    });
+
+    it('coerces a non-Date value to unselected instead of crashing', () => {
+      // FilterChipValue allows string, but a date column needs a real Date —
+      // strings must start the field unselected, not throw.
+      expect(() =>
+        render(
+          <FilterChip
+            label='Created'
+            columnType={FilterType.date}
+            value='2026-05-27'
+          />
+        )
+      ).not.toThrow();
+      expect(screen.getByPlaceholderText('Select date')).toHaveValue('');
+    });
+
+    it('formats a Date value with the default month-as-text format', () => {
+      // Local-component Date so the formatted string is timezone-stable.
+      render(
+        <FilterChip
+          label='Created'
+          columnType={FilterType.date}
+          value={new Date(2026, 4, 27)}
+        />
+      );
+      expect(screen.getByDisplayValue('27 May 2026')).toBeInTheDocument();
+    });
+
+    it('honors a custom dateFormat', () => {
+      render(
+        <FilterChip
+          label='Created'
+          columnType={FilterType.date}
+          value={new Date(2026, 4, 27)}
+          dateFormat='DD/MM/YYYY'
+        />
+      );
+      expect(screen.getByDisplayValue('27/05/2026')).toBeInTheDocument();
+    });
+  });
+
+  describe('Content-fit width', () => {
+    it('sizes the string input container to its content', () => {
+      const { container } = render(
+        <FilterChip label='Name' columnType={FilterType.string} />
+      );
+      const inputContainer = container.querySelector(`.${styles.inputField}`);
+      expect(inputContainer).toHaveStyle({ width: 'fit-content' });
+    });
+
+    it('sizes the date field container to its content', () => {
+      const { container } = render(
+        <FilterChip label='Created' columnType={FilterType.date} />
+      );
+      const dateContainer = container.querySelector(`.${styles.dateField}`);
+      expect(dateContainer).toHaveStyle({ width: 'fit-content' });
+    });
+  });
+
   describe('Forwarded HTML attributes', () => {
     it('forwards arbitrary HTML attributes onto the root div', () => {
       render(

--- a/packages/raystack/components/filter-chip/filter-chip.module.css
+++ b/packages/raystack/components/filter-chip/filter-chip.module.css
@@ -7,8 +7,11 @@
   background: var(--rs-color-background-base-primary);
   border-radius: var(--rs-radius-2);
   text-wrap: nowrap;
+  /* Hug content, but cap at the parent and shrink under it. `min-width: 0`
+   * is required: `min-content` would let the value leak in and beat the cap. */
   width: fit-content;
-  min-width: min-content;
+  min-width: 0;
+  max-width: 100%;
   overflow: clip;
 }
 
@@ -148,6 +151,9 @@ button.selectValue:hover {
   height: 22px;
   border: none;
   box-shadow: none;
+  /* Clickable floor for an empty value; on the container (not the input) so
+   * the `overflow: hidden` wrapper can still clip it away under pressure. */
+  min-width: var(--rs-space-10);
 }
 
 /* Match height of Input when FilterChip variant is text */
@@ -156,17 +162,14 @@ button.selectValue:hover {
   min-height: var(--rs-space-7);
 }
 
-/*
-* Hug the content via `field-sizing` (Chromium/Safari); elsewhere fall back
-* to the intrinsic `width: auto`. Bounds are guardrails: clickable floor +
-* runaway ceiling.
-*/
+/* Hug the value (`field-sizing`, `width: auto` fallback). `min-width: 0` lets
+ * it clip under pressure; `max-width` caps a runaway value so chips stay compact. */
 .inputFieldWrapper input {
   padding-left: var(--rs-space-3);
   padding-right: var(--rs-space-3);
   field-sizing: content;
   width: auto;
-  min-width: var(--rs-space-10);
+  min-width: 0;
   max-width: 200px;
 }
 
@@ -182,6 +185,8 @@ button.selectValue:hover {
   justify-content: space-between;
   align-items: center;
   width: fit-content;
+  /* Clickable floor on the container — see .inputField. */
+  min-width: var(--rs-space-10);
   height: 22px;
   min-height: 22px;
   border: none;
@@ -201,7 +206,7 @@ button.selectValue:hover {
   /* Hug the formatted date string — see .inputFieldWrapper input. */
   field-sizing: content;
   width: auto;
-  min-width: var(--rs-space-10);
+  min-width: 0;
   max-width: 200px;
 }
 

--- a/packages/raystack/components/filter-chip/filter-chip.module.css
+++ b/packages/raystack/components/filter-chip/filter-chip.module.css
@@ -39,12 +39,9 @@
   background: var(--rs-color-background-base-primary-hover);
 }
 
-/* Target any input fields within the chip. The input itself hugs its value
- * (`field-sizing`, `width: auto` fallback) and is the element that shrinks
- * under parent-resize pressure (`flex-shrink`) — so `text-overflow` can
- * ellipsize with the side padding intact instead of the wrapper clipping it.
- * `min-width` keeps a clickable floor for an empty value; `max-width` caps a
- * runaway value so chips stay compact. */
+/* Inputs within the chip hug their value (`field-sizing`) and shrink under
+ * resize pressure so `text-overflow` ellipsizes with padding intact;
+ * `min-width` keeps an empty value clickable, `max-width` caps a runaway one. */
 .chip input {
   border: none;
   box-shadow: none;

--- a/packages/raystack/components/filter-chip/filter-chip.module.css
+++ b/packages/raystack/components/filter-chip/filter-chip.module.css
@@ -39,13 +39,23 @@
   background: var(--rs-color-background-base-primary-hover);
 }
 
-/* Target any input fields within the chip */
+/* Target any input fields within the chip. The input itself hugs its value
+ * (`field-sizing`, `width: auto` fallback) and is the element that shrinks
+ * under parent-resize pressure (`flex-shrink`) — so `text-overflow` can
+ * ellipsize with the side padding intact instead of the wrapper clipping it.
+ * `min-width` keeps a clickable floor for an empty value; `max-width` caps a
+ * runaway value so chips stay compact. */
 .chip input {
   border: none;
   box-shadow: none;
   background: transparent;
   min-height: unset;
   padding: 0;
+  field-sizing: content;
+  max-width: 200px;
+  width: auto;
+  min-width: 50px;
+  flex-shrink: 1;
   text-overflow: ellipsis;
 }
 
@@ -151,9 +161,6 @@ button.selectValue:hover {
   height: 22px;
   border: none;
   box-shadow: none;
-  /* Clickable floor for an empty value; on the container (not the input) so
-   * the `overflow: hidden` wrapper can still clip it away under pressure. */
-  min-width: var(--rs-space-10);
 }
 
 /* Match height of Input when FilterChip variant is text */
@@ -162,15 +169,9 @@ button.selectValue:hover {
   min-height: var(--rs-space-7);
 }
 
-/* Hug the value (`field-sizing`, `width: auto` fallback). `min-width: 0` lets
- * it clip under pressure; `max-width` caps a runaway value so chips stay compact. */
 .inputFieldWrapper input {
   padding-left: var(--rs-space-3);
   padding-right: var(--rs-space-3);
-  field-sizing: content;
-  width: auto;
-  min-width: 0;
-  max-width: 200px;
 }
 
 .dateFieldWrapper {
@@ -185,8 +186,6 @@ button.selectValue:hover {
   justify-content: space-between;
   align-items: center;
   width: fit-content;
-  /* Clickable floor on the container — see .inputField. */
-  min-width: var(--rs-space-10);
   height: 22px;
   min-height: 22px;
   border: none;
@@ -203,11 +202,6 @@ button.selectValue:hover {
   text-align: left;
   padding-left: var(--rs-space-3);
   padding-right: var(--rs-space-3);
-  /* Hug the formatted date string — see .inputFieldWrapper input. */
-  field-sizing: content;
-  width: auto;
-  min-width: 0;
-  max-width: 200px;
 }
 
 .dateField [data-trailing] {

--- a/packages/raystack/components/filter-chip/filter-chip.module.css
+++ b/packages/raystack/components/filter-chip/filter-chip.module.css
@@ -156,9 +156,18 @@ button.selectValue:hover {
   min-height: var(--rs-space-7);
 }
 
+/*
+* Hug the content via `field-sizing` (Chromium/Safari); elsewhere fall back
+* to the intrinsic `width: auto`. Bounds are guardrails: clickable floor +
+* runaway ceiling.
+*/
 .inputFieldWrapper input {
   padding-left: var(--rs-space-3);
   padding-right: var(--rs-space-3);
+  field-sizing: content;
+  width: auto;
+  min-width: var(--rs-space-10);
+  max-width: 200px;
 }
 
 .dateFieldWrapper {
@@ -189,6 +198,11 @@ button.selectValue:hover {
   text-align: left;
   padding-left: var(--rs-space-3);
   padding-right: var(--rs-space-3);
+  /* Hug the formatted date string — see .inputFieldWrapper input. */
+  field-sizing: content;
+  width: auto;
+  min-width: var(--rs-space-10);
+  max-width: 200px;
 }
 
 .dateField [data-trailing] {

--- a/packages/raystack/components/filter-chip/filter-chip.tsx
+++ b/packages/raystack/components/filter-chip/filter-chip.tsx
@@ -171,7 +171,6 @@ export const FilterChip = ({
               slotProps={{
                 ...calendarProps?.slotProps,
                 input: {
-                  width: 'fit-content',
                   classNames: { container: styles.dateField },
                   ...calendarProps?.slotProps?.input
                 }
@@ -187,7 +186,6 @@ export const FilterChip = ({
               classNames={{ container: styles.inputField }}
               value={filterValue}
               onChange={e => handleFilterValueChange(e.target.value)}
-              width='fit-content'
             />
           </div>
         );

--- a/packages/raystack/components/filter-chip/filter-chip.tsx
+++ b/packages/raystack/components/filter-chip/filter-chip.tsx
@@ -47,6 +47,12 @@ export interface FilterChipProps
   leadingIcon?: ReactElement;
   operations?: FilterOperator<string>[];
   selectProps?: BaseSelectProps;
+  /**
+   * Date display/parse format for `columnType="date"`, forwarded to the
+   * underlying DatePicker. Defaults to a month-as-text format so the
+   * month reads as e.g. "27 May 2026" instead of "27/05/2026".
+   */
+  dateFormat?: string;
 }
 
 export const FilterChip = ({
@@ -63,6 +69,7 @@ export const FilterChip = ({
   variant,
   operations,
   selectProps,
+  dateFormat = 'DD MMM YYYY',
   ...props
 }: FilterChipProps) => {
   const computedOperations = operations?.length
@@ -138,10 +145,16 @@ export const FilterChip = ({
         return (
           <div className={styles.dateFieldWrapper}>
             <DatePicker
-              value={filterValue}
+              value={filterValue instanceof Date ? filterValue : undefined}
               onSelect={date => handleFilterValueChange(date)}
+              dateFormat={dateFormat}
               showCalendarIcon={false}
-              inputProps={{ classNames: { container: styles.dateField } }}
+              slotProps={{
+                input: {
+                  width: 'fit-content',
+                  classNames: { container: styles.dateField }
+                }
+              }}
             />
           </div>
         );
@@ -153,6 +166,7 @@ export const FilterChip = ({
               classNames={{ container: styles.inputField }}
               value={filterValue}
               onChange={e => handleFilterValueChange(e.target.value)}
+              width='fit-content'
             />
           </div>
         );

--- a/packages/raystack/components/filter-chip/filter-chip.tsx
+++ b/packages/raystack/components/filter-chip/filter-chip.tsx
@@ -11,7 +11,7 @@ import {
   FilterTypes,
   filterOperators
 } from '~/types/filters';
-import { DatePicker } from '../calendar';
+import { DatePicker, type DatePickerProps } from '../calendar';
 import { Flex } from '../flex';
 import { Input } from '../input';
 import { Select } from '../select';
@@ -34,6 +34,17 @@ const chip = cva(styles.chip, {
 
 export type FilterChipValue = string | string[] | number | Date;
 
+/**
+ * Subset of `DatePickerProps` that consumers may forward to the chip's
+ * built-in DatePicker via `calendarProps`. `value`/`onSelect`/`defaultValue`
+ * are owned by `FilterChip`; `children` would replace the input trigger and
+ * break the chip layout.
+ */
+export type FilterChipCalendarProps = Omit<
+  DatePickerProps,
+  'value' | 'onSelect' | 'defaultValue' | 'children'
+>;
+
 export interface FilterChipProps
   extends ComponentProps<'div'>,
     VariantProps<typeof chip> {
@@ -48,11 +59,11 @@ export interface FilterChipProps
   operations?: FilterOperator<string>[];
   selectProps?: BaseSelectProps;
   /**
-   * Date display/parse format for `columnType="date"`, forwarded to the
-   * underlying DatePicker. Defaults to a month-as-text format so the
-   * month reads as e.g. "27 May 2026" instead of "27/05/2026".
+   * Props forwarded to the underlying `DatePicker` for `columnType="date"`.
+   * `value`/`onSelect`/`defaultValue` are owned by `FilterChip` and excluded;
+   * `children` is excluded so the chip's input trigger isn't replaced.
    */
-  dateFormat?: string;
+  calendarProps?: FilterChipCalendarProps;
 }
 
 /**
@@ -77,7 +88,7 @@ export const FilterChip = ({
   variant,
   operations,
   selectProps,
-  dateFormat = 'DD MMM YYYY',
+  calendarProps,
   ...props
 }: FilterChipProps) => {
   const computedOperations = operations?.length
@@ -153,14 +164,16 @@ export const FilterChip = ({
         return (
           <div className={styles.dateFieldWrapper}>
             <DatePicker
+              showCalendarIcon={false}
+              {...calendarProps}
               value={filterValue instanceof Date ? filterValue : undefined}
               onSelect={date => handleFilterValueChange(date)}
-              dateFormat={dateFormat}
-              showCalendarIcon={false}
               slotProps={{
+                ...calendarProps?.slotProps,
                 input: {
                   width: 'fit-content',
-                  classNames: { container: styles.dateField }
+                  classNames: { container: styles.dateField },
+                  ...calendarProps?.slotProps?.input
                 }
               }}
             />

--- a/packages/raystack/components/filter-chip/filter-chip.tsx
+++ b/packages/raystack/components/filter-chip/filter-chip.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Cross1Icon } from '@radix-ui/react-icons';
-import { cva, cx, VariantProps } from 'class-variance-authority';
+import { cva, VariantProps } from 'class-variance-authority';
+import dayjs from 'dayjs';
 import { ComponentProps, ReactElement, useCallback, useState } from 'react';
 import {
   FilterOperation,
@@ -33,6 +34,20 @@ const chip = cva(styles.chip, {
 });
 
 export type FilterChipValue = string | string[] | number | Date;
+
+/**
+ * Coerce a `FilterChipValue` to the `Date` the DatePicker expects — filter
+ * state hydrated from a serialized query arrives as a string or epoch number.
+ * Unparseable values leave the field unselected.
+ */
+const toDateValue = (value: unknown): Date | undefined => {
+  if (value instanceof Date) return value;
+  if (typeof value === 'string' || typeof value === 'number') {
+    const parsed = dayjs(value);
+    return parsed.isValid() ? parsed.toDate() : undefined;
+  }
+  return undefined;
+};
 
 /**
  * Subset of `DatePickerProps` that consumers may forward to the chip's
@@ -137,10 +152,7 @@ export const FilterChip = ({
                 }
               }}
               variant='text'
-              className={cx(
-                styles.selectValue,
-                !showOnRemove && styles.selectColumn
-              )}
+              className={styles.selectValue}
             >
               <Select.Value placeholder='Select value'>
                 {isMultiSelectColumn && filterValue.length > 1
@@ -166,7 +178,7 @@ export const FilterChip = ({
             <DatePicker
               showCalendarIcon={false}
               {...calendarProps}
-              value={filterValue instanceof Date ? filterValue : undefined}
+              value={toDateValue(filterValue)}
               onSelect={date => handleFilterValueChange(date)}
               slotProps={{
                 ...calendarProps?.slotProps,

--- a/packages/raystack/components/filter-chip/filter-chip.tsx
+++ b/packages/raystack/components/filter-chip/filter-chip.tsx
@@ -55,6 +55,14 @@ export interface FilterChipProps
   dateFormat?: string;
 }
 
+/**
+ * A compact, removable filter pill that pairs a label and operator with a
+ * value control chosen by `columnType`: a `Select` (`select`/`multiselect`),
+ * a `DatePicker` (`date`), or a text `Input` (`string`/`number`). The value
+ * control sizes to its content so the chip hugs the active filter. Emits
+ * `onValueChange`/`onOperationChange` and renders a remove button when
+ * `onRemove` is provided.
+ */
 export const FilterChip = ({
   label,
   value,

--- a/packages/raystack/components/filter-chip/index.tsx
+++ b/packages/raystack/components/filter-chip/index.tsx
@@ -1,5 +1,6 @@
 export {
   FilterChip,
   type FilterChipCalendarProps,
+  type FilterChipProps,
   type FilterChipValue
 } from './filter-chip';

--- a/packages/raystack/components/filter-chip/index.tsx
+++ b/packages/raystack/components/filter-chip/index.tsx
@@ -1,1 +1,5 @@
-export { FilterChip, type FilterChipValue } from './filter-chip';
+export {
+  FilterChip,
+  type FilterChipCalendarProps,
+  type FilterChipValue
+} from './filter-chip';

--- a/packages/raystack/index.tsx
+++ b/packages/raystack/index.tsx
@@ -15,6 +15,8 @@ export {
   type CalendarProps,
   type CalendarPropsExtended,
   DatePicker,
+  type DatePickerProps,
+  type DatePickerSlotProps,
   type DateRange,
   RangePicker
 } from './components/calendar';
@@ -54,7 +56,12 @@ export { Drawer } from './components/drawer';
 export { EmptyState } from './components/empty-state';
 export { Field } from './components/field';
 export { Fieldset } from './components/fieldset';
-export { FilterChip } from './components/filter-chip';
+export {
+  FilterChip,
+  type FilterChipCalendarProps,
+  type FilterChipProps,
+  type FilterChipValue
+} from './components/filter-chip';
 export { Flex } from './components/flex';
 export { FloatingActions } from './components/floating-actions';
 export { Form } from './components/form';


### PR DESCRIPTION
Fixes the date-type `FilterChip`, makes its value fields hug **and truncate to** their content,and cleans up the surrounding filter toolbars in `DataTable`/`DataView`.

After PR #819 made `DatePicker.value` strictly `Date | undefined` and added a controlled-sync effect keyed on `valueProp?.getTime()`, the date filter chip crashed: `FilterChip` seeds its value state with `''` and forwarded that string to the picker, so `''.getTime()` threw `TypeError: valueProp?.getTime is not a function` (caught by the ErrorBoundary, regenerating the tree).


  Changes:

   | Change | Details |
   | --- | --- |
| **Fix the crash & parse serialized dates** | The date field runs its value through `toDateValue()`: a `Date` passes through, a string or epoch number (e.g. filter state hydrated from a URL/query) is parsed via dayjs, and only an unparseable value starts on the "Select date" placeholder instead of throwing. |
| **Migrate to `slotProps.input`** | Off the `inputProps` API #819 deprecated. |
| **New `calendarProps` prop** | Mirrors the `selectProps` pattern: forwards arbitrary `DatePicker` props (`dateFormat`, `timeZone`, `slotProps.calendar`, …) for `columnType="date"`; `value`/`onSelect`/`defaultValue`/`children` stay owned by `FilterChip`. `DataTable`/`DataView` columns gain a parallel `filterProps.calendar` slot. The picker-level `dateFormat` default is now `'DD MMM YYYY'`, so the capture-date filter reads "27 May 2026" instead of "27/05/2026". |
| **Content-fit width & truncation** | The value input itself hugs its content (`field-sizing: content`, `width: auto` fallback) and is the element that shrinks under toolbar resize pressure — so `text-overflow: ellipsis` fires with side padding intact instead of the wrapper clipping both away. `min-width: 50px` keeps an empty value clickable across the whole visible area; `max-width: 200px` caps runaway values. (Input-level approach aligned with draft #826.) |
| **Chips wrap to the panel** | `DataTable`'s `.filterContainer` and `DataView`'s filters row fill the toolbar (`flex: 1; min-width: 0; flex-wrap: wrap`) so applied chips wrap and shrink instead of overflowing in a single row. |
| **DataTable filter fixes** | Adding a `select` filter with no `filterOptions` no longer crashes (`options[0]?.value`); `multiselect` filters preselect the first option like `select` does (`[]` when there are no options) instead of falling through to `''`; `classNames.addFilter` is now actually applied to the default add-filter triggers. |
| **Cleanups & public types** | Removed a dead `selectColumn` class reference left behind by #810. Exported the supporting types from the package root: `FilterChipProps`, `FilterChipCalendarProps`, `FilterChipValue`, `DatePickerProps`, `DatePickerSlotProps`. |
| **Docs** | New "Calendar, DatePicker & RangePicker" and "FilterChip" sections in `V1-migration.md`; CHANGELOG entries under 0.49.0 (amended #819 items + a dedicated section for this PR). `multiselect` is now documented end to end: FilterChip props/demo tabs/playground control, `DataTableColumnDef.filterType` + operators in the datatable docs, `FiltersProps.classNames`, and a working multiselect **Team** filter in `/examples/datatable`. |

   **Behavior notes:**
  - Existing date `FilterChip`s display month-as-text by default — overridable per chip via `calendarProps={{ dateFormat: '…' }}`.
   - A date chip driven by a string/epoch value now displays the parsed date (previously rendered blank).
   - A freshly added `multiselect` filter starts with the first option preselected, matching `select` behavior (previously `''`).
   
  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [x] New feature (non-breaking change that adds functionality)
  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] Documentation update
  - [ ] Refactor (no functional changes, no bug fixes just code improvements)
  - [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
  - [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
  - [x] Test (adding missing tests or correcting existing tests)
  - [x] Improvement (Improvements to existing code)
  - [ ] Other (please specify)

  ## How Has This Been Tested?

| Check | Result |
| --- | --- |
| Unit tests in `filter-chip.test.tsx` | 12 → 20, all passing: no-crash regression for an unset date chip, string-date parsing (`'2026-05-27'` → "27 May 2026"), epoch-number parsing, unparseable-value fallback to unselected, default month-as-text formatting, custom `dateFormat` via `calendarProps`, and fluid-container wiring on both the string and date fields. |
| Full `@raystack/apsara` Vitest suite | Passes — 1,861 tests across 77 files; filter-chip + data-table + calendar together: 262/262. |
| `tsc --noEmit` | No errors in any touched file (the repo's 12 pre-existing errors in untouched data-table/data-view files are unchanged). |
| Biome lint | Clean for all touched files (only the 2 pre-existing `any` warnings in the original `useCallback`s; no new warnings). |
| Manual | Resize-pressure behavior (ellipsis, padding, clickable floor, chip wrapping) verified in the `/examples/datatable` and dataview example pages. |

  ## Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation (.mdx files)
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

[Add screenshots here]

## Related Issues

[Link any related issues here using #issue-number]
