### PR TITLE
feat: add DataView component

### DIFF
--- a/apps/www/src/app/examples/dataview-beta/page.tsx
+++ b/apps/www/src/app/examples/dataview-beta/page.tsx
@@ -501,7 +501,7 @@ const Page = () => {
         </Sidebar.Header>
         <Sidebar.Main>
           <Sidebar.Item
-            href='/examples/dataview'
+            href='/examples/dataview-beta'
             leadingIcon={<SidebarIcon />}
             active
           >
@@ -565,7 +565,7 @@ const Page = () => {
               name='list'
               variant='list'
               columns={listColumns}
-              rowHeight={72}
+              estimatedRowHeight={72}
               showDividers
               showGroupHeaders
             />

--- a/apps/www/src/components/dataview-demo.tsx
+++ b/apps/www/src/components/dataview-demo.tsx
@@ -1,22 +1,18 @@
 'use client';
 
-import { TransformIcon } from '@radix-ui/react-icons';
+import { ListBulletIcon, RowsIcon } from '@radix-ui/react-icons';
 import {
   Avatar,
   Badge,
   Button,
-  Checkbox,
-  Chip,
   // biome-ignore lint/suspicious/noShadowRestrictedNames: legitimate export name
   DataView,
   DataViewField,
   DataViewListColumn,
   Flex,
-  FloatingActions,
-  Text,
-  useDataView
+  Text
 } from '@raystack/apsara';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 type Person = {
   id: string;
@@ -194,11 +190,8 @@ export function DataViewTableDemo() {
       <div style={{ height: 400 }}>
         <DataView data={people} fields={fields} defaultSort={defaultSort}>
           <DataView.Toolbar>
-            <DataView.Search placeholder='Search people…' />
-            <Flex gap={3}>
-              <DataView.Filters />
-              <DataView.DisplayControls />
-            </Flex>
+            <DataView.Filters />
+            <DataView.DisplayControls />
           </DataView.Toolbar>
           <DataView.List variant='table' columns={tableColumns} />
         </DataView>
@@ -213,7 +206,6 @@ export function DataViewListDemo() {
       <div style={{ height: 400 }}>
         <DataView data={people} fields={fields} defaultSort={defaultSort}>
           <DataView.Toolbar>
-            <DataView.Search placeholder='Search…' />
             <DataView.Filters />
           </DataView.Toolbar>
           <DataView.List variant='list' columns={listColumns} />
@@ -223,11 +215,29 @@ export function DataViewListDemo() {
   );
 }
 
+export function DataViewSearchDemo() {
+  return (
+    <Flex direction='column' gap={4} width='full'>
+      <div style={{ height: 400 }}>
+        <DataView data={people} fields={fields} defaultSort={defaultSort}>
+          <DataView.Toolbar>
+            <DataView.Search placeholder='Search by name, email, team…' />
+          </DataView.Toolbar>
+          <DataView.List variant='table' columns={tableColumns} />
+          <DataView.EmptyState>
+            <Text>No people match your search.</Text>
+          </DataView.EmptyState>
+        </DataView>
+      </div>
+    </Flex>
+  );
+}
+
 export function DataViewMultiViewDemo() {
   const views = useMemo(
     () => [
-      { value: 'table', label: 'Table' },
-      { value: 'list', label: 'List' }
+      { value: 'table', label: 'Table', leadingIcon: <RowsIcon /> },
+      { value: 'list', label: 'List', leadingIcon: <ListBulletIcon /> }
     ],
     []
   );
@@ -242,14 +252,8 @@ export function DataViewMultiViewDemo() {
           defaultView='table'
         >
           <DataView.Toolbar>
-            <Flex gap={3}>
-              <DataView.Search />
-              <DataView.Filters />
-            </Flex>
-            <Flex gap={3}>
-              <DataView.ViewSwitcher />
-              <DataView.DisplayControls />
-            </Flex>
+            <DataView.Filters />
+            <DataView.DisplayControls />
           </DataView.Toolbar>
           <DataView.List name='table' variant='table' columns={tableColumns} />
           <DataView.List name='list' variant='list' columns={listColumns} />
@@ -275,7 +279,6 @@ export function DataViewEmptyZeroDemo() {
           }
         >
           <DataView.Toolbar>
-            <DataView.Search />
             <DataView.Filters />
           </DataView.Toolbar>
           <DataView.List variant='table' columns={tableColumns} />
@@ -387,11 +390,8 @@ export function DataViewVirtualizedDemo() {
       <div style={{ height: 400 }}>
         <DataView data={data} fields={fields} defaultSort={defaultSort}>
           <DataView.Toolbar>
-            <DataView.Search placeholder='Search 1,000 people…' />
-            <Flex gap={3}>
-              <DataView.Filters />
-              <DataView.DisplayControls />
-            </Flex>
+            <DataView.Filters />
+            <DataView.DisplayControls />
           </DataView.Toolbar>
           <DataView.List
             variant='table'
@@ -423,11 +423,8 @@ export function DataViewGroupingDemo() {
           query={{ group_by: ['team'] }}
         >
           <DataView.Toolbar>
-            <DataView.Search />
-            <Flex gap={3}>
-              <DataView.Filters />
-              <DataView.DisplayControls />
-            </Flex>
+            <DataView.Filters />
+            <DataView.DisplayControls />
           </DataView.Toolbar>
           <DataView.List
             variant='table'
@@ -458,11 +455,8 @@ export function DataViewVirtualizedGroupingDemo() {
           query={{ group_by: ['team'] }}
         >
           <DataView.Toolbar>
-            <DataView.Search placeholder='Search 1,500 people…' />
-            <Flex gap={3}>
-              <DataView.Filters />
-              <DataView.DisplayControls />
-            </Flex>
+            <DataView.Filters />
+            <DataView.DisplayControls />
           </DataView.Toolbar>
           <DataView.List
             variant='table'
@@ -507,7 +501,6 @@ export function DataViewLoadingDemo() {
           loadingRowCount={4}
         >
           <DataView.Toolbar>
-            <DataView.Search />
             <DataView.Filters />
           </DataView.Toolbar>
           <DataView.List variant='table' columns={tableColumns} />
@@ -548,7 +541,6 @@ export function DataViewVirtualizedLoadingDemo() {
           loadingRowCount={6}
         >
           <DataView.Toolbar>
-            <DataView.Search />
             <DataView.Filters />
           </DataView.Toolbar>
           <DataView.List
@@ -570,8 +562,8 @@ export function DataViewVirtualizedLoadingDemo() {
 export function DataViewPerViewFieldsDemo() {
   const views = useMemo(
     () => [
-      { value: 'table', label: 'Table' },
-      { value: 'list', label: 'List' }
+      { value: 'table', label: 'Table', leadingIcon: <RowsIcon /> },
+      { value: 'list', label: 'List', leadingIcon: <ListBulletIcon /> }
     ],
     []
   );
@@ -595,12 +587,8 @@ export function DataViewPerViewFieldsDemo() {
           defaultView='table'
         >
           <DataView.Toolbar>
-            <DataView.Search />
-            <Flex gap={3}>
-              <DataView.Filters />
-              <DataView.ViewSwitcher />
-              <DataView.DisplayControls />
-            </Flex>
+            <DataView.Filters />
+            <DataView.DisplayControls />
           </DataView.Toolbar>
           <DataView.List name='table' variant='table' columns={tableColumns} />
           <DataView.List
@@ -609,106 +597,6 @@ export function DataViewPerViewFieldsDemo() {
             columns={listColumns}
             fields={listFields}
           />
-        </DataView>
-      </div>
-    </Flex>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Row selection demo — reads the underlying TanStack table from useDataView()
-// and floats a FloatingActions bar when rows are selected.
-// ---------------------------------------------------------------------------
-
-const selectionColumn: DataViewListColumn<Person> = {
-  accessorKey: 'select',
-  width: '40px',
-  header: ({ table }) => (
-    <Checkbox
-      checked={table.getIsAllRowsSelected()}
-      onCheckedChange={value => table.toggleAllRowsSelected(Boolean(value))}
-      aria-label='Select all rows'
-    />
-  ),
-  cell: ({ row }) => (
-    <Checkbox
-      checked={row.getIsSelected()}
-      onCheckedChange={value => row.toggleSelected(Boolean(value))}
-      aria-label='Select row'
-      onClick={e => e.stopPropagation()}
-    />
-  )
-};
-
-function SelectionBar() {
-  const { table } = useDataView<Person>();
-  const selected = table.getSelectedRowModel().rows;
-  if (selected.length === 0) return null;
-
-  return (
-    <FloatingActions aria-label='Selection actions'>
-      <Chip
-        variant='outline'
-        size='large'
-        color='neutral'
-        leadingIcon={<TransformIcon />}
-        isDismissible
-        onDismiss={() => table.resetRowSelection()}
-      >
-        {selected.length} selected
-      </Chip>
-      <FloatingActions.Separator />
-      <Button variant='outline' color='neutral' size='small'>
-        Move to
-      </Button>
-      <Button variant='outline' color='neutral' size='small'>
-        Actions
-      </Button>
-    </FloatingActions>
-  );
-}
-
-function InitialSelection() {
-  const { table } = useDataView<Person>();
-  useEffect(() => {
-    table.setRowSelection({ '1': true });
-  }, [table]);
-  return null;
-}
-
-const selectionColumns: DataViewListColumn<Person>[] = [
-  selectionColumn,
-  ...tableColumns
-];
-
-export function DataViewSelectionDemo() {
-  return (
-    <Flex direction='column' gap={4} width='full'>
-      <div
-        style={{
-          position: 'relative',
-          height: 420,
-          width: '100%',
-          overflow: 'hidden',
-          transform: 'translateZ(0)'
-        }}
-      >
-        <DataView
-          data={people}
-          fields={fields}
-          defaultSort={defaultSort}
-          getRowId={row => row.id}
-        >
-          <DataView.Toolbar>
-            <DataView.Search />
-            <Flex gap={3}>
-              <DataView.Filters />
-              <DataView.DisplayControls />
-            </Flex>
-          </DataView.Toolbar>
-          <DataView.List variant='table' columns={selectionColumns} />
-          <InitialSelection />
-          <SelectionBar />
         </DataView>
       </div>
     </Flex>

--- a/apps/www/src/components/dataview-demo.tsx
+++ b/apps/www/src/components/dataview-demo.tsx
@@ -1,0 +1,716 @@
+'use client';
+
+import { TransformIcon } from '@radix-ui/react-icons';
+import {
+  Avatar,
+  Badge,
+  Button,
+  Checkbox,
+  Chip,
+  // biome-ignore lint/suspicious/noShadowRestrictedNames: legitimate export name
+  DataView,
+  DataViewField,
+  DataViewListColumn,
+  Flex,
+  FloatingActions,
+  Text,
+  useDataView
+} from '@raystack/apsara';
+import { useEffect, useMemo, useState } from 'react';
+
+type Person = {
+  id: string;
+  name: string;
+  email: string;
+  team: 'Eng' | 'Design' | 'Ops';
+  status: 'active' | 'invited' | 'archived';
+};
+
+const people: Person[] = [
+  {
+    id: '1',
+    name: 'Ada Lovelace',
+    email: 'ada@example.com',
+    team: 'Eng',
+    status: 'active'
+  },
+  {
+    id: '2',
+    name: 'Grace Hopper',
+    email: 'grace@example.com',
+    team: 'Eng',
+    status: 'active'
+  },
+  {
+    id: '3',
+    name: 'Margaret Hamilton',
+    email: 'margaret@example.com',
+    team: 'Eng',
+    status: 'invited'
+  },
+  {
+    id: '4',
+    name: 'Katherine Johnson',
+    email: 'katherine@example.com',
+    team: 'Ops',
+    status: 'active'
+  },
+  {
+    id: '5',
+    name: 'Susan Kare',
+    email: 'susan@example.com',
+    team: 'Design',
+    status: 'archived'
+  }
+];
+
+const fields: DataViewField<Person>[] = [
+  {
+    accessorKey: 'name',
+    label: 'Name',
+    sortable: true,
+    filterable: true,
+    filterType: 'string',
+    hideable: true
+  },
+  {
+    accessorKey: 'email',
+    label: 'Email',
+    sortable: true,
+    filterable: true,
+    filterType: 'string',
+    hideable: true
+  },
+  {
+    accessorKey: 'team',
+    label: 'Team',
+    sortable: true,
+    filterable: true,
+    filterType: 'select',
+    hideable: true,
+    groupable: true,
+    filterOptions: [
+      { label: 'Eng', value: 'Eng' },
+      { label: 'Design', value: 'Design' },
+      { label: 'Ops', value: 'Ops' }
+    ]
+  },
+  {
+    accessorKey: 'status',
+    label: 'Status',
+    sortable: true,
+    filterable: true,
+    filterType: 'select',
+    hideable: true,
+    groupable: true,
+    filterOptions: [
+      { label: 'Active', value: 'active' },
+      { label: 'Invited', value: 'invited' },
+      { label: 'Archived', value: 'archived' }
+    ]
+  }
+];
+
+const tableColumns: DataViewListColumn<Person>[] = [
+  {
+    accessorKey: 'name',
+    width: '1.2fr',
+    cell: ({ row }) => <Text>{row.original.name}</Text>
+  },
+  {
+    accessorKey: 'email',
+    width: '1fr',
+    cell: ({ row }) => <Text variant='secondary'>{row.original.email}</Text>
+  },
+  {
+    accessorKey: 'team',
+    width: 'auto',
+    cell: ({ row }) => <Badge variant='neutral'>{row.original.team}</Badge>
+  },
+  {
+    accessorKey: 'status',
+    width: 'auto',
+    cell: ({ row }) => (
+      <Badge
+        variant={
+          row.original.status === 'active'
+            ? 'success'
+            : row.original.status === 'invited'
+              ? 'warning'
+              : 'neutral'
+        }
+      >
+        {row.original.status}
+      </Badge>
+    )
+  }
+];
+
+const listColumns: DataViewListColumn<Person>[] = [
+  {
+    accessorKey: 'name',
+    width: '1fr',
+    cell: ({ row }) => (
+      <Flex gap={3} align='center'>
+        <Avatar size={3} fallback={row.original.name.charAt(0)} />
+        <Flex direction='column'>
+          <Text weight='medium'>{row.original.name}</Text>
+          <Text size='small' variant='secondary'>
+            {row.original.email}
+          </Text>
+        </Flex>
+      </Flex>
+    )
+  },
+  {
+    accessorKey: 'team',
+    width: 'auto',
+    cell: ({ row }) => <Badge variant='neutral'>{row.original.team}</Badge>
+  },
+  {
+    accessorKey: 'status',
+    width: 'auto',
+    cell: ({ row }) => (
+      <Badge
+        variant={
+          row.original.status === 'active'
+            ? 'success'
+            : row.original.status === 'invited'
+              ? 'warning'
+              : 'neutral'
+        }
+      >
+        {row.original.status}
+      </Badge>
+    )
+  }
+];
+
+const defaultSort = { name: 'name', order: 'asc' as const };
+
+export function DataViewTableDemo() {
+  return (
+    <Flex direction='column' gap={4} width='full'>
+      <div style={{ height: 400 }}>
+        <DataView data={people} fields={fields} defaultSort={defaultSort}>
+          <DataView.Toolbar>
+            <DataView.Search placeholder='Search people…' />
+            <Flex gap={3}>
+              <DataView.Filters />
+              <DataView.DisplayControls />
+            </Flex>
+          </DataView.Toolbar>
+          <DataView.List variant='table' columns={tableColumns} />
+        </DataView>
+      </div>
+    </Flex>
+  );
+}
+
+export function DataViewListDemo() {
+  return (
+    <Flex direction='column' gap={4} width='full'>
+      <div style={{ height: 400 }}>
+        <DataView data={people} fields={fields} defaultSort={defaultSort}>
+          <DataView.Toolbar>
+            <DataView.Search placeholder='Search…' />
+            <DataView.Filters />
+          </DataView.Toolbar>
+          <DataView.List variant='list' columns={listColumns} />
+        </DataView>
+      </div>
+    </Flex>
+  );
+}
+
+export function DataViewMultiViewDemo() {
+  const views = useMemo(
+    () => [
+      { value: 'table', label: 'Table' },
+      { value: 'list', label: 'List' }
+    ],
+    []
+  );
+  return (
+    <Flex direction='column' gap={4} width='full'>
+      <div style={{ height: 400 }}>
+        <DataView
+          data={people}
+          fields={fields}
+          defaultSort={defaultSort}
+          views={views}
+          defaultView='table'
+        >
+          <DataView.Toolbar>
+            <Flex gap={3}>
+              <DataView.Search />
+              <DataView.Filters />
+            </Flex>
+            <Flex gap={3}>
+              <DataView.ViewSwitcher />
+              <DataView.DisplayControls />
+            </Flex>
+          </DataView.Toolbar>
+          <DataView.List name='table' variant='table' columns={tableColumns} />
+          <DataView.List name='list' variant='list' columns={listColumns} />
+        </DataView>
+      </div>
+    </Flex>
+  );
+}
+
+export function DataViewEmptyZeroDemo() {
+  const [filtered, setFiltered] = useState(false);
+  return (
+    <Flex direction='column' gap={4} width='full'>
+      <div style={{ height: 400 }}>
+        <DataView
+          data={filtered ? [] : people}
+          fields={fields}
+          defaultSort={defaultSort}
+          query={
+            filtered
+              ? { filters: [{ name: 'name', operator: 'eq', value: 'Nobody' }] }
+              : undefined
+          }
+        >
+          <DataView.Toolbar>
+            <DataView.Search />
+            <DataView.Filters />
+          </DataView.Toolbar>
+          <DataView.List variant='table' columns={tableColumns} />
+          <DataView.EmptyState>
+            <Text>No people match your filters.</Text>
+          </DataView.EmptyState>
+          <DataView.ZeroState>
+            <Text>Nothing here yet.</Text>
+          </DataView.ZeroState>
+        </DataView>
+      </div>
+    </Flex>
+  );
+}
+
+export function DataViewCustomDemo() {
+  return (
+    <Flex direction='column' gap={4} width='full'>
+      <DataView data={people} fields={fields} defaultSort={defaultSort}>
+        <DataView.Toolbar>
+          <DataView.Filters />
+          <DataView.DisplayControls />
+        </DataView.Toolbar>
+        <DataView.Custom>
+          {ctx => (
+            <Flex gap={3} wrap='wrap' style={{ padding: 'var(--rs-space-4)' }}>
+              {(ctx.data as Person[]).map(p => (
+                <Flex
+                  key={p.id}
+                  direction='column'
+                  gap={2}
+                  style={{
+                    padding: 'var(--rs-space-4)',
+                    border: '0.5px solid var(--rs-color-border-base-primary)',
+                    borderRadius: 'var(--rs-radius-3)',
+                    width: 220
+                  }}
+                >
+                  <DataView.DisplayAccess accessorKey='name'>
+                    <Text weight='medium'>{p.name}</Text>
+                  </DataView.DisplayAccess>
+                  <DataView.DisplayAccess accessorKey='email'>
+                    <Text size='small' variant='secondary'>
+                      {p.email}
+                    </Text>
+                  </DataView.DisplayAccess>
+                  <Flex gap={2}>
+                    <DataView.DisplayAccess accessorKey='team'>
+                      <Badge variant='neutral'>{p.team}</Badge>
+                    </DataView.DisplayAccess>
+                    <DataView.DisplayAccess accessorKey='status'>
+                      <Badge variant='success'>{p.status}</Badge>
+                    </DataView.DisplayAccess>
+                  </Flex>
+                </Flex>
+              ))}
+            </Flex>
+          )}
+        </DataView.Custom>
+      </DataView>
+    </Flex>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Virtualized large-dataset demo
+// ---------------------------------------------------------------------------
+
+function generatePeople(count: number): Person[] {
+  const teams: Person['team'][] = ['Eng', 'Design', 'Ops'];
+  const statuses: Person['status'][] = ['active', 'invited', 'archived'];
+  const firstNames = [
+    'Ada',
+    'Grace',
+    'Margaret',
+    'Katherine',
+    'Susan',
+    'Hedy',
+    'Radia',
+    'Lynn',
+    'Frances',
+    'Joan'
+  ];
+  const lastNames = [
+    'Lovelace',
+    'Hopper',
+    'Hamilton',
+    'Johnson',
+    'Kare',
+    'Lamarr',
+    'Perlman',
+    'Conway',
+    'Allen',
+    'Clarke'
+  ];
+  return Array.from({ length: count }, (_, i) => ({
+    id: String(i + 1),
+    name: `${firstNames[i % firstNames.length]} ${lastNames[(i + 3) % lastNames.length]}`,
+    email: `user${i + 1}@example.com`,
+    team: teams[i % teams.length],
+    status: statuses[i % statuses.length]
+  }));
+}
+
+export function DataViewVirtualizedDemo() {
+  const data = useMemo(() => generatePeople(1000), []);
+  return (
+    <Flex direction='column' gap={4} width='full'>
+      <div style={{ height: 400 }}>
+        <DataView data={data} fields={fields} defaultSort={defaultSort}>
+          <DataView.Toolbar>
+            <DataView.Search placeholder='Search 1,000 people…' />
+            <Flex gap={3}>
+              <DataView.Filters />
+              <DataView.DisplayControls />
+            </Flex>
+          </DataView.Toolbar>
+          <DataView.List
+            variant='table'
+            columns={tableColumns}
+            virtualized
+            estimatedRowHeight={44}
+          />
+        </DataView>
+      </div>
+    </Flex>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Grouping + sticky group header demo
+// ---------------------------------------------------------------------------
+
+export function DataViewGroupingDemo() {
+  // 60 rows across 3 teams forces the table to scroll inside a 320px viewport,
+  // so the sticky group header visibly swaps as the user moves between teams.
+  const groupedPeople = useMemo(() => generatePeople(60), []);
+  return (
+    <Flex direction='column' gap={4} width='full'>
+      <div style={{ height: 320 }}>
+        <DataView
+          data={groupedPeople}
+          fields={fields}
+          defaultSort={defaultSort}
+          query={{ group_by: ['team'] }}
+        >
+          <DataView.Toolbar>
+            <DataView.Search />
+            <Flex gap={3}>
+              <DataView.Filters />
+              <DataView.DisplayControls />
+            </Flex>
+          </DataView.Toolbar>
+          <DataView.List
+            variant='table'
+            columns={tableColumns}
+            stickyGroupHeader
+          />
+        </DataView>
+      </div>
+    </Flex>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Virtualized + grouping + sticky header — exercises the combined path that
+// uses the anchor pattern (single sticky element whose content swaps as you
+// scroll past each group's offset).
+// ---------------------------------------------------------------------------
+
+export function DataViewVirtualizedGroupingDemo() {
+  const data = useMemo(() => generatePeople(1500), []);
+  return (
+    <Flex direction='column' gap={4} width='full'>
+      <div style={{ height: 360 }}>
+        <DataView
+          data={data}
+          fields={fields}
+          defaultSort={defaultSort}
+          query={{ group_by: ['team'] }}
+        >
+          <DataView.Toolbar>
+            <DataView.Search placeholder='Search 1,500 people…' />
+            <Flex gap={3}>
+              <DataView.Filters />
+              <DataView.DisplayControls />
+            </Flex>
+          </DataView.Toolbar>
+          <DataView.List
+            variant='table'
+            columns={tableColumns}
+            virtualized
+            estimatedRowHeight={44}
+            stickyGroupHeader
+          />
+        </DataView>
+      </div>
+    </Flex>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton demo
+// ---------------------------------------------------------------------------
+
+export function DataViewLoadingDemo() {
+  const [isLoading, setIsLoading] = useState(true);
+  return (
+    <Flex direction='column' gap={4} width='full'>
+      <Flex gap={3} align='center'>
+        <Button
+          size='small'
+          variant='outline'
+          color='neutral'
+          onClick={() => setIsLoading(v => !v)}
+        >
+          {isLoading ? 'Stop loading' : 'Show skeletons'}
+        </Button>
+        <Text size='small' variant='secondary'>
+          Skeleton rows render while `isLoading` is true.
+        </Text>
+      </Flex>
+      <div style={{ height: 320 }}>
+        <DataView
+          data={isLoading ? [] : people}
+          fields={fields}
+          defaultSort={defaultSort}
+          isLoading={isLoading}
+          loadingRowCount={4}
+        >
+          <DataView.Toolbar>
+            <DataView.Search />
+            <DataView.Filters />
+          </DataView.Toolbar>
+          <DataView.List variant='table' columns={tableColumns} />
+        </DataView>
+      </div>
+    </Flex>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Loading + virtualization combined
+// ---------------------------------------------------------------------------
+
+export function DataViewVirtualizedLoadingDemo() {
+  const [isLoading, setIsLoading] = useState(true);
+  const allPeople = useMemo(() => generatePeople(1000), []);
+  return (
+    <Flex direction='column' gap={4} width='full'>
+      <Flex gap={3} align='center'>
+        <Button
+          size='small'
+          variant='outline'
+          color='neutral'
+          onClick={() => setIsLoading(v => !v)}
+        >
+          {isLoading ? 'Stop loading' : 'Show skeletons'}
+        </Button>
+        <Text size='small' variant='secondary'>
+          Skeleton rows render under existing rows even when virtualized.
+        </Text>
+      </Flex>
+      <div style={{ height: 400 }}>
+        <DataView
+          data={isLoading ? [] : allPeople}
+          fields={fields}
+          defaultSort={defaultSort}
+          isLoading={isLoading}
+          loadingRowCount={6}
+        >
+          <DataView.Toolbar>
+            <DataView.Search />
+            <DataView.Filters />
+          </DataView.Toolbar>
+          <DataView.List
+            variant='table'
+            columns={tableColumns}
+            virtualized
+            estimatedRowHeight={44}
+          />
+        </DataView>
+      </div>
+    </Flex>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Per-view fields override demo — Email hidden in the List view only.
+// ---------------------------------------------------------------------------
+
+export function DataViewPerViewFieldsDemo() {
+  const views = useMemo(
+    () => [
+      { value: 'table', label: 'Table' },
+      { value: 'list', label: 'List' }
+    ],
+    []
+  );
+  const listFields = useMemo(
+    () =>
+      fields.map(f =>
+        f.accessorKey === 'email'
+          ? { ...f, hideable: false, defaultHidden: true }
+          : f
+      ),
+    []
+  );
+  return (
+    <Flex direction='column' gap={4} width='full'>
+      <div style={{ height: 400 }}>
+        <DataView
+          data={people}
+          fields={fields}
+          defaultSort={defaultSort}
+          views={views}
+          defaultView='table'
+        >
+          <DataView.Toolbar>
+            <DataView.Search />
+            <Flex gap={3}>
+              <DataView.Filters />
+              <DataView.ViewSwitcher />
+              <DataView.DisplayControls />
+            </Flex>
+          </DataView.Toolbar>
+          <DataView.List name='table' variant='table' columns={tableColumns} />
+          <DataView.List
+            name='list'
+            variant='list'
+            columns={listColumns}
+            fields={listFields}
+          />
+        </DataView>
+      </div>
+    </Flex>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Row selection demo — reads the underlying TanStack table from useDataView()
+// and floats a FloatingActions bar when rows are selected.
+// ---------------------------------------------------------------------------
+
+const selectionColumn: DataViewListColumn<Person> = {
+  accessorKey: 'select',
+  width: '40px',
+  header: ({ table }) => (
+    <Checkbox
+      checked={table.getIsAllRowsSelected()}
+      onCheckedChange={value => table.toggleAllRowsSelected(Boolean(value))}
+      aria-label='Select all rows'
+    />
+  ),
+  cell: ({ row }) => (
+    <Checkbox
+      checked={row.getIsSelected()}
+      onCheckedChange={value => row.toggleSelected(Boolean(value))}
+      aria-label='Select row'
+      onClick={e => e.stopPropagation()}
+    />
+  )
+};
+
+function SelectionBar() {
+  const { table } = useDataView<Person>();
+  const selected = table.getSelectedRowModel().rows;
+  if (selected.length === 0) return null;
+
+  return (
+    <FloatingActions aria-label='Selection actions'>
+      <Chip
+        variant='outline'
+        size='large'
+        color='neutral'
+        leadingIcon={<TransformIcon />}
+        isDismissible
+        onDismiss={() => table.resetRowSelection()}
+      >
+        {selected.length} selected
+      </Chip>
+      <FloatingActions.Separator />
+      <Button variant='outline' color='neutral' size='small'>
+        Move to
+      </Button>
+      <Button variant='outline' color='neutral' size='small'>
+        Actions
+      </Button>
+    </FloatingActions>
+  );
+}
+
+function InitialSelection() {
+  const { table } = useDataView<Person>();
+  useEffect(() => {
+    table.setRowSelection({ '1': true });
+  }, [table]);
+  return null;
+}
+
+const selectionColumns: DataViewListColumn<Person>[] = [
+  selectionColumn,
+  ...tableColumns
+];
+
+export function DataViewSelectionDemo() {
+  return (
+    <Flex direction='column' gap={4} width='full'>
+      <div
+        style={{
+          position: 'relative',
+          height: 420,
+          width: '100%',
+          overflow: 'hidden',
+          transform: 'translateZ(0)'
+        }}
+      >
+        <DataView
+          data={people}
+          fields={fields}
+          defaultSort={defaultSort}
+          getRowId={row => row.id}
+        >
+          <DataView.Toolbar>
+            <DataView.Search />
+            <Flex gap={3}>
+              <DataView.Filters />
+              <DataView.DisplayControls />
+            </Flex>
+          </DataView.Toolbar>
+          <DataView.List variant='table' columns={selectionColumns} />
+          <InitialSelection />
+          <SelectionBar />
+        </DataView>
+      </div>
+    </Flex>
+  );
+}

--- a/apps/www/src/components/demo/demo.tsx
+++ b/apps/www/src/components/demo/demo.tsx
@@ -50,7 +50,7 @@ import {
   DataViewLoadingDemo,
   DataViewMultiViewDemo,
   DataViewPerViewFieldsDemo,
-  DataViewSelectionDemo,
+  DataViewSearchDemo,
   DataViewTableDemo,
   DataViewVirtualizedDemo,
   DataViewVirtualizedGroupingDemo
@@ -85,7 +85,7 @@ export default function Demo(props: DemoProps) {
       DataViewVirtualizedGroupingDemo,
       DataViewLoadingDemo,
       DataViewPerViewFieldsDemo,
-      DataViewSelectionDemo,
+      DataViewSearchDemo,
       ChipInputDemo,
       DataTableSelectionDemo,
       LinearMenuDemo,

--- a/apps/www/src/components/demo/demo.tsx
+++ b/apps/www/src/components/demo/demo.tsx
@@ -42,6 +42,19 @@ import {
   DataTableVirtualizedDemo
 } from '../datatable-demo';
 import DataTableSelectionDemo from '../datatable-selection-demo';
+import {
+  DataViewCustomDemo,
+  DataViewEmptyZeroDemo,
+  DataViewGroupingDemo,
+  DataViewListDemo,
+  DataViewLoadingDemo,
+  DataViewMultiViewDemo,
+  DataViewPerViewFieldsDemo,
+  DataViewSelectionDemo,
+  DataViewTableDemo,
+  DataViewVirtualizedDemo,
+  DataViewVirtualizedGroupingDemo
+} from '../dataview-demo';
 import ChipInputDemo from '../inputfield-chip-demo';
 import LinearMenuDemo from '../linear-dropdown-demo';
 import PopoverColorPicker from '../popover-color-picker';
@@ -62,6 +75,17 @@ export default function Demo(props: DemoProps) {
       DataTableDemo,
       DataTableSearchDemo,
       DataTableVirtualizedDemo,
+      DataViewTableDemo,
+      DataViewListDemo,
+      DataViewMultiViewDemo,
+      DataViewEmptyZeroDemo,
+      DataViewCustomDemo,
+      DataViewVirtualizedDemo,
+      DataViewGroupingDemo,
+      DataViewVirtualizedGroupingDemo,
+      DataViewLoadingDemo,
+      DataViewPerViewFieldsDemo,
+      DataViewSelectionDemo,
       ChipInputDemo,
       DataTableSelectionDemo,
       LinearMenuDemo,

--- a/apps/www/src/components/theme-switcher/theme-toggle.tsx
+++ b/apps/www/src/components/theme-switcher/theme-toggle.tsx
@@ -1,14 +1,16 @@
 'use client';
-import { useTheme } from '@/components/theme';
 import { IconButton } from '@raystack/apsara';
 import { Moon, Sun } from 'lucide-react';
 import { type HTMLAttributes } from 'react';
+import { useTheme } from '@/components/theme';
 
 const ICONS_MAP = { light: Sun, dark: Moon } as const;
 
 export default function ThemeToggle(props: HTMLAttributes<HTMLElement>) {
   const { setTheme, theme } = useTheme();
-  const Icon = ICONS_MAP[theme as keyof typeof ICONS_MAP];
+  // `theme` can briefly be undefined or an unexpected value during hydration
+  // (next-themes resolves async). Fall back so rendering doesn't crash.
+  const Icon = ICONS_MAP[theme as keyof typeof ICONS_MAP] ?? Sun;
 
   return (
     <IconButton

--- a/apps/www/src/content/docs/components/dataview/demo.ts
+++ b/apps/www/src/content/docs/components/dataview/demo.ts
@@ -11,7 +11,6 @@ export const tablePreview = {
       code: `
       <DataView data={data} fields={fields} defaultSort={{ name: "name", order: "asc" }}>
         <DataView.Toolbar>
-          <DataView.Search />
           <DataView.Filters />
           <DataView.DisplayControls />
         </DataView.Toolbar>
@@ -32,7 +31,6 @@ export const listPreview = {
       code: `
       <DataView data={data} fields={fields} defaultSort={{ name: "name", order: "asc" }}>
         <DataView.Toolbar>
-          <DataView.Search />
           <DataView.Filters />
         </DataView.Toolbar>
         <DataView.List variant="list" columns={listColumns} />
@@ -50,9 +48,11 @@ export const multiViewPreview = {
     {
       label: 'index.tsx',
       code: `
+      /* The view switcher lives inside the DisplayControls popover. Give each
+         view an optional leadingIcon to show alongside its label. */
       const views = [
-        { value: "table", label: "Table" },
-        { value: "list",  label: "List"  },
+        { value: "table", label: "Table", leadingIcon: <RowsIcon /> },
+        { value: "list",  label: "List",  leadingIcon: <ListBulletIcon /> },
       ];
 
       <DataView
@@ -63,9 +63,7 @@ export const multiViewPreview = {
         defaultView="table"
       >
         <DataView.Toolbar>
-          <DataView.Search />
           <DataView.Filters />
-          <DataView.ViewSwitcher />
           <DataView.DisplayControls />
         </DataView.Toolbar>
         <DataView.List name="table" variant="table" columns={tableColumns} />
@@ -86,7 +84,6 @@ export const emptyZeroPreview = {
       code: `
       <DataView data={data} fields={fields} defaultSort={{ name: "name", order: "asc" }}>
         <DataView.Toolbar>
-          <DataView.Search />
           <DataView.Filters />
         </DataView.Toolbar>
         <DataView.List variant="table" columns={tableColumns} />
@@ -116,7 +113,6 @@ export const virtualizedPreview = {
       <div style={{ height: 400 }}>
         <DataView data={data} fields={fields} defaultSort={{ name: "name", order: "asc" }}>
           <DataView.Toolbar>
-            <DataView.Search />
             <DataView.Filters />
             <DataView.DisplayControls />
           </DataView.Toolbar>
@@ -152,7 +148,6 @@ export const groupingPreview = {
         query={{ group_by: ["team"] }}
       >
         <DataView.Toolbar>
-          <DataView.Search />
           <DataView.Filters />
           <DataView.DisplayControls />
         </DataView.Toolbar>
@@ -187,7 +182,6 @@ export const virtualizedGroupingPreview = {
           query={{ group_by: ["team"] }}
         >
           <DataView.Toolbar>
-            <DataView.Search />
             <DataView.Filters />
             <DataView.DisplayControls />
           </DataView.Toolbar>
@@ -224,7 +218,6 @@ export const loadingPreview = {
         loadingRowCount={4}
       >
         <DataView.Toolbar>
-          <DataView.Search />
           <DataView.Filters />
         </DataView.Toolbar>
         <DataView.List variant="table" columns={tableColumns} />
@@ -261,9 +254,7 @@ export const perViewFieldsPreview = {
         defaultView="table"
       >
         <DataView.Toolbar>
-          <DataView.Search />
           <DataView.Filters />
-          <DataView.ViewSwitcher />
           <DataView.DisplayControls />
         </DataView.Toolbar>
         <DataView.List name="table" variant="table" columns={tableColumns} />
@@ -274,100 +265,6 @@ export const perViewFieldsPreview = {
           fields={listFields}
         />
       </DataView>`
-    }
-  ]
-};
-
-export const selectionPreview = {
-  type: 'code',
-  previewCode: false,
-  code: `<DataViewSelectionDemo />`,
-  codePreview: [
-    {
-      label: 'index.tsx',
-      code: `import {
-  Button,
-  Checkbox,
-  Chip,
-  DataView,
-  FloatingActions,
-  useDataView,
-} from "@raystack/apsara";
-import { TransformIcon } from "@radix-ui/react-icons";
-
-// 1. Leading checkbox column that wires TanStack selection through the
-//    DataView.List grid track.
-const selectionColumn = {
-  accessorKey: "select",
-  width: "40px",
-  header: ({ table }) => (
-    <Checkbox
-      checked={
-        table.getIsAllRowsSelected()
-          ? true
-          : table.getIsSomeRowsSelected()
-          ? "indeterminate"
-          : false
-      }
-      onCheckedChange={(v) => table.toggleAllRowsSelected(Boolean(v))}
-    />
-  ),
-  cell: ({ row }) => (
-    <Checkbox
-      checked={row.getIsSelected()}
-      onCheckedChange={(v) => row.toggleSelected(Boolean(v))}
-      onClick={(e) => e.stopPropagation()}
-    />
-  ),
-};
-
-// 2. Read selection from context and float a bar when any row is selected.
-function SelectionBar() {
-  const { table } = useDataView();
-  const selected = table.getSelectedRowModel().rows;
-  if (selected.length === 0) return null;
-
-  return (
-    <FloatingActions aria-label="Selection actions">
-      <Chip
-        variant="outline"
-        size="large"
-        color="neutral"
-        leadingIcon={<TransformIcon />}
-        isDismissible
-        onDismiss={() => table.resetRowSelection()}
-      >
-        {selected.length} selected
-      </Chip>
-      <FloatingActions.Separator />
-      <Button variant="outline" color="neutral" size="small">
-        Move to
-      </Button>
-      <Button variant="outline" color="neutral" size="small">
-        Actions
-      </Button>
-    </FloatingActions>
-  );
-}
-
-// 3. Compose.
-<DataView
-  data={rows}
-  fields={fields}
-  defaultSort={{ name: "name", order: "asc" }}
-  getRowId={(row) => row.id}
->
-  <DataView.Toolbar>
-    <DataView.Search />
-    <DataView.Filters />
-    <DataView.DisplayControls />
-  </DataView.Toolbar>
-  <DataView.List
-    variant="table"
-    columns={[selectionColumn, ...tableColumns]}
-  />
-  <SelectionBar />
-</DataView>`
     }
   ]
 };
@@ -403,6 +300,31 @@ export const customPreview = {
             ))
           }
         </DataView.Custom>
+      </DataView>`
+    }
+  ]
+};
+
+export const searchPreview = {
+  type: 'code',
+  style: { padding: 0 },
+  previewCode: false,
+  code: `<DataViewSearchDemo />`,
+  codePreview: [
+    {
+      label: 'index.tsx',
+      code: `
+      /* DataView.Search writes the input to query.search, which feeds
+         TanStack's globalFilter — rows are filtered across every field as
+         the user types. Try "ada", "design", or "invited". */
+      <DataView data={data} fields={fields} defaultSort={{ name: "name", order: "asc" }}>
+        <DataView.Toolbar>
+          <DataView.Search placeholder="Search by name, email, team…" />
+        </DataView.Toolbar>
+        <DataView.List variant="table" columns={tableColumns} />
+        <DataView.EmptyState>
+          <Text>No people match your search.</Text>
+        </DataView.EmptyState>
       </DataView>`
     }
   ]

--- a/apps/www/src/content/docs/components/dataview/demo.ts
+++ b/apps/www/src/content/docs/components/dataview/demo.ts
@@ -1,0 +1,409 @@
+'use client';
+
+export const tablePreview = {
+  type: 'code',
+  style: { padding: 0 },
+  previewCode: false,
+  code: `<DataViewTableDemo />`,
+  codePreview: [
+    {
+      label: 'index.tsx',
+      code: `
+      <DataView data={data} fields={fields} defaultSort={{ name: "name", order: "asc" }}>
+        <DataView.Toolbar>
+          <DataView.Search />
+          <DataView.Filters />
+          <DataView.DisplayControls />
+        </DataView.Toolbar>
+        <DataView.List variant="table" columns={tableColumns} />
+      </DataView>`
+    }
+  ]
+};
+
+export const listPreview = {
+  type: 'code',
+  style: { padding: 0 },
+  previewCode: false,
+  code: `<DataViewListDemo />`,
+  codePreview: [
+    {
+      label: 'index.tsx',
+      code: `
+      <DataView data={data} fields={fields} defaultSort={{ name: "name", order: "asc" }}>
+        <DataView.Toolbar>
+          <DataView.Search />
+          <DataView.Filters />
+        </DataView.Toolbar>
+        <DataView.List variant="list" columns={listColumns} />
+      </DataView>`
+    }
+  ]
+};
+
+export const multiViewPreview = {
+  type: 'code',
+  style: { padding: 0 },
+  previewCode: false,
+  code: `<DataViewMultiViewDemo />`,
+  codePreview: [
+    {
+      label: 'index.tsx',
+      code: `
+      const views = [
+        { value: "table", label: "Table" },
+        { value: "list",  label: "List"  },
+      ];
+
+      <DataView
+        data={data}
+        fields={fields}
+        defaultSort={{ name: "name", order: "asc" }}
+        views={views}
+        defaultView="table"
+      >
+        <DataView.Toolbar>
+          <DataView.Search />
+          <DataView.Filters />
+          <DataView.ViewSwitcher />
+          <DataView.DisplayControls />
+        </DataView.Toolbar>
+        <DataView.List name="table" variant="table" columns={tableColumns} />
+        <DataView.List name="list"  variant="list"  columns={listColumns}  />
+      </DataView>`
+    }
+  ]
+};
+
+export const emptyZeroPreview = {
+  type: 'code',
+  style: { padding: 0 },
+  previewCode: false,
+  code: `<DataViewEmptyZeroDemo />`,
+  codePreview: [
+    {
+      label: 'index.tsx',
+      code: `
+      <DataView data={data} fields={fields} defaultSort={{ name: "name", order: "asc" }}>
+        <DataView.Toolbar>
+          <DataView.Search />
+          <DataView.Filters />
+        </DataView.Toolbar>
+        <DataView.List variant="table" columns={tableColumns} />
+
+        {/* Sibling state components driven by context. */}
+        <DataView.EmptyState>
+          <Text>No people match your filters.</Text>
+        </DataView.EmptyState>
+        <DataView.ZeroState>
+          <Text>Nothing here yet.</Text>
+        </DataView.ZeroState>
+      </DataView>`
+    }
+  ]
+};
+
+export const virtualizedPreview = {
+  type: 'code',
+  style: { padding: 0 },
+  previewCode: false,
+  code: `<DataViewVirtualizedDemo />`,
+  codePreview: [
+    {
+      label: 'index.tsx',
+      code: `
+      /* Parent container must have a fixed height. */
+      <div style={{ height: 400 }}>
+        <DataView data={data} fields={fields} defaultSort={{ name: "name", order: "asc" }}>
+          <DataView.Toolbar>
+            <DataView.Search />
+            <DataView.Filters />
+            <DataView.DisplayControls />
+          </DataView.Toolbar>
+          <DataView.List
+            variant="table"
+            columns={tableColumns}
+            virtualized
+            estimatedRowHeight={44}
+          />
+        </DataView>
+      </div>`
+    }
+  ]
+};
+
+export const groupingPreview = {
+  type: 'code',
+  style: { padding: 0 },
+  previewCode: false,
+  code: `<DataViewGroupingDemo />`,
+  codePreview: [
+    {
+      label: 'index.tsx',
+      code: `
+      /* Initial \`group_by\` is supplied via \`query\`. The user can pick a
+         different group from DisplayControls — same wire format either way.
+         The active group header sticks under the column header as the user
+         scrolls past it. */
+      <DataView
+        data={data}
+        fields={fields}
+        defaultSort={{ name: "name", order: "asc" }}
+        query={{ group_by: ["team"] }}
+      >
+        <DataView.Toolbar>
+          <DataView.Search />
+          <DataView.Filters />
+          <DataView.DisplayControls />
+        </DataView.Toolbar>
+        <DataView.List
+          variant="table"
+          columns={tableColumns}
+          stickyGroupHeader
+        />
+      </DataView>`
+    }
+  ]
+};
+
+export const virtualizedGroupingPreview = {
+  type: 'code',
+  style: { padding: 0 },
+  previewCode: false,
+  code: `<DataViewVirtualizedGroupingDemo />`,
+  codePreview: [
+    {
+      label: 'index.tsx',
+      code: `
+      /* Virtualized + grouped + sticky. A single sticky-anchor element shows
+         the active group's label; its content swaps as the user scrolls past
+         each group's offset. The natural group header at the active offset is
+         hidden so the anchor doesn't double-render the label. */
+      <div style={{ height: 360 }}>
+        <DataView
+          data={data} // ~1500 rows
+          fields={fields}
+          defaultSort={{ name: "name", order: "asc" }}
+          query={{ group_by: ["team"] }}
+        >
+          <DataView.Toolbar>
+            <DataView.Search />
+            <DataView.Filters />
+            <DataView.DisplayControls />
+          </DataView.Toolbar>
+          <DataView.List
+            variant="table"
+            columns={tableColumns}
+            virtualized
+            estimatedRowHeight={44}
+            stickyGroupHeader
+          />
+        </DataView>
+      </div>`
+    }
+  ]
+};
+
+export const loadingPreview = {
+  type: 'code',
+  style: { padding: 0 },
+  previewCode: false,
+  code: `<DataViewLoadingDemo />`,
+  codePreview: [
+    {
+      label: 'index.tsx',
+      code: `
+      /* \`DataView.List\` renders \`loadingRowCount\` skeleton rows while
+         \`isLoading\` is true. Existing rows render alongside skeletons in
+         server mode (load-more). */
+      <DataView
+        data={loadingRows}
+        fields={fields}
+        defaultSort={{ name: "name", order: "asc" }}
+        isLoading={isLoading}
+        loadingRowCount={4}
+      >
+        <DataView.Toolbar>
+          <DataView.Search />
+          <DataView.Filters />
+        </DataView.Toolbar>
+        <DataView.List variant="table" columns={tableColumns} />
+      </DataView>`
+    }
+  ]
+};
+
+export const perViewFieldsPreview = {
+  type: 'code',
+  style: { padding: 0 },
+  previewCode: false,
+  code: `<DataViewPerViewFieldsDemo />`,
+  codePreview: [
+    {
+      label: 'index.tsx',
+      code: `
+      /* The List view hides Email by overriding fields on its renderer.
+         Display Properties and filter chips both reflect the override. */
+      const listFields = fields.map((f) =>
+        f.accessorKey === "email"
+          ? { ...f, hideable: false, defaultHidden: true }
+          : f
+      );
+
+      <DataView
+        data={data}
+        fields={fields}
+        defaultSort={{ name: "name", order: "asc" }}
+        views={[
+          { value: "table", label: "Table" },
+          { value: "list",  label: "List"  },
+        ]}
+        defaultView="table"
+      >
+        <DataView.Toolbar>
+          <DataView.Search />
+          <DataView.Filters />
+          <DataView.ViewSwitcher />
+          <DataView.DisplayControls />
+        </DataView.Toolbar>
+        <DataView.List name="table" variant="table" columns={tableColumns} />
+        <DataView.List
+          name="list"
+          variant="list"
+          columns={listColumns}
+          fields={listFields}
+        />
+      </DataView>`
+    }
+  ]
+};
+
+export const selectionPreview = {
+  type: 'code',
+  previewCode: false,
+  code: `<DataViewSelectionDemo />`,
+  codePreview: [
+    {
+      label: 'index.tsx',
+      code: `import {
+  Button,
+  Checkbox,
+  Chip,
+  DataView,
+  FloatingActions,
+  useDataView,
+} from "@raystack/apsara";
+import { TransformIcon } from "@radix-ui/react-icons";
+
+// 1. Leading checkbox column that wires TanStack selection through the
+//    DataView.List grid track.
+const selectionColumn = {
+  accessorKey: "select",
+  width: "40px",
+  header: ({ table }) => (
+    <Checkbox
+      checked={
+        table.getIsAllRowsSelected()
+          ? true
+          : table.getIsSomeRowsSelected()
+          ? "indeterminate"
+          : false
+      }
+      onCheckedChange={(v) => table.toggleAllRowsSelected(Boolean(v))}
+    />
+  ),
+  cell: ({ row }) => (
+    <Checkbox
+      checked={row.getIsSelected()}
+      onCheckedChange={(v) => row.toggleSelected(Boolean(v))}
+      onClick={(e) => e.stopPropagation()}
+    />
+  ),
+};
+
+// 2. Read selection from context and float a bar when any row is selected.
+function SelectionBar() {
+  const { table } = useDataView();
+  const selected = table.getSelectedRowModel().rows;
+  if (selected.length === 0) return null;
+
+  return (
+    <FloatingActions aria-label="Selection actions">
+      <Chip
+        variant="outline"
+        size="large"
+        color="neutral"
+        leadingIcon={<TransformIcon />}
+        isDismissible
+        onDismiss={() => table.resetRowSelection()}
+      >
+        {selected.length} selected
+      </Chip>
+      <FloatingActions.Separator />
+      <Button variant="outline" color="neutral" size="small">
+        Move to
+      </Button>
+      <Button variant="outline" color="neutral" size="small">
+        Actions
+      </Button>
+    </FloatingActions>
+  );
+}
+
+// 3. Compose.
+<DataView
+  data={rows}
+  fields={fields}
+  defaultSort={{ name: "name", order: "asc" }}
+  getRowId={(row) => row.id}
+>
+  <DataView.Toolbar>
+    <DataView.Search />
+    <DataView.Filters />
+    <DataView.DisplayControls />
+  </DataView.Toolbar>
+  <DataView.List
+    variant="table"
+    columns={[selectionColumn, ...tableColumns]}
+  />
+  <SelectionBar />
+</DataView>`
+    }
+  ]
+};
+
+export const customPreview = {
+  type: 'code',
+  style: { padding: 0 },
+  previewCode: false,
+  code: `<DataViewCustomDemo />`,
+  codePreview: [
+    {
+      label: 'index.tsx',
+      code: `
+      <DataView data={data} fields={fields} defaultSort={{ name: "name", order: "asc" }}>
+        <DataView.Toolbar>
+          <DataView.Filters />
+          <DataView.DisplayControls />
+        </DataView.Toolbar>
+
+        {/* Render prop receives the full DataView context. */}
+        <DataView.Custom>
+          {({ data }) =>
+            data.map((p) => (
+              <Card key={p.id}>
+                {/* DisplayAccess gates fields on the global Display Properties toggle. */}
+                <DataView.DisplayAccess accessorKey="name">
+                  <Text>{p.name}</Text>
+                </DataView.DisplayAccess>
+                <DataView.DisplayAccess accessorKey="email">
+                  <Text>{p.email}</Text>
+                </DataView.DisplayAccess>
+              </Card>
+            ))
+          }
+        </DataView.Custom>
+      </DataView>`
+    }
+  ]
+};

--- a/apps/www/src/content/docs/components/dataview/index.mdx
+++ b/apps/www/src/content/docs/components/dataview/index.mdx
@@ -1,0 +1,256 @@
+---
+title: DataView
+description: A unified data primitive whose query state drives swappable renderers. List, custom, multi-view — one filter/sort/group/search model.
+source: packages/raystack/components/data-view
+---
+
+import {
+  tablePreview,
+  listPreview,
+  multiViewPreview,
+  emptyZeroPreview,
+  customPreview,
+  virtualizedPreview,
+  groupingPreview,
+  virtualizedGroupingPreview,
+  loadingPreview,
+  perViewFieldsPreview,
+  selectionPreview,
+} from "./demo.ts";
+
+<Demo data={tablePreview} />
+
+## Overview
+
+`DataView` owns the data layer — query state (filters, sort, group, search), client/server mode, row model derivation — and lets you pick the renderer that draws it. The same `<DataView>` can host a table, a list, or a free-form view, switchable at runtime without losing query state.
+
+In scope today: `DataView.List` (table + list presentations) and `DataView.Custom` (escape hatch for cards, kanban, gallery, etc.).
+
+## Anatomy
+
+```tsx
+import {
+  DataView,
+  DataViewField,
+  DataViewListColumn,
+  ViewSpec,
+  useDataView,
+  EmptyFilterValue,
+} from "@raystack/apsara";
+
+<DataView data={data} fields={fields} defaultSort={defaultSort}>
+  <DataView.Toolbar>
+    <DataView.Search />
+    <DataView.Filters />
+    <DataView.DisplayControls />
+  </DataView.Toolbar>
+
+  <DataView.List variant="table" columns={tableColumns} />
+
+  <DataView.EmptyState>{/* no matches */}</DataView.EmptyState>
+  <DataView.ZeroState>{/* no data yet */}</DataView.ZeroState>
+</DataView>
+```
+
+## Core ideas
+
+### Fields vs columns
+
+`fields` is renderer-agnostic metadata declared **once on the root** — filter capability, sort capability, group capability, visibility, group-header presentation. Cell/header renderers live on the **renderer's** column spec (e.g. `DataView.List`'s `columns`).
+
+```ts
+const fields: DataViewField<Person>[] = [
+  { accessorKey: "name",  label: "Name",   sortable: true, filterable: true, filterType: "string", hideable: true },
+  { accessorKey: "team",  label: "Team",   filterable: true, filterType: "select", groupable: true, filterOptions: [...] },
+  { accessorKey: "email", label: "Email",  hideable: true, defaultHidden: true },
+];
+
+const tableColumns: DataViewListColumn<Person>[] = [
+  { accessorKey: "name",  width: "1fr",  cell: ({ row }) => <Text>{row.original.name}</Text> },
+  { accessorKey: "team",  width: "auto", cell: ({ row }) => <Badge>{row.original.team}</Badge> },
+  { accessorKey: "email", width: "1fr",  cell: ({ row }) => <Text>{row.original.email}</Text> },
+];
+```
+
+### Empty vs zero state
+
+Empty/zero is computed once on context (`isEmptyState`, `isZeroState`) and exposed as sibling components.
+
+- **Zero state** — no data, no active query. The "first-use" surface. Toolbar is hidden automatically.
+- **Empty state** — no rows visible because filters/search/sort exclude them all. Toolbar stays visible so the user can correct it.
+
+```tsx
+<DataView.EmptyState>
+  <Text>No matches for your filters.</Text>
+</DataView.EmptyState>
+<DataView.ZeroState>
+  <Text>Nothing here yet.</Text>
+</DataView.ZeroState>
+```
+
+Renderers return `null` when `!hasData` — siblings render the messaging.
+
+### Display Properties (column visibility)
+
+Visibility is a **single global map** on context. `DataView.List` honours it for free (TanStack column visibility hides the grid track). For free-form renderers, wrap fields in `DataView.DisplayAccess`:
+
+```tsx
+<DataView.DisplayAccess accessorKey="email">
+  <Text>{row.email}</Text>
+</DataView.DisplayAccess>
+```
+
+`accessorKey`s not present in `fields` default to visible, so typos don't silently break renders.
+
+## API Reference
+
+### Root
+
+<auto-type-table path="./props.ts" name="DataViewProps" />
+
+### Field
+
+<auto-type-table path="./props.ts" name="DataViewField" />
+
+### Sort
+
+<auto-type-table path="./props.ts" name="DataViewSort" />
+
+### Query
+
+<auto-type-table path="./props.ts" name="DataViewQuery" />
+
+### View spec
+
+<auto-type-table path="./props.ts" name="ViewSpec" />
+
+### DataView.List
+
+<auto-type-table path="./props.ts" name="DataViewListProps" />
+
+#### Column
+
+<auto-type-table path="./props.ts" name="DataViewListColumn" />
+
+### DataView.Custom
+
+<auto-type-table path="./props.ts" name="DataViewCustomProps" />
+
+### DataView.DisplayAccess
+
+<auto-type-table path="./props.ts" name="DataViewDisplayAccessProps" />
+
+### DataView.EmptyState
+
+<auto-type-table path="./props.ts" name="DataViewEmptyStateProps" />
+
+### DataView.ZeroState
+
+<auto-type-table path="./props.ts" name="DataViewZeroStateProps" />
+
+### DataView.ViewSwitcher
+
+<auto-type-table path="./props.ts" name="DataViewViewSwitcherProps" />
+
+## Examples
+
+### List variant
+
+`DataView.List` ships two presentations behind one renderer. Use `variant="list"` for card-style rows; the default `1fr` middle column with `auto` end columns gives you the familiar justify-between layout.
+
+<Demo data={listPreview} />
+
+### Multi-view
+
+Pass `views` + give each renderer a `name`. `DataView.DisplayControls` hosts the switcher automatically (or place `<DataView.ViewSwitcher>` standalone). Query state — filters, sort, search, visibility — persists across switches.
+
+<Demo data={multiViewPreview} />
+
+### Empty / zero state
+
+<Demo data={emptyZeroPreview} />
+
+### Custom renderer
+
+`DataView.Custom` exposes the full context as a render prop. Use it for cards, kanban, gallery, map, or any non-tabular presentation. Wrap fields in `DataView.DisplayAccess` so the single Display Properties toggle reaches them.
+
+<Demo data={customPreview} />
+
+### Virtualized list
+
+For large datasets, pass `virtualized` to `DataView.List`. The parent must have a fixed height — only the rows in view are rendered. Rows auto-measure after paint, so variable-height content (avatars, wrapped text, badges) just works. `estimatedRowHeight` is an optional hint used only until the first measurement.
+
+<Demo data={virtualizedPreview} />
+
+### Grouping with sticky header
+
+Group rows by any `groupable` field. `stickyGroupHeader` pins the active group label directly under the column headers while you scroll past that group's rows. Pick a different field from `DisplayControls` → Grouping at runtime — the wire format stays `group_by: string[]`.
+
+<Demo data={groupingPreview} />
+
+In virtualized mode, a single sticky-anchor element swaps its content as the user scrolls past each group's offset. The natural group header at the active offset is hidden so the anchor doesn't double-render the label, and the lookup uses binary search + `requestAnimationFrame` so the cost stays flat regardless of group count.
+
+<Demo data={virtualizedGroupingPreview} />
+
+### Loading state
+
+While `isLoading` is `true`, `DataView.List` renders `loadingRowCount` skeleton rows at the tail. Behaviour is identical in virtualized and non-virtualized mode, and during initial load (skeletons fill the row pane) as well as during paginated server-mode load-more (skeletons render below the last loaded row).
+
+<Demo data={loadingPreview} />
+
+In server mode, infinite scroll triggers via a single sentinel + `IntersectionObserver` — there are no scroll-distance knobs to tune. While `isLoading` is true the sentinel is suppressed so the consumer's `onLoadMore` isn't fired again during a fetch.
+
+### Per-view fields override
+
+Each renderer accepts an optional `fields` prop. It **fully replaces** the root `fields` for that view's active session — filter chips, sort menu, and Display Properties reflect the override while the view is active. Common pattern: spread root fields and tweak the few that differ.
+
+<Demo data={perViewFieldsPreview} />
+
+```tsx
+const listFields = fields.map((f) =>
+  f.accessorKey === "email" ? { ...f, hideable: false, defaultHidden: true } : f,
+);
+
+<DataView.List name="list" variant="list" columns={listColumns} fields={listFields} />;
+```
+
+### Row selection
+
+`DataView` doesn't ship a built-in selection toolbar, but the TanStack table instance is exposed through `useDataView()`. Wire a leading checkbox column, then float a [`FloatingActions`](/docs/components/floating-actions) bar while any row is selected.
+
+<Demo data={selectionPreview} />
+
+Notes:
+- `table.resetRowSelection()` clears the selection; wire it to `Chip`'s `onDismiss`.
+- `FloatingActions` defaults to `variant="floating"` (`position: fixed`, bottom-center). To scope the bar to the table region rather than the viewport, give an ancestor `transform`, `filter`, or `contain: paint` so it becomes the containing block for the fixed bar.
+
+### Custom group buckets (`groupByResolvers`)
+
+The wire format keeps `group_by: string[]`. To group by something that isn't a raw accessor (e.g. "by week of created_at"), supply a resolver:
+
+```tsx
+<DataView
+  groupByResolvers={{
+    name_first_letter: (row) => row.name.charAt(0).toUpperCase(),
+  }}
+  // query.group_by = ["name_first_letter"]
+/>
+```
+
+### Server mode
+
+```tsx
+<DataView
+  mode="server"
+  data={page.rows}
+  isLoading={loading}
+  totalRowCount={page.total}
+  query={query}
+  onTableQueryChange={(q) => setQuery(q)}
+  onLoadMore={() => fetchNext()}
+>
+  …
+</DataView>
+```
+
+In server mode, `onTableQueryChange` fires whenever the query changes. The `DataView.List` shows skeleton loader rows when `isLoading` is true. Filter predicates and sort run on the server — the local TanStack table is manual.

--- a/apps/www/src/content/docs/components/dataview/index.mdx
+++ b/apps/www/src/content/docs/components/dataview/index.mdx
@@ -6,6 +6,7 @@ source: packages/raystack/components/data-view
 
 import {
   tablePreview,
+  searchPreview,
   listPreview,
   multiViewPreview,
   emptyZeroPreview,
@@ -15,7 +16,6 @@ import {
   virtualizedGroupingPreview,
   loadingPreview,
   perViewFieldsPreview,
-  selectionPreview,
 } from "./demo.ts";
 
 <Demo data={tablePreview} />
@@ -148,11 +148,21 @@ Visibility is a **single global map** on context. `DataView.List` honours it for
 
 <auto-type-table path="./props.ts" name="DataViewZeroStateProps" />
 
-### DataView.ViewSwitcher
+### DataView.DisplayControls
 
-<auto-type-table path="./props.ts" name="DataViewViewSwitcherProps" />
+The popover housing the view switcher, Ordering, Grouping, and Display Properties. The view switcher appears at the top whenever `views.length > 1`. Each section can be hidden individually.
+
+<auto-type-table path="./props.ts" name="DataViewDisplayControlsProps" />
 
 ## Examples
+
+### Search
+
+`DataView.Search` writes the input to `query.search`, which feeds TanStack's `globalFilter` — rows are filtered across every field as the user types. Drop it into the toolbar wherever you want it; in client mode no extra wiring is needed. Type a name, email, or team below to filter the rows.
+
+<Demo data={searchPreview} />
+
+By default search auto-disables in the zero state (no data and no active query) and re-enables the moment the user types. Pass `autoDisableInZeroState={false}` to keep it always enabled, or `disabled` to control it yourself. In server mode, read `query.search` in `onTableQueryChange` and filter on the backend.
 
 ### List variant
 
@@ -162,7 +172,7 @@ Visibility is a **single global map** on context. `DataView.List` honours it for
 
 ### Multi-view
 
-Pass `views` + give each renderer a `name`. `DataView.DisplayControls` hosts the switcher automatically (or place `<DataView.ViewSwitcher>` standalone). Query state — filters, sort, search, visibility — persists across switches.
+Pass `views` + give each renderer a `name`. `DataView.DisplayControls` hosts the view switcher at the top of its popover automatically — give each view an optional `leadingIcon` to show alongside its label. Query state — filters, sort, search, visibility — persists across switches.
 
 <Demo data={multiViewPreview} />
 
@@ -213,16 +223,6 @@ const listFields = fields.map((f) =>
 
 <DataView.List name="list" variant="list" columns={listColumns} fields={listFields} />;
 ```
-
-### Row selection
-
-`DataView` doesn't ship a built-in selection toolbar, but the TanStack table instance is exposed through `useDataView()`. Wire a leading checkbox column, then float a [`FloatingActions`](/docs/components/floating-actions) bar while any row is selected.
-
-<Demo data={selectionPreview} />
-
-Notes:
-- `table.resetRowSelection()` clears the selection; wire it to `Chip`'s `onDismiss`.
-- `FloatingActions` defaults to `variant="floating"` (`position: fixed`, bottom-center). To scope the bar to the table region rather than the viewport, give an ancestor `transform`, `filter`, or `contain: paint` so it becomes the containing block for the fixed bar.
 
 ### Custom group buckets (`groupByResolvers`)
 

--- a/apps/www/src/content/docs/components/dataview/props.ts
+++ b/apps/www/src/content/docs/components/dataview/props.ts
@@ -205,12 +205,17 @@ export interface DataViewZeroStateProps {
   children: ReactNode;
 }
 
-export interface DataViewViewSwitcherProps {
-  /**
-   * @defaultValue "small"
-   */
-  size?: 'small' | 'medium' | 'large';
-  className?: string;
+export interface DataViewDisplayControlsProps {
+  /** Custom trigger element for the popover. */
+  trigger?: ReactNode;
+  /** Hide the multi-view switcher (shown by default when `views.length > 1`). */
+  hideViewSwitcher?: boolean;
+  /** Hide the Ordering (sort) control. */
+  hideOrdering?: boolean;
+  /** Hide the Grouping control. */
+  hideGrouping?: boolean;
+  /** Hide the Display Properties (column visibility) section. */
+  hideDisplayProperties?: boolean;
 }
 
 export interface ViewSpec {
@@ -218,7 +223,8 @@ export interface ViewSpec {
   value: string;
   /** Shown in the view switcher. */
   label: string;
-  icon?: ReactNode;
+  /** Optional icon rendered before the view's label in the switcher tab. */
+  leadingIcon?: ReactNode;
 }
 
 export interface DataViewQuery {

--- a/apps/www/src/content/docs/components/dataview/props.ts
+++ b/apps/www/src/content/docs/components/dataview/props.ts
@@ -1,0 +1,240 @@
+import { ReactNode } from 'react';
+
+// Documentation-only placeholders so `auto-type-table` can render the public
+// API without surfacing real generics (TData is shown as `T` for readability).
+type T = any;
+type DataViewContext = unknown;
+
+export interface DataViewProps {
+  /** Renderer-agnostic field metadata. Drives filter/sort/group/visibility. (Required) */
+  fields: DataViewField[];
+
+  /** Table data. (Required) */
+  data: Array<T>;
+
+  /** Default sort. (Required) */
+  defaultSort: DataViewSort;
+
+  /**
+   * Data processing mode.
+   * @defaultValue "client"
+   */
+  mode?: 'client' | 'server';
+
+  /**
+   * Loading state.
+   * @defaultValue false
+   */
+  isLoading?: boolean;
+
+  /** Initial query state. */
+  query?: DataViewQuery;
+
+  /** Called whenever the internal query changes — only in server mode. */
+  onTableQueryChange?: (query: DataViewQuery) => void;
+
+  /** Infinite scroll callback. */
+  onLoadMore?: () => Promise<void> | void;
+
+  /** Row click handler. */
+  onRowClick?: (row: T) => void;
+
+  /** Column visibility change callback. */
+  onColumnVisibilityChange?: (visibility: Record<string, boolean>) => void;
+
+  /** Return a stable unique id for each row (used as React key). */
+  getRowId?: (row: T, index: number) => string;
+
+  /** Total rows available on server (used for the "hidden by filters" footer in server mode). */
+  totalRowCount?: number;
+
+  /**
+   * Skeleton rows to render while loading.
+   * @defaultValue 3
+   */
+  loadingRowCount?: number;
+
+  /** Multi-view configuration. */
+  views?: ViewSpec[];
+
+  /** Default active view (uncontrolled). */
+  defaultView?: string;
+
+  /** Active view (controlled). */
+  view?: string;
+
+  /** Called when the active view changes. */
+  onViewChange?: (view: string) => void;
+
+  /**
+   * Optional local resolvers for non-accessor `group_by` keys.
+   * Keeps the wire format (`group_by: string[]`) unchanged.
+   */
+  groupByResolvers?: Record<string, (row: T) => string>;
+}
+
+export interface DataViewField {
+  /** Key into the row object. */
+  accessorKey: string;
+
+  /** Human-readable label. */
+  label: string;
+
+  /** Optional icon (e.g. for grouping menu). */
+  icon?: ReactNode;
+
+  /** Allow filtering on this field. */
+  filterable?: boolean;
+
+  /** Filter input type. */
+  filterType?: 'string' | 'number' | 'date' | 'select' | 'multiselect';
+
+  /** Options when filterType is select/multiselect. */
+  filterOptions?: Array<{ label: string; value: string }>;
+
+  /** Allow sorting. */
+  sortable?: boolean;
+
+  /** Allow grouping. */
+  groupable?: boolean;
+
+  /** Allow toggling visibility. */
+  hideable?: boolean;
+
+  /** Hide this field by default. */
+  defaultHidden?: boolean;
+
+  /** Show item count next to the group header label. */
+  showGroupCount?: boolean;
+
+  /** Override group bucket labels (key → label). */
+  groupLabelsMap?: Record<string, string>;
+}
+
+export interface DataViewListProps {
+  /** Multi-view name. When set, the renderer gates itself on the active view. */
+  name?: string;
+
+  /**
+   * Visual variant. `table` renders headers and uses `role="table"`;
+   * `list` renders no headers and uses `role="list"`.
+   * @defaultValue "list"
+   */
+  variant?: 'table' | 'list';
+
+  /** Override the header visibility. */
+  showHeaders?: boolean;
+
+  /** Override the root ARIA role. */
+  role?: 'table' | 'list';
+
+  /** Optional view-scoped field override (full replacement). */
+  fields?: DataViewField[];
+
+  /** Column render specs. (Required) */
+  columns: DataViewListColumn[];
+
+  /**
+   * Initial row-height estimate (px). Rows are auto-measured after they paint,
+   * so this is only used until the first measurement. Default 40 for table,
+   * 56 for list.
+   */
+  estimatedRowHeight?: number;
+
+  /** When true, only viewport-visible rows render. Parent must have a fixed height. */
+  virtualized?: boolean;
+
+  /** Render dividers between rows (default true for table). */
+  showDividers?: boolean;
+
+  /** Render group section headers when grouping is active. Default true. */
+  showGroupHeaders?: boolean;
+
+  /** When true, the active group header sticks under the table header while scrolling. */
+  stickyGroupHeader?: boolean;
+}
+
+export interface DataViewListColumn {
+  /** Pointer into `fields[]`. */
+  accessorKey: string;
+
+  /** TanStack-style cell renderer. */
+  cell?: (ctx) => ReactNode;
+
+  /** TanStack-style header renderer. Overrides the field `label`. */
+  header?: (ctx) => ReactNode;
+
+  /**
+   * CSS grid track width.
+   * Examples: `'1fr'`, `'auto'`, `'200px'`, `'minmax(80px, 1fr)'`, or a number (pixels).
+   * @defaultValue "1fr"
+   */
+  width?: string | number;
+}
+
+export interface DataViewCustomProps {
+  /** Multi-view name. */
+  name?: string;
+
+  /** Optional view-scoped field override. */
+  fields?: DataViewField[];
+
+  /** Render prop. Receives the full DataView context. */
+  children: (context: DataViewContext) => ReactNode;
+}
+
+export interface DataViewDisplayAccessProps {
+  /** Field accessor key whose visibility gates `children`. */
+  accessorKey: string;
+
+  /** Rendered when the field is currently hidden. */
+  fallback?: ReactNode;
+
+  children: ReactNode;
+}
+
+export interface DataViewEmptyStateProps {
+  /** Restrict to a specific view's `name`. */
+  forView?: string;
+  children: ReactNode;
+}
+
+export interface DataViewZeroStateProps {
+  /** Restrict to a specific view's `name`. */
+  forView?: string;
+  children: ReactNode;
+}
+
+export interface DataViewViewSwitcherProps {
+  /**
+   * @defaultValue "small"
+   */
+  size?: 'small' | 'medium' | 'large';
+  className?: string;
+}
+
+export interface ViewSpec {
+  /** Matches the `name` prop on a renderer. */
+  value: string;
+  /** Shown in the view switcher. */
+  label: string;
+  icon?: ReactNode;
+}
+
+export interface DataViewQuery {
+  filters?: Array<{
+    name: string;
+    operator: string;
+    value: unknown;
+  }>;
+  sort?: DataViewSort[];
+  group_by?: string[];
+  search?: string;
+  offset?: number;
+  limit?: number;
+}
+
+export interface DataViewSort {
+  name: string;
+  order: 'asc' | 'desc';
+}

--- a/packages/raystack/components/data-view/__tests__/data-view.test.tsx
+++ b/packages/raystack/components/data-view/__tests__/data-view.test.tsx
@@ -1,0 +1,1114 @@
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+// SVG icons are inlined via @svgr/rollup at build time. In Vitest they resolve
+// to undefined, so stub the `~/icons` module with no-op components.
+vi.mock('~/icons', () => ({
+  FilterIcon: () => null,
+  __esModule: true
+}));
+
+// biome-ignore lint/suspicious/noShadowRestrictedNames: legitimate export name
+import { DataView } from '../data-view';
+import type {
+  DataViewField,
+  DataViewListColumn,
+  ViewSpec
+} from '../data-view.types';
+import { useDataView as useDataViewForTest } from '../hooks/useDataView';
+
+// Drivable IntersectionObserver mock. Tests grab the most recent observer
+// instance via `getLastObserver()` and call its `trigger` to simulate the
+// sentinel entering the viewport.
+type IOInstance = {
+  observe: (el: Element) => void;
+  unobserve: (el: Element) => void;
+  disconnect: () => void;
+  trigger: (isIntersecting: boolean) => void;
+  observed: Element[];
+};
+
+let ioInstances: IOInstance[] = [];
+
+beforeAll(() => {
+  // biome-ignore lint/suspicious/noExplicitAny: jsdom doesn't ship IntersectionObserver
+  global.IntersectionObserver = vi.fn().mockImplementation(function (
+    this: IOInstance,
+    cb: IntersectionObserverCallback
+  ) {
+    const observed: Element[] = [];
+    this.observed = observed;
+    this.observe = (el: Element) => {
+      observed.push(el);
+    };
+    this.unobserve = (el: Element) => {
+      const i = observed.indexOf(el);
+      if (i >= 0) observed.splice(i, 1);
+    };
+    this.disconnect = () => {
+      observed.length = 0;
+    };
+    this.trigger = (isIntersecting: boolean) => {
+      const entries = observed.map(
+        el =>
+          ({
+            isIntersecting,
+            target: el
+          }) as unknown as IntersectionObserverEntry
+      );
+      cb(entries, this as unknown as IntersectionObserver);
+    };
+    ioInstances.push(this);
+  }) as unknown as typeof IntersectionObserver;
+
+  // jsdom doesn't implement ResizeObserver — TanStack Virtual uses it for
+  // measureElement.
+  // biome-ignore lint/suspicious/noExplicitAny: jsdom lacks ResizeObserver
+  (global as any).ResizeObserver =
+    (global as any).ResizeObserver ||
+    vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn()
+    }));
+});
+
+afterEach(() => {
+  ioInstances = [];
+});
+
+function getLastObserver(): IOInstance | undefined {
+  return ioInstances[ioInstances.length - 1];
+}
+
+interface TestData {
+  id: number;
+  name: string;
+  email: string;
+  status: 'active' | 'inactive';
+}
+
+const mockData: TestData[] = [
+  { id: 1, name: 'John Doe', email: 'john@example.com', status: 'active' },
+  { id: 2, name: 'Jane Smith', email: 'jane@example.com', status: 'inactive' },
+  { id: 3, name: 'Bob Johnson', email: 'bob@example.com', status: 'active' }
+];
+
+const mockFields: DataViewField<TestData>[] = [
+  {
+    accessorKey: 'name',
+    label: 'Name',
+    sortable: true,
+    filterable: true,
+    filterType: 'string',
+    hideable: true
+  },
+  {
+    accessorKey: 'email',
+    label: 'Email',
+    sortable: true,
+    filterable: true,
+    filterType: 'string',
+    hideable: true
+  },
+  {
+    accessorKey: 'status',
+    label: 'Status',
+    sortable: true,
+    filterable: true,
+    filterType: 'string',
+    hideable: true,
+    groupable: true
+  }
+];
+
+const mockColumns: DataViewListColumn<TestData>[] = [
+  { accessorKey: 'name', cell: ({ getValue }) => getValue() as string },
+  { accessorKey: 'email', cell: ({ getValue }) => getValue() as string },
+  { accessorKey: 'status', cell: ({ getValue }) => getValue() as string }
+];
+
+const defaultSort = { name: 'name', order: 'asc' as const };
+
+describe('DataView', () => {
+  describe('Basic Rendering', () => {
+    it('renders a table renderer with role="table"', () => {
+      render(
+        <DataView data={mockData} fields={mockFields} defaultSort={defaultSort}>
+          <DataView.List variant='table' columns={mockColumns} />
+        </DataView>
+      );
+      expect(screen.getByRole('table')).toBeInTheDocument();
+    });
+
+    it('renders a list renderer with role="list"', () => {
+      render(
+        <DataView data={mockData} fields={mockFields} defaultSort={defaultSort}>
+          <DataView.List variant='list' columns={mockColumns} />
+        </DataView>
+      );
+      expect(screen.getByRole('list')).toBeInTheDocument();
+    });
+
+    it('provides context to children via useDataView', () => {
+      const Probe = () => <div data-testid='probe' />;
+      render(
+        <DataView data={mockData} fields={mockFields} defaultSort={defaultSort}>
+          <Probe />
+        </DataView>
+      );
+      expect(screen.getByTestId('probe')).toBeInTheDocument();
+    });
+
+    it('throws if useDataView is used outside provider', () => {
+      const Probe = () => {
+        useDataViewForTest();
+        return null;
+      };
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      expect(() => render(<Probe />)).toThrow(/useDataView/);
+      spy.mockRestore();
+    });
+  });
+
+  describe('Data Display', () => {
+    it('renders row values', () => {
+      render(
+        <DataView data={mockData} fields={mockFields} defaultSort={defaultSort}>
+          <DataView.List variant='table' columns={mockColumns} />
+        </DataView>
+      );
+      expect(screen.getByText('John Doe')).toBeInTheDocument();
+      expect(screen.getByText('jane@example.com')).toBeInTheDocument();
+    });
+
+    it('renders headers when variant="table"', () => {
+      render(
+        <DataView data={mockData} fields={mockFields} defaultSort={defaultSort}>
+          <DataView.List variant='table' columns={mockColumns} />
+        </DataView>
+      );
+      expect(
+        screen.getByRole('columnheader', { name: 'Name' })
+      ).toBeInTheDocument();
+    });
+
+    it('omits headers when variant="list"', () => {
+      render(
+        <DataView data={mockData} fields={mockFields} defaultSort={defaultSort}>
+          <DataView.List variant='list' columns={mockColumns} />
+        </DataView>
+      );
+      expect(screen.queryByRole('columnheader')).not.toBeInTheDocument();
+    });
+
+    it('list renderer emits listitem rows', () => {
+      render(
+        <DataView data={mockData} fields={mockFields} defaultSort={defaultSort}>
+          <DataView.List variant='list' columns={mockColumns} />
+        </DataView>
+      );
+      expect(screen.getAllByRole('listitem')).toHaveLength(mockData.length);
+    });
+  });
+
+  describe('Row Click', () => {
+    it('fires onRowClick with the row data', async () => {
+      const user = userEvent.setup();
+      const onRowClick = vi.fn();
+      render(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          onRowClick={onRowClick}
+        >
+          <DataView.List variant='table' columns={mockColumns} />
+        </DataView>
+      );
+      await user.click(screen.getByText('John Doe'));
+      expect(onRowClick).toHaveBeenCalledWith(mockData[0]);
+    });
+  });
+
+  describe('Zero / Empty State', () => {
+    it('renders ZeroState sibling when no data and no active query', () => {
+      render(
+        <DataView data={[]} fields={mockFields} defaultSort={defaultSort}>
+          <DataView.List variant='table' columns={mockColumns} />
+          <DataView.ZeroState>
+            <div data-testid='zero'>Nothing here yet</div>
+          </DataView.ZeroState>
+          <DataView.EmptyState>
+            <div data-testid='empty'>No matches</div>
+          </DataView.EmptyState>
+        </DataView>
+      );
+      expect(screen.getByTestId('zero')).toBeInTheDocument();
+      expect(screen.queryByTestId('empty')).not.toBeInTheDocument();
+    });
+
+    it('renders EmptyState sibling when filters yield no rows', () => {
+      render(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          query={{
+            filters: [{ name: 'name', operator: 'eq', value: 'NonExistent' }]
+          }}
+        >
+          <DataView.List variant='table' columns={mockColumns} />
+          <DataView.ZeroState>
+            <div data-testid='zero'>Nothing here yet</div>
+          </DataView.ZeroState>
+          <DataView.EmptyState>
+            <div data-testid='empty'>No matches</div>
+          </DataView.EmptyState>
+        </DataView>
+      );
+      expect(screen.getByTestId('empty')).toBeInTheDocument();
+      expect(screen.queryByTestId('zero')).not.toBeInTheDocument();
+    });
+
+    it('renders nothing in renderer when !hasData (sibling takes over)', () => {
+      render(
+        <DataView data={[]} fields={mockFields} defaultSort={defaultSort}>
+          <DataView.List variant='table' columns={mockColumns} />
+        </DataView>
+      );
+      expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Toolbar', () => {
+    it('renders nothing in pure zero state', () => {
+      const { container } = render(
+        <DataView data={[]} fields={mockFields} defaultSort={defaultSort}>
+          <DataView.Toolbar>
+            <DataView.Search data-testid='search' />
+          </DataView.Toolbar>
+        </DataView>
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders children when data exists', () => {
+      render(
+        <DataView data={mockData} fields={mockFields} defaultSort={defaultSort}>
+          <DataView.Toolbar>
+            <DataView.Search />
+            <DataView.Filters />
+          </DataView.Toolbar>
+          <DataView.List variant='table' columns={mockColumns} />
+        </DataView>
+      );
+      // Search input
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+      // Filter button
+      expect(
+        screen.getByRole('button', { name: /filter/i })
+      ).toBeInTheDocument();
+    });
+
+    it('search input updates the query', async () => {
+      const user = userEvent.setup();
+      render(
+        <DataView data={mockData} fields={mockFields} defaultSort={defaultSort}>
+          <DataView.Toolbar>
+            <DataView.Search />
+          </DataView.Toolbar>
+          <DataView.List variant='table' columns={mockColumns} />
+        </DataView>
+      );
+      const search = screen.getByRole('textbox') as HTMLInputElement;
+      await user.type(search, 'jane');
+      expect(search.value).toBe('jane');
+      // John row should no longer appear (client-mode global filter)
+      expect(screen.queryByText('John Doe')).not.toBeInTheDocument();
+      expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+    });
+  });
+
+  describe('Multi-view', () => {
+    const views: ViewSpec[] = [
+      { value: 'table', label: 'Table' },
+      { value: 'list', label: 'List' }
+    ];
+
+    it('renders only the active view', () => {
+      render(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          views={views}
+          defaultView='table'
+        >
+          <DataView.List name='table' variant='table' columns={mockColumns} />
+          <DataView.List name='list' variant='list' columns={mockColumns} />
+        </DataView>
+      );
+      expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(screen.queryByRole('list')).not.toBeInTheDocument();
+    });
+
+    it('switches when controlled `view` prop changes', () => {
+      const { rerender } = render(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          views={views}
+          view='table'
+        >
+          <DataView.List name='table' variant='table' columns={mockColumns} />
+          <DataView.List name='list' variant='list' columns={mockColumns} />
+        </DataView>
+      );
+      expect(screen.getByRole('table')).toBeInTheDocument();
+
+      rerender(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          views={views}
+          view='list'
+        >
+          <DataView.List name='table' variant='table' columns={mockColumns} />
+          <DataView.List name='list' variant='list' columns={mockColumns} />
+        </DataView>
+      );
+      expect(screen.queryByRole('table')).not.toBeInTheDocument();
+      expect(screen.getByRole('list')).toBeInTheDocument();
+    });
+
+    it('renderer with name not matching any views[].value renders nothing', () => {
+      render(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          views={views}
+          defaultView='table'
+        >
+          <DataView.List name='ghost' variant='table' columns={mockColumns} />
+        </DataView>
+      );
+      // ghost never matches activeView=table, no table rendered
+      expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    });
+
+    it('preserves query state across view switches (filters, search)', () => {
+      const { rerender } = render(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          views={views}
+          view='table'
+          query={{
+            filters: [{ name: 'status', operator: 'eq', value: 'active' }]
+          }}
+        >
+          <DataView.List name='table' variant='table' columns={mockColumns} />
+          <DataView.List name='list' variant='list' columns={mockColumns} />
+        </DataView>
+      );
+      // Two active rows visible in table
+      expect(screen.getByText('John Doe')).toBeInTheDocument();
+      expect(screen.queryByText('Jane Smith')).not.toBeInTheDocument();
+
+      rerender(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          views={views}
+          view='list'
+          query={{
+            filters: [{ name: 'status', operator: 'eq', value: 'active' }]
+          }}
+        >
+          <DataView.List name='table' variant='table' columns={mockColumns} />
+          <DataView.List name='list' variant='list' columns={mockColumns} />
+        </DataView>
+      );
+      // Filter still applied on list
+      expect(screen.getByText('John Doe')).toBeInTheDocument();
+      expect(screen.queryByText('Jane Smith')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Per-view fields override', () => {
+    it('hides a field in one view by overriding fields on the renderer', () => {
+      const views: ViewSpec[] = [
+        { value: 'table', label: 'Table' },
+        { value: 'list', label: 'List' }
+      ];
+      // In `list` view, mark email as defaultHidden — the column gates itself.
+      const listFields = mockFields.map(f =>
+        f.accessorKey === 'email' ? { ...f, defaultHidden: true } : f
+      );
+
+      const { rerender } = render(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          views={views}
+          view='table'
+        >
+          <DataView.List name='table' variant='table' columns={mockColumns} />
+          <DataView.List
+            name='list'
+            variant='list'
+            columns={mockColumns}
+            fields={listFields}
+          />
+        </DataView>
+      );
+      // Email visible in table view (no override)
+      expect(screen.getByText('john@example.com')).toBeInTheDocument();
+
+      // Switching to list doesn't retroactively hide email because
+      // columnVisibility is initialised from root fields. The override changes
+      // metadata (filterable/hideable) seen by the toolbar but not the initial
+      // global visibility map. This is the documented behaviour.
+      rerender(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          views={views}
+          view='list'
+        >
+          <DataView.List name='table' variant='table' columns={mockColumns} />
+          <DataView.List
+            name='list'
+            variant='list'
+            columns={mockColumns}
+            fields={listFields}
+          />
+        </DataView>
+      );
+      expect(screen.getByRole('list')).toBeInTheDocument();
+    });
+  });
+
+  describe('DisplayAccess', () => {
+    it('renders children when accessorKey is visible', () => {
+      render(
+        <DataView data={mockData} fields={mockFields} defaultSort={defaultSort}>
+          <DataView.DisplayAccess accessorKey='name'>
+            <span data-testid='gated'>visible</span>
+          </DataView.DisplayAccess>
+        </DataView>
+      );
+      expect(screen.getByTestId('gated')).toBeInTheDocument();
+    });
+
+    it('hides children when columnVisibility flag is false', async () => {
+      const user = userEvent.setup();
+      const Toggle = () => {
+        const { setColumnVisibility } = useDataViewForTest();
+        return (
+          <button
+            type='button'
+            data-testid='toggle'
+            onClick={() =>
+              setColumnVisibility((prev: Record<string, boolean>) => ({
+                ...prev,
+                name: false
+              }))
+            }
+          >
+            toggle
+          </button>
+        );
+      };
+      render(
+        <DataView data={mockData} fields={mockFields} defaultSort={defaultSort}>
+          <Toggle />
+          <DataView.DisplayAccess accessorKey='name'>
+            <span data-testid='gated'>visible</span>
+          </DataView.DisplayAccess>
+        </DataView>
+      );
+      expect(screen.getByTestId('gated')).toBeInTheDocument();
+      await user.click(screen.getByTestId('toggle'));
+      expect(screen.queryByTestId('gated')).not.toBeInTheDocument();
+    });
+
+    it('renders fallback when hidden', async () => {
+      const user = userEvent.setup();
+      const Toggle = () => {
+        const { setColumnVisibility } = useDataViewForTest();
+        return (
+          <button
+            type='button'
+            data-testid='toggle'
+            onClick={() =>
+              setColumnVisibility((prev: Record<string, boolean>) => ({
+                ...prev,
+                email: false
+              }))
+            }
+          >
+            toggle
+          </button>
+        );
+      };
+      render(
+        <DataView data={mockData} fields={mockFields} defaultSort={defaultSort}>
+          <Toggle />
+          <DataView.DisplayAccess
+            accessorKey='email'
+            fallback={<span data-testid='fb'>hidden</span>}
+          >
+            <span data-testid='visible'>visible</span>
+          </DataView.DisplayAccess>
+        </DataView>
+      );
+      expect(screen.getByTestId('visible')).toBeInTheDocument();
+      await user.click(screen.getByTestId('toggle'));
+      expect(screen.getByTestId('fb')).toBeInTheDocument();
+      expect(screen.queryByTestId('visible')).not.toBeInTheDocument();
+    });
+
+    it('defaults to visible for unknown accessor (typos do not break the render)', () => {
+      render(
+        <DataView data={mockData} fields={mockFields} defaultSort={defaultSort}>
+          <DataView.DisplayAccess accessorKey='nope'>
+            <span data-testid='unknown'>still visible</span>
+          </DataView.DisplayAccess>
+        </DataView>
+      );
+      expect(screen.getByTestId('unknown')).toBeInTheDocument();
+    });
+  });
+
+  describe('Custom renderer', () => {
+    it('passes the full context to the render prop', () => {
+      render(
+        <DataView data={mockData} fields={mockFields} defaultSort={defaultSort}>
+          <DataView.Custom>
+            {ctx => (
+              <div data-testid='custom'>
+                rows={ctx.data.length}; hasData={String(ctx.hasData)}
+              </div>
+            )}
+          </DataView.Custom>
+        </DataView>
+      );
+      expect(screen.getByTestId('custom')).toHaveTextContent(
+        'rows=3; hasData=true'
+      );
+    });
+
+    it('gates on name vs activeView', () => {
+      const views: ViewSpec[] = [
+        { value: 'table', label: 'Table' },
+        { value: 'board', label: 'Board' }
+      ];
+      render(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          views={views}
+          defaultView='board'
+        >
+          <DataView.List name='table' variant='table' columns={mockColumns} />
+          <DataView.Custom name='board'>
+            {() => <div data-testid='board'>BOARD</div>}
+          </DataView.Custom>
+        </DataView>
+      );
+      expect(screen.getByTestId('board')).toBeInTheDocument();
+      expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Filter clearing', () => {
+    it('Clear Filters button resets filters', async () => {
+      const user = userEvent.setup();
+      render(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          query={{
+            filters: [{ name: 'name', operator: 'eq', value: 'NonExistent' }]
+          }}
+        >
+          <DataView.List variant='table' columns={mockColumns} />
+          <DataView.EmptyState>
+            <div data-testid='empty'>no matches</div>
+          </DataView.EmptyState>
+        </DataView>
+      );
+      // In empty state, filter summary is *not* shown by the List (renderer
+      // returns null when !hasData). EmptyState sibling handles it. Just
+      // confirm the empty state path is taken.
+      expect(screen.getByTestId('empty')).toBeInTheDocument();
+    });
+  });
+
+  describe('Grouping', () => {
+    it('groups rows by accessor key', () => {
+      const { container } = render(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          query={{ group_by: ['status'] }}
+        >
+          <DataView.List variant='table' columns={mockColumns} />
+        </DataView>
+      );
+      // Two group headers (active, inactive) — counted via class
+      const groupHeaders = container.querySelectorAll(
+        '[class*="listGroupHeader"]'
+      );
+      expect(groupHeaders.length).toBe(2);
+    });
+
+    it('applies groupByResolvers for non-accessor keys', () => {
+      const dataWithDate: TestData[] = mockData;
+      render(
+        <DataView
+          data={dataWithDate}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          query={{ group_by: ['name_first_letter'] }}
+          groupByResolvers={{
+            name_first_letter: row => row.name.charAt(0).toUpperCase()
+          }}
+        >
+          <DataView.List variant='table' columns={mockColumns} />
+        </DataView>
+      );
+      // Buckets: J (John, Jane), B (Bob)
+      expect(screen.getByText('J')).toBeInTheDocument();
+      expect(screen.getByText('B')).toBeInTheDocument();
+    });
+  });
+
+  describe('Wire-format translation', () => {
+    it('does NOT call onTableQueryChange in client mode', async () => {
+      const onTableQueryChange = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          mode='client'
+          onTableQueryChange={onTableQueryChange}
+        >
+          <DataView.Toolbar>
+            <DataView.Search />
+          </DataView.Toolbar>
+          <DataView.List variant='table' columns={mockColumns} />
+        </DataView>
+      );
+      await user.type(screen.getByRole('textbox'), 'jane');
+      expect(onTableQueryChange).not.toHaveBeenCalled();
+    });
+
+    it('calls onTableQueryChange in server mode after query change', async () => {
+      const onTableQueryChange = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          mode='server'
+          onTableQueryChange={onTableQueryChange}
+        >
+          <DataView.Toolbar>
+            <DataView.Search />
+          </DataView.Toolbar>
+          <DataView.List variant='table' columns={mockColumns} />
+        </DataView>
+      );
+      await user.type(screen.getByRole('textbox'), 'a');
+      expect(onTableQueryChange).toHaveBeenCalled();
+      const calls = onTableQueryChange.mock.calls;
+      const lastCall = calls[calls.length - 1]?.[0];
+      expect(lastCall?.search).toBe('a');
+    });
+  });
+
+  describe('Loading state', () => {
+    it('renders skeleton rows when isLoading is true (non-virtualized)', () => {
+      const { container } = render(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          isLoading
+          loadingRowCount={4}
+        >
+          <DataView.List variant='table' columns={mockColumns} />
+        </DataView>
+      );
+      const loaderRows = container.querySelectorAll('[aria-busy="true"]');
+      expect(loaderRows.length).toBe(4);
+    });
+
+    it('renders skeleton rows when isLoading is true (virtualized)', () => {
+      const { container } = render(
+        <div style={{ height: 300 }}>
+          <DataView
+            data={mockData}
+            fields={mockFields}
+            defaultSort={defaultSort}
+            isLoading
+            loadingRowCount={5}
+          >
+            <DataView.List variant='table' columns={mockColumns} virtualized />
+          </DataView>
+        </div>
+      );
+      const loaderRows = container.querySelectorAll('[aria-busy="true"]');
+      expect(loaderRows.length).toBe(5);
+    });
+
+    it('renders skeleton rows on initial load even with no data (non-virtualized)', () => {
+      const { container } = render(
+        <DataView
+          data={[]}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          isLoading
+          loadingRowCount={3}
+        >
+          <DataView.List variant='table' columns={mockColumns} />
+          <DataView.ZeroState>
+            <div data-testid='zero'>zero</div>
+          </DataView.ZeroState>
+        </DataView>
+      );
+      // ZeroState must NOT render while loading is in flight.
+      expect(screen.queryByTestId('zero')).not.toBeInTheDocument();
+      const loaderRows = container.querySelectorAll('[aria-busy="true"]');
+      expect(loaderRows.length).toBe(3);
+    });
+
+    it('renders skeleton rows on initial load even with no data (virtualized)', () => {
+      const { container } = render(
+        <div style={{ height: 300 }}>
+          <DataView
+            data={[]}
+            fields={mockFields}
+            defaultSort={defaultSort}
+            isLoading
+            loadingRowCount={3}
+          >
+            <DataView.List variant='table' columns={mockColumns} virtualized />
+          </DataView>
+        </div>
+      );
+      const loaderRows = container.querySelectorAll('[aria-busy="true"]');
+      expect(loaderRows.length).toBe(3);
+    });
+
+    it('skeleton row count respects loadingRowCount prop', () => {
+      const { container, rerender } = render(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          isLoading
+          loadingRowCount={2}
+        >
+          <DataView.List variant='table' columns={mockColumns} />
+        </DataView>
+      );
+      expect(container.querySelectorAll('[aria-busy="true"]').length).toBe(2);
+
+      rerender(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          isLoading
+          loadingRowCount={7}
+        >
+          <DataView.List variant='table' columns={mockColumns} />
+        </DataView>
+      );
+      expect(container.querySelectorAll('[aria-busy="true"]').length).toBe(7);
+    });
+  });
+
+  describe('Infinite scroll (sentinel-based)', () => {
+    it('triggers onLoadMore when sentinel intersects (non-virtualized)', () => {
+      const onLoadMore = vi.fn();
+      render(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          mode='server'
+          onLoadMore={onLoadMore}
+        >
+          <DataView.List variant='table' columns={mockColumns} />
+        </DataView>
+      );
+      const observer = getLastObserver();
+      expect(observer).toBeDefined();
+      act(() => observer?.trigger(true));
+      expect(onLoadMore).toHaveBeenCalledTimes(1);
+    });
+
+    it('triggers onLoadMore when sentinel intersects (virtualized)', () => {
+      const onLoadMore = vi.fn();
+      render(
+        <div style={{ height: 300 }}>
+          <DataView
+            data={mockData}
+            fields={mockFields}
+            defaultSort={defaultSort}
+            mode='server'
+            onLoadMore={onLoadMore}
+          >
+            <DataView.List variant='table' columns={mockColumns} virtualized />
+          </DataView>
+        </div>
+      );
+      const observer = getLastObserver();
+      expect(observer).toBeDefined();
+      act(() => observer?.trigger(true));
+      expect(onLoadMore).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not trigger onLoadMore while isLoading is true', () => {
+      const onLoadMore = vi.fn();
+      render(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          mode='server'
+          isLoading
+          onLoadMore={onLoadMore}
+        >
+          <DataView.List variant='table' columns={mockColumns} />
+        </DataView>
+      );
+      const observer = getLastObserver();
+      act(() => observer?.trigger(true));
+      expect(onLoadMore).not.toHaveBeenCalled();
+    });
+
+    it('does not trigger onLoadMore in client mode', () => {
+      const onLoadMore = vi.fn();
+      render(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          mode='client'
+          onLoadMore={onLoadMore}
+        >
+          <DataView.List variant='table' columns={mockColumns} />
+        </DataView>
+      );
+      // No observer is attached in client mode.
+      const observer = getLastObserver();
+      if (observer) {
+        act(() => observer.trigger(true));
+      }
+      expect(onLoadMore).not.toHaveBeenCalled();
+    });
+
+    it('ignores non-intersecting sentinel entries', () => {
+      const onLoadMore = vi.fn();
+      render(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          mode='server'
+          onLoadMore={onLoadMore}
+        >
+          <DataView.List variant='table' columns={mockColumns} />
+        </DataView>
+      );
+      const observer = getLastObserver();
+      act(() => observer?.trigger(false));
+      expect(onLoadMore).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Virtualization', () => {
+    it('accepts estimatedRowHeight as the initial size hint', () => {
+      // Smoke test — render with virtualized + estimatedRowHeight and verify
+      // the listGrid mounts. The exact pixel math is exercised by
+      // @tanstack/react-virtual; we only confirm the prop is honoured.
+      const { container } = render(
+        <div style={{ height: 300 }}>
+          <DataView
+            data={mockData}
+            fields={mockFields}
+            defaultSort={defaultSort}
+          >
+            <DataView.List
+              variant='table'
+              columns={mockColumns}
+              virtualized
+              estimatedRowHeight={88}
+            />
+          </DataView>
+        </div>
+      );
+      expect(container.querySelector('[role="table"]')).toBeInTheDocument();
+    });
+
+    it('renders the sticky group anchor when virtualized + grouped + sticky', () => {
+      const { container } = render(
+        <div style={{ height: 300 }}>
+          <DataView
+            data={mockData}
+            fields={mockFields}
+            defaultSort={defaultSort}
+            query={{ group_by: ['status'] }}
+          >
+            <DataView.List
+              variant='table'
+              columns={mockColumns}
+              virtualized
+              stickyGroupHeader
+            />
+          </DataView>
+        </div>
+      );
+      // Anchor is a single dedicated element distinct from the natural group
+      // header rows; it carries `aria-hidden` since its content is duplicated
+      // by the natural header underneath.
+      const anchor = container.querySelector(
+        '[class*="listGroupAnchor"][aria-hidden="true"]'
+      );
+      expect(anchor).not.toBeNull();
+    });
+
+    it('does not render the sticky anchor when not grouped', () => {
+      const { container } = render(
+        <div style={{ height: 300 }}>
+          <DataView
+            data={mockData}
+            fields={mockFields}
+            defaultSort={defaultSort}
+          >
+            <DataView.List
+              variant='table'
+              columns={mockColumns}
+              virtualized
+              stickyGroupHeader
+            />
+          </DataView>
+        </div>
+      );
+      expect(container.querySelector('[class*="listGroupAnchor"]')).toBeNull();
+    });
+
+    it('listGrid carries the gridTemplateColumns derived from column widths', () => {
+      const widthedColumns: DataViewListColumn<TestData>[] = [
+        { accessorKey: 'name', width: '200px' },
+        { accessorKey: 'email', width: '1fr' },
+        { accessorKey: 'status', width: 'auto' }
+      ];
+      const { container } = render(
+        <div style={{ height: 300 }}>
+          <DataView
+            data={mockData}
+            fields={mockFields}
+            defaultSort={defaultSort}
+          >
+            <DataView.List
+              variant='table'
+              columns={widthedColumns}
+              virtualized
+              estimatedRowHeight={40}
+            />
+          </DataView>
+        </div>
+      );
+      const grid = container.querySelector('[role="table"]') as HTMLElement;
+      // gridTemplateColumns is set inline on .listGrid in both modes; virtual
+      // rows re-declare it inline so columns stay aligned even when items are
+      // absolutely positioned (out of the subgrid flow).
+      expect(grid?.style.gridTemplateColumns).toBe('200px 1fr auto');
+    });
+  });
+
+  describe('Unmanaged display columns', () => {
+    // Selection / row-action / drag-handle columns aren't declared as fields
+    // (no filter/sort/group/visibility semantics) — they're presentation only.
+    // Such accessors must still render via their column spec.
+    it('renders header + cells for a column whose accessor is absent from fields', async () => {
+      const user = userEvent.setup();
+      const onSelect = vi.fn();
+      const selectionColumn: DataViewListColumn<TestData> = {
+        accessorKey: 'select',
+        width: '40px',
+        header: () => <span data-testid='sel-header'>SEL</span>,
+        cell: ({ row }) => (
+          <button
+            data-testid={`sel-cell-${(row.original as TestData).id}`}
+            onClick={() => onSelect((row.original as TestData).id)}
+          >
+            x
+          </button>
+        )
+      };
+      render(
+        <DataView data={mockData} fields={mockFields} defaultSort={defaultSort}>
+          <DataView.List
+            variant='table'
+            columns={[selectionColumn, ...mockColumns]}
+          />
+        </DataView>
+      );
+      expect(screen.getByTestId('sel-header')).toBeInTheDocument();
+      expect(screen.getByTestId('sel-cell-1')).toBeInTheDocument();
+      expect(screen.getByTestId('sel-cell-2')).toBeInTheDocument();
+      expect(screen.getByTestId('sel-cell-3')).toBeInTheDocument();
+      await user.click(screen.getByTestId('sel-cell-2'));
+      expect(onSelect).toHaveBeenCalledWith(2);
+    });
+
+    it('exposes table + row to unmanaged column render fns', () => {
+      let receivedTable: unknown = null;
+      let receivedRowOriginal: unknown = null;
+      const selectionColumn: DataViewListColumn<TestData> = {
+        accessorKey: 'select',
+        header: ({ table }) => {
+          receivedTable = table;
+          return <span data-testid='sel-header' />;
+        },
+        cell: ({ row }) => {
+          if (receivedRowOriginal === null) receivedRowOriginal = row.original;
+          return <span data-testid='sel-cell' />;
+        }
+      };
+      render(
+        <DataView data={mockData} fields={mockFields} defaultSort={defaultSort}>
+          <DataView.List
+            variant='table'
+            columns={[selectionColumn, ...mockColumns]}
+          />
+        </DataView>
+      );
+      expect(receivedTable).not.toBeNull();
+      // First row after default ascending name sort is "Bob Johnson" (id=3).
+      expect(receivedRowOriginal).toMatchObject({ id: 3 });
+    });
+  });
+});

--- a/packages/raystack/components/data-view/__tests__/debug.test.tsx
+++ b/packages/raystack/components/data-view/__tests__/debug.test.tsx
@@ -1,0 +1,6 @@
+import { describe, it } from 'vitest';
+
+// placeholder — was used for bisecting Filter trigger render issue.
+describe.skip('debug', () => {
+  it('noop', () => {});
+});

--- a/packages/raystack/components/data-view/__tests__/filter-operations.test.ts
+++ b/packages/raystack/components/data-view/__tests__/filter-operations.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getDataType,
+  getFilterFn,
+  getFilterOperator,
+  getFilterValue
+} from '../utils/filter-operations';
+
+describe('filter-operations', () => {
+  describe('getFilterFn', () => {
+    it('returns predicates for known types', () => {
+      expect(typeof getFilterFn('string', 'contains')).toBe('function');
+      expect(typeof getFilterFn('number', 'gte')).toBe('function');
+      expect(typeof getFilterFn('select', 'eq')).toBe('function');
+    });
+  });
+
+  describe('getFilterOperator', () => {
+    it('maps string contains/starts_with/ends_with to ilike', () => {
+      expect(
+        getFilterOperator({
+          value: 'a',
+          filterType: 'string',
+          operator: 'contains'
+        })
+      ).toBe('ilike');
+      expect(
+        getFilterOperator({
+          value: 'a',
+          filterType: 'string',
+          operator: 'starts_with'
+        })
+      ).toBe('ilike');
+    });
+
+    it('returns "empty" for the empty sentinel on select', () => {
+      expect(
+        getFilterOperator({
+          value: '--empty--',
+          filterType: 'select',
+          operator: 'eq'
+        })
+      ).toBe('empty');
+    });
+  });
+
+  describe('getFilterValue', () => {
+    it('wraps string contains with %…%', () => {
+      const v = getFilterValue({
+        value: 'foo',
+        filterType: 'string',
+        operator: 'contains'
+      });
+      expect(v.stringValue).toBe('%foo%');
+      expect(v.value).toBe('foo');
+    });
+
+    it('wraps starts_with with foo%', () => {
+      const v = getFilterValue({
+        value: 'foo',
+        filterType: 'string',
+        operator: 'starts_with'
+      });
+      expect(v.stringValue).toBe('foo%');
+    });
+
+    it('emits ISO string for valid dates', () => {
+      const d = new Date('2024-01-15T00:00:00Z');
+      const v = getFilterValue({
+        value: d,
+        filterType: 'date',
+        operator: 'eq'
+      });
+      expect(v.stringValue).toBe(d.toISOString());
+    });
+
+    it('emits boolValue for boolean dataType', () => {
+      const v = getFilterValue({
+        value: true,
+        dataType: 'boolean',
+        operator: 'eq'
+      });
+      expect(v.boolValue).toBe(true);
+    });
+
+    it('emits numberValue for number dataType', () => {
+      const v = getFilterValue({
+        value: 42,
+        dataType: 'number',
+        operator: 'eq'
+      });
+      expect(v.numberValue).toBe(42);
+    });
+  });
+
+  describe('getDataType', () => {
+    it('uses dataType for select/multiselect', () => {
+      expect(getDataType({ filterType: 'select', dataType: 'number' })).toBe(
+        'number'
+      );
+    });
+    it('forces string for date', () => {
+      expect(getDataType({ filterType: 'date' })).toBe('string');
+    });
+    it('returns the filterType for primitives', () => {
+      expect(getDataType({ filterType: 'string' })).toBe('string');
+      expect(getDataType({ filterType: 'number' })).toBe('number');
+    });
+  });
+});

--- a/packages/raystack/components/data-view/components/custom.tsx
+++ b/packages/raystack/components/data-view/components/custom.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { ReactNode, useEffect } from 'react';
+import { DataViewContextType, DataViewField } from '../data-view.types';
+import { useDataView } from '../hooks/useDataView';
+
+export interface DataViewCustomProps<TData> {
+  /** Multi-view name. When set, the renderer gates itself on the active view. */
+  name?: string;
+  /** Optional view-scoped field override (full replacement for this view). */
+  fields?: DataViewField<TData>[];
+  /**
+   * Render prop receiving the full `DataView` context (table, fields, query,
+   * derived empty/zero flags, etc.). Pair with `<DataView.DisplayAccess>` so
+   * field visibility tracks the single Display Properties toggle.
+   */
+  children: (context: DataViewContextType<TData>) => ReactNode;
+}
+
+/**
+ * Escape-hatch renderer for free-form views (cards, kanban, map, gallery).
+ * Reads the `DataView` context and hands it to a render prop.
+ */
+export function DataViewCustom<TData>({
+  name,
+  fields: fieldsOverride,
+  children
+}: DataViewCustomProps<TData>) {
+  const ctx = useDataView<TData>();
+  const { activeView, registerFieldsForView } = ctx;
+
+  useEffect(() => {
+    if (!name || !fieldsOverride) return;
+    return registerFieldsForView(name, fieldsOverride);
+  }, [name, fieldsOverride, registerFieldsForView]);
+
+  const isActive = !name || activeView === undefined || activeView === name;
+  if (!isActive) return null;
+
+  return <>{children(ctx)}</>;
+}
+
+DataViewCustom.displayName = 'DataView.Custom';

--- a/packages/raystack/components/data-view/components/display-access.tsx
+++ b/packages/raystack/components/data-view/components/display-access.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { useDataView } from '../hooks/useDataView';
+
+export interface DataViewDisplayAccessProps {
+  /** Field (column) accessor key. Gates rendering on the column's current visibility state. */
+  accessorKey: string;
+  children: ReactNode;
+  /** Rendered when the referenced field is currently hidden. Defaults to null. */
+  fallback?: ReactNode;
+}
+
+/**
+ * Gates children on the current column visibility from `DataView` context. Use
+ * inside `DataView.Custom` or other free-form renderers so the single
+ * `DisplayControls` toggle reaches the same visibility story that `DataView.List`
+ * rows get for free.
+ */
+export function DisplayAccess({
+  accessorKey,
+  children,
+  fallback = null
+}: DataViewDisplayAccessProps) {
+  const { columnVisibility, fields } = useDataView();
+  // Visibility is stored as a single global map on context per RFC. A missing
+  // entry means "not toggled off"; default to visible so consumers can wrap
+  // JSX in DisplayAccess without typos silently breaking the render.
+  const stateVisible = columnVisibility[accessorKey];
+  // A field forced `hideable: false` in the active view is always shown
+  // regardless of stored state (RFC §"Unified Column Visibility").
+  const field = fields.find(f => f.accessorKey === accessorKey);
+  const hideable = field?.hideable ?? true;
+  const isVisible = !hideable || stateVisible !== false;
+  return <>{isVisible ? children : fallback}</>;
+}
+
+DisplayAccess.displayName = 'DataView.DisplayAccess';

--- a/packages/raystack/components/data-view/components/display-controls.tsx
+++ b/packages/raystack/components/data-view/components/display-controls.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { MixerHorizontalIcon } from '@radix-ui/react-icons';
+import { isValidElement, ReactNode } from 'react';
+
+import { Button } from '../../button';
+import { Flex } from '../../flex';
+import { Popover } from '../../popover';
+import styles from '../data-view.module.css';
+import { defaultGroupOption, SortOrdersValues } from '../data-view.types';
+import { useDataView } from '../hooks/useDataView';
+import { DisplayProperties } from './display-properties';
+import { Grouping } from './grouping';
+import { Ordering } from './ordering';
+import { ViewSwitcher } from './view-switcher';
+
+interface DisplayControlsProps {
+  trigger?: ReactNode;
+}
+
+/**
+ * `DataView.DisplayControls` — the popover housing Ordering, Grouping, Display
+ * Properties (column visibility), and Reset. When `views.length > 1`, the
+ * popover also hosts the view switcher (consumers can place
+ * `<DataView.ViewSwitcher>` standalone elsewhere for layout flexibility).
+ */
+export function DisplayControls<TData>({
+  trigger = (
+    <Button
+      variant='outline'
+      color='neutral'
+      size='small'
+      leadingIcon={<MixerHorizontalIcon />}
+    >
+      Display
+    </Button>
+  )
+}: DisplayControlsProps) {
+  const {
+    fields,
+    updateTableQuery,
+    tableQuery,
+    defaultSort,
+    onDisplaySettingsReset,
+    views
+  } = useDataView<TData>();
+
+  const sortableColumns = (fields ?? [])
+    .filter(f => f.sortable)
+    .map(f => ({ label: f.label, id: f.accessorKey }));
+
+  const onSortChange = (columnId: string, order: SortOrdersValues) =>
+    updateTableQuery(query => ({
+      ...query,
+      sort: [{ name: columnId, order }]
+    }));
+
+  const onGroupChange = (columnId: string) =>
+    updateTableQuery(query => ({ ...query, group_by: [columnId] }));
+
+  const onGroupRemove = () =>
+    updateTableQuery(query => ({ ...query, group_by: [] }));
+
+  const onReset = () => onDisplaySettingsReset();
+
+  const showViewSwitcher = (views?.length ?? 0) > 1;
+
+  return (
+    <Popover>
+      <Popover.Trigger
+        render={isValidElement(trigger) ? trigger : <button>{trigger}</button>}
+      />
+      <Popover.Content
+        className={styles['display-popover-content']}
+        align='end'
+      >
+        <Flex direction='column'>
+          {showViewSwitcher ? (
+            <Flex className={styles['display-popover-properties-container']}>
+              <ViewSwitcher />
+            </Flex>
+          ) : null}
+          <Flex
+            direction='column'
+            className={styles['display-popover-properties-container']}
+            gap={5}
+          >
+            <Ordering
+              columnList={sortableColumns}
+              onChange={onSortChange}
+              value={tableQuery?.sort?.[0] || defaultSort}
+            />
+            <Grouping
+              fields={fields ?? []}
+              onRemove={onGroupRemove}
+              onChange={onGroupChange}
+              value={tableQuery?.group_by?.[0] || defaultGroupOption.id}
+            />
+          </Flex>
+          <Flex className={styles['display-popover-properties-container']}>
+            <DisplayProperties fields={fields ?? []} />
+          </Flex>
+          <Flex
+            justify='end'
+            className={styles['display-popover-reset-container']}
+          >
+            <Button variant='text' onClick={onReset} color='neutral'>
+              Reset to default
+            </Button>
+          </Flex>
+        </Flex>
+      </Popover.Content>
+    </Popover>
+  );
+}
+
+DisplayControls.displayName = 'DataView.DisplayControls';

--- a/packages/raystack/components/data-view/components/display-controls.tsx
+++ b/packages/raystack/components/data-view/components/display-controls.tsx
@@ -16,13 +16,18 @@ import { ViewSwitcher } from './view-switcher';
 
 interface DisplayControlsProps {
   trigger?: ReactNode;
+  hideViewSwitcher?: boolean;
+  hideOrdering?: boolean;
+  hideGrouping?: boolean;
+  hideDisplayProperties?: boolean;
 }
 
 /**
- * `DataView.DisplayControls` — the popover housing Ordering, Grouping, Display
- * Properties (column visibility), and Reset. When `views.length > 1`, the
- * popover also hosts the view switcher (consumers can place
- * `<DataView.ViewSwitcher>` standalone elsewhere for layout flexibility).
+ * `DataView.DisplayControls` — the popover housing the view switcher, Ordering,
+ * Grouping, Display Properties (column visibility), and Reset. The view switcher
+ * appears at the top whenever `views.length > 1`. Each section can be hidden
+ * individually via `hideViewSwitcher` / `hideOrdering` / `hideGrouping` /
+ * `hideDisplayProperties`.
  */
 export function DisplayControls<TData>({
   trigger = (
@@ -34,7 +39,11 @@ export function DisplayControls<TData>({
     >
       Display
     </Button>
-  )
+  ),
+  hideViewSwitcher = false,
+  hideOrdering = false,
+  hideGrouping = false,
+  hideDisplayProperties = false
 }: DisplayControlsProps) {
   const {
     fields,
@@ -63,7 +72,8 @@ export function DisplayControls<TData>({
 
   const onReset = () => onDisplaySettingsReset();
 
-  const showViewSwitcher = (views?.length ?? 0) > 1;
+  const showViewSwitcher = !hideViewSwitcher && (views?.length ?? 0) > 1;
+  const showOrderingOrGrouping = !hideOrdering || !hideGrouping;
 
   return (
     <Popover>
@@ -80,26 +90,34 @@ export function DisplayControls<TData>({
               <ViewSwitcher />
             </Flex>
           ) : null}
-          <Flex
-            direction='column'
-            className={styles['display-popover-properties-container']}
-            gap={5}
-          >
-            <Ordering
-              columnList={sortableColumns}
-              onChange={onSortChange}
-              value={tableQuery?.sort?.[0] || defaultSort}
-            />
-            <Grouping
-              fields={fields ?? []}
-              onRemove={onGroupRemove}
-              onChange={onGroupChange}
-              value={tableQuery?.group_by?.[0] || defaultGroupOption.id}
-            />
-          </Flex>
-          <Flex className={styles['display-popover-properties-container']}>
-            <DisplayProperties fields={fields ?? []} />
-          </Flex>
+          {showOrderingOrGrouping ? (
+            <Flex
+              direction='column'
+              className={styles['display-popover-properties-container']}
+              gap={5}
+            >
+              {!hideOrdering ? (
+                <Ordering
+                  columnList={sortableColumns}
+                  onChange={onSortChange}
+                  value={tableQuery?.sort?.[0] || defaultSort}
+                />
+              ) : null}
+              {!hideGrouping ? (
+                <Grouping
+                  fields={fields ?? []}
+                  onRemove={onGroupRemove}
+                  onChange={onGroupChange}
+                  value={tableQuery?.group_by?.[0] || defaultGroupOption.id}
+                />
+              ) : null}
+            </Flex>
+          ) : null}
+          {!hideDisplayProperties ? (
+            <Flex className={styles['display-popover-properties-container']}>
+              <DisplayProperties fields={fields ?? []} />
+            </Flex>
+          ) : null}
           <Flex
             justify='end'
             className={styles['display-popover-reset-container']}

--- a/packages/raystack/components/data-view/components/display-properties.tsx
+++ b/packages/raystack/components/data-view/components/display-properties.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { Chip } from '../../chip';
+import { Flex } from '../../flex';
+import { Text } from '../../text';
+import { DataViewField } from '../data-view.types';
+import { useDataView } from '../hooks/useDataView';
+
+/**
+ * Reads visibility from context's single global `columnVisibility` map (RFC §
+ * "Unified Column Visibility via DisplayAccess"). Renderers honour the same
+ * state — columnar via TanStack column hides, free-form via `DisplayAccess`.
+ */
+export function DisplayProperties<TData>({
+  fields
+}: {
+  fields: DataViewField<TData>[];
+}) {
+  const { columnVisibility, setColumnVisibility } = useDataView<TData>();
+  const hidableFields = fields?.filter(f => f.hideable) ?? [];
+
+  const toggleVisibility = (accessorKey: string) => {
+    setColumnVisibility(prev => ({
+      ...prev,
+      [accessorKey]: !(prev[accessorKey] ?? true)
+    }));
+  };
+
+  return (
+    <Flex direction='column' gap={5}>
+      <Text size='small' weight='medium' variant='secondary'>
+        Display Properties
+      </Text>
+      <Flex gap={3} wrap='wrap' align='center'>
+        {hidableFields.map(field => {
+          const isVisible = columnVisibility[field.accessorKey] ?? true;
+          return (
+            <Chip
+              key={field.accessorKey}
+              variant='outline'
+              size='small'
+              color={isVisible ? 'accent' : 'neutral'}
+              onClick={() => toggleVisibility(field.accessorKey)}
+            >
+              {field.label}
+            </Chip>
+          );
+        })}
+      </Flex>
+    </Flex>
+  );
+}

--- a/packages/raystack/components/data-view/components/empty-state.tsx
+++ b/packages/raystack/components/data-view/components/empty-state.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { cx } from 'class-variance-authority';
+import { ReactNode } from 'react';
+import styles from '../data-view.module.css';
+import { useDataView } from '../hooks/useDataView';
+
+export interface DataViewEmptyStateProps {
+  /** Restrict to a specific view's `name`. */
+  forView?: string;
+  className?: string;
+  children: ReactNode;
+}
+
+/**
+ * Renders its children when the current data + query result in an empty state
+ * (a query is active but no rows match). Reads `isEmptyState` from `DataView`
+ * context.
+ */
+export function DataViewEmptyState({
+  forView,
+  className,
+  children
+}: DataViewEmptyStateProps) {
+  const { isEmptyState, activeView } = useDataView();
+  if (!isEmptyState) return null;
+  if (forView && activeView !== forView) return null;
+  return (
+    <div className={cx(styles.dataStateContainer, className)}>{children}</div>
+  );
+}
+
+DataViewEmptyState.displayName = 'DataView.EmptyState';

--- a/packages/raystack/components/data-view/components/filters.tsx
+++ b/packages/raystack/components/data-view/components/filters.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { cx } from 'class-variance-authority';
+import { isValidElement, ReactNode, useMemo } from 'react';
+import { FilterIcon } from '~/icons';
+import { FilterOperatorTypes, FilterType } from '~/types/filters';
+import { Button } from '../../button';
+import { FilterChip } from '../../filter-chip';
+import { Flex } from '../../flex';
+import { IconButton } from '../../icon-button';
+import { Menu } from '../../menu';
+import styles from '../data-view.module.css';
+import { DataViewField } from '../data-view.types';
+import { useDataView } from '../hooks/useDataView';
+import { useFilters } from '../hooks/useFilters';
+
+type Trigger<TData> =
+  | ReactNode
+  | ((args: {
+      availableFilters: DataViewField<TData>[];
+      appliedFilters: Set<string>;
+    }) => ReactNode);
+
+interface AddFilterProps<TData> {
+  fieldList: DataViewField<TData>[];
+  appliedFiltersSet: Set<string>;
+  onAddFilter: (field: DataViewField<TData>) => void;
+  children?: Trigger<TData>;
+}
+
+function AddFilter<TData>({
+  fieldList = [],
+  appliedFiltersSet,
+  onAddFilter,
+  children
+}: AddFilterProps<TData>) {
+  const availableFilters = fieldList?.filter(
+    f => !appliedFiltersSet.has(f.accessorKey)
+  );
+
+  const trigger = useMemo(() => {
+    if (typeof children === 'function')
+      return children({ availableFilters, appliedFilters: appliedFiltersSet });
+    if (children) return children;
+    if (appliedFiltersSet.size > 0) {
+      return (
+        <IconButton size={4}>
+          <FilterIcon />
+        </IconButton>
+      );
+    }
+    return (
+      <Button
+        variant='text'
+        size='small'
+        leadingIcon={<FilterIcon />}
+        color='neutral'
+      >
+        Filter
+      </Button>
+    );
+  }, [children, appliedFiltersSet, availableFilters]);
+
+  return availableFilters.length > 0 ? (
+    <Menu>
+      <Menu.Trigger
+        render={isValidElement(trigger) ? trigger : <button>{trigger}</button>}
+      />
+      <Menu.Content>
+        {availableFilters?.map(field => (
+          <Menu.Item key={field.accessorKey} onClick={() => onAddFilter(field)}>
+            {field.label}
+          </Menu.Item>
+        ))}
+      </Menu.Content>
+    </Menu>
+  ) : null;
+}
+
+export interface DataViewFiltersProps<TData> {
+  classNames?: {
+    filterChips?: string;
+    addFilter?: string;
+  };
+  className?: string;
+  trigger?: Trigger<TData>;
+}
+
+export function Filters<TData>({
+  classNames,
+  className,
+  trigger
+}: DataViewFiltersProps<TData>) {
+  const { fields, tableQuery } = useDataView<TData>();
+
+  const {
+    onAddFilter,
+    handleRemoveFilter,
+    handleFilterValueChange,
+    handleFilterOperationChange
+  } = useFilters<TData>();
+
+  const filterableFields = fields?.filter(f => f.filterable) ?? [];
+
+  const appliedFiltersSet = new Set(
+    tableQuery?.filters?.map(filter => filter.name)
+  );
+
+  const appliedFilters =
+    tableQuery?.filters?.map(filter => {
+      const field = fields?.find(f => f.accessorKey === filter.name);
+      return {
+        filterType: field?.filterType || FilterType.string,
+        label: field?.label || '',
+        options: field?.filterOptions || [],
+        selectProps: field?.filterProps?.select,
+        ...filter
+      };
+    }) || [];
+
+  const hasAppliedFilters = appliedFilters.length > 0;
+
+  return (
+    <Flex
+      gap={3}
+      align='center'
+      className={cx(styles.filterContainer, className)}
+      data-has-filter-chips={hasAppliedFilters || undefined}
+    >
+      {appliedFilters.map(filter => (
+        <FilterChip
+          key={filter.name}
+          label={filter.label}
+          value={filter.value}
+          onRemove={() => handleRemoveFilter(filter.name)}
+          onValueChange={value => handleFilterValueChange(filter.name, value)}
+          onOperationChange={operator =>
+            handleFilterOperationChange(
+              filter.name,
+              operator as FilterOperatorTypes
+            )
+          }
+          columnType={filter.filterType}
+          options={filter.options}
+          selectProps={filter.selectProps}
+          className={classNames?.filterChips}
+        />
+      ))}
+      <AddFilter
+        fieldList={filterableFields}
+        appliedFiltersSet={appliedFiltersSet}
+        onAddFilter={onAddFilter}
+      >
+        {trigger}
+      </AddFilter>
+    </Flex>
+  );
+}
+
+Filters.displayName = 'DataView.Filters';

--- a/packages/raystack/components/data-view/components/grouping.tsx
+++ b/packages/raystack/components/data-view/components/grouping.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { Flex } from '../../flex';
+import { Select } from '../../select';
+import { Text } from '../../text';
+import styles from '../data-view.module.css';
+import { DataViewField, defaultGroupOption } from '../data-view.types';
+
+interface GroupingProps<TData> {
+  fields: DataViewField<TData>[];
+  onChange: (fieldAccessor: string) => void;
+  onRemove: () => void;
+  value: string;
+}
+
+export function Grouping<TData>({
+  fields = [],
+  onChange,
+  onRemove,
+  value
+}: GroupingProps<TData>) {
+  const groupableFields = fields.filter(f => f.groupable);
+
+  const handleGroupChange = (fieldAccessor: string) => {
+    if (fieldAccessor === defaultGroupOption.id) {
+      onRemove();
+      return;
+    }
+    const field = fields.find(f => f.accessorKey === fieldAccessor);
+    if (field) onChange(field.accessorKey);
+  };
+
+  return (
+    <Flex align='center' gap={5}>
+      <Text
+        size='small'
+        weight='medium'
+        variant='secondary'
+        className={styles['display-popover-properties-label']}
+      >
+        Grouping
+      </Text>
+      <Flex
+        align='center'
+        className={styles['display-popover-properties-control']}
+      >
+        <Select onValueChange={handleGroupChange} value={value}>
+          <Select.Trigger
+            size='small'
+            className={styles['display-popover-properties-select']}
+          >
+            <Select.Value placeholder='Select value' />
+          </Select.Trigger>
+          <Select.Content data-variant='filter'>
+            <Select.Item value={defaultGroupOption.id}>
+              {defaultGroupOption.label}
+            </Select.Item>
+            {groupableFields.map(field => (
+              <Select.Item key={field.accessorKey} value={field.accessorKey}>
+                {field.label}
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select>
+      </Flex>
+    </Flex>
+  );
+}

--- a/packages/raystack/components/data-view/components/list.tsx
+++ b/packages/raystack/components/data-view/components/list.tsx
@@ -1,0 +1,545 @@
+'use client';
+
+import { Cross2Icon } from '@radix-ui/react-icons';
+import type { Header, Row } from '@tanstack/react-table';
+import { flexRender } from '@tanstack/react-table';
+import { cx } from 'class-variance-authority';
+import { CSSProperties, useCallback, useEffect, useMemo, useRef } from 'react';
+
+import { Badge } from '../../badge';
+import { Button } from '../../button';
+import { Flex } from '../../flex';
+import { Skeleton } from '../../skeleton';
+import styles from '../data-view.module.css';
+import {
+  DataViewListColumn,
+  DataViewListProps,
+  defaultGroupOption,
+  GroupedData
+} from '../data-view.types';
+import { useDataView } from '../hooks/useDataView';
+import { useElementHeight } from '../hooks/useElementHeight';
+import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
+import { useStickyGroupAnchor } from '../hooks/useStickyGroupAnchor';
+import { useVirtualRows } from '../hooks/useVirtualRows';
+import {
+  countLeafRows,
+  getClientHiddenLeafRowCount,
+  hasActiveTableFiltering
+} from '../utils';
+
+function formatGridWidth(width: string | number | undefined) {
+  if (width === undefined) return '1fr';
+  if (typeof width === 'number') return `${width}px`;
+  return width;
+}
+
+const GROUP_HEADER_HEIGHT = 36;
+const DEFAULT_TABLE_ROW_HEIGHT = 40;
+const DEFAULT_LIST_ROW_HEIGHT = 56;
+
+export function DataViewList<TData, TValue = unknown>({
+  name,
+  variant = 'list',
+  showHeaders,
+  role,
+  fields: fieldsOverride,
+  columns,
+  estimatedRowHeight,
+  virtualized = false,
+  showDividers,
+  showGroupHeaders = true,
+  stickyGroupHeader = false,
+  classNames = {}
+}: DataViewListProps<TData, TValue>) {
+  const {
+    table,
+    mode,
+    onRowClick,
+    isLoading,
+    loadingRowCount = 3,
+    loadMoreData,
+    tableQuery,
+    totalRowCount,
+    updateTableQuery,
+    activeView,
+    registerFieldsForView,
+    hasData
+  } = useDataView<TData>();
+
+  // Register per-view field override so the toolbar's effectiveFields reflects
+  // this renderer's metadata while it's the active view.
+  useEffect(() => {
+    if (!name || !fieldsOverride) return;
+    return registerFieldsForView(name, fieldsOverride);
+  }, [name, fieldsOverride, registerFieldsForView]);
+
+  // Multi-view gate. When `name` is set, render only when this is the active
+  // view. When unset (single-renderer mode), always render.
+  const isActive = !name || activeView === undefined || activeView === name;
+
+  const isTableVariant = variant === 'table';
+  const headersVisible = showHeaders ?? isTableVariant;
+  const ariaRole = role ?? (isTableVariant ? 'table' : 'list');
+  const dividers = showDividers ?? isTableVariant;
+  const effectiveRowHeight =
+    estimatedRowHeight ??
+    (isTableVariant ? DEFAULT_TABLE_ROW_HEIGHT : DEFAULT_LIST_ROW_HEIGHT);
+
+  const visibleLeafColumns = table.getVisibleLeafColumns();
+
+  const columnMap = useMemo(() => {
+    const map = new Map<string, DataViewListColumn<TData, TValue>>();
+    columns.forEach(c => map.set(c.accessorKey, c));
+    return map;
+  }, [columns]);
+
+  // Render order from `columns`. TanStack-managed accessors (those declared in
+  // root `fields`) gate on the current visibility map. Accessors with no
+  // matching field are "unmanaged" display columns (selection, row actions,
+  // drag handles, …) — render unconditionally.
+  const allLeafIds = useMemo(
+    () => new Set(table.getAllLeafColumns().map(c => c.id)),
+    [table, visibleLeafColumns]
+  );
+  const renderedAccessors = useMemo(() => {
+    const visibleSet = new Set(visibleLeafColumns.map(c => c.id));
+    return columns
+      .map(c => c.accessorKey)
+      .filter(k => !allLeafIds.has(k) || visibleSet.has(k));
+  }, [columns, visibleLeafColumns, allLeafIds]);
+
+  const gridTemplateColumns = useMemo(() => {
+    if (renderedAccessors.length === 0) return '1fr';
+    return renderedAccessors
+      .map(accessor => formatGridWidth(columnMap.get(accessor)?.width))
+      .join(' ');
+  }, [renderedAccessors, columnMap]);
+
+  const headerGroups = table?.getHeaderGroups() ?? [];
+  const lastHeaderGroup = headerGroups[headerGroups.length - 1];
+  const headerByAccessor = useMemo(() => {
+    const map = new Map<string, Header<TData, TValue>>();
+    lastHeaderGroup?.headers.forEach(h => map.set(h.column.id, h));
+    return map;
+  }, [lastHeaderGroup]);
+
+  const rowModel = table?.getRowModel();
+  const { rows = [] } = rowModel || {};
+
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  // Measure the column-header row so sticky group elements sit directly under it.
+  const [headerMeasureRef, headerHeight] = useElementHeight();
+
+  // Group offsets — needed for sticky group anchor under virtualization.
+  const group_by = tableQuery?.group_by?.[0];
+  const isGrouped = Boolean(group_by) && group_by !== defaultGroupOption.id;
+
+  const groupHeaderList = useMemo(() => {
+    const list: {
+      index: number;
+      start: number;
+      data: GroupedData<TData>;
+    }[] = [];
+    let offset = 0;
+    rows.forEach((row, i) => {
+      const isGroupHeader = row.subRows && row.subRows.length > 0;
+      if (isGroupHeader) {
+        list.push({
+          index: i,
+          start: offset,
+          data: row.original as GroupedData<TData>
+        });
+      }
+      offset += isGroupHeader ? GROUP_HEADER_HEIGHT : effectiveRowHeight;
+    });
+    return list;
+  }, [rows, effectiveRowHeight]);
+
+  const { totalSize, items, measureRef } = useVirtualRows({
+    enabled: virtualized,
+    rows,
+    scrollRef,
+    estimatedRowHeight: effectiveRowHeight,
+    estimateSize: row => {
+      const isGroupHeader = row?.subRows && row.subRows.length > 0;
+      return isGroupHeader ? GROUP_HEADER_HEIGHT : effectiveRowHeight;
+    }
+  });
+
+  // Sticky group anchor (virtualized + grouped + opt-in).
+  const {
+    stickyGroup,
+    stickyGroupIndex,
+    recompute: recomputeStickyGroup
+  } = useStickyGroupAnchor<TData>({
+    enabled: virtualized && stickyGroupHeader && isGrouped,
+    groupHeaderList,
+    scrollContainerRef: scrollRef
+  });
+
+  // Single sentinel-based load-more for both virtualized and non-virtualized.
+  useInfiniteScroll({
+    enabled: isActive && mode === 'server' && Boolean(loadMoreData),
+    sentinelRef,
+    scrollRef,
+    isLoading,
+    onLoadMore: loadMoreData
+  });
+
+  const hiddenLeafRowCount =
+    mode === 'client'
+      ? getClientHiddenLeafRowCount(table)
+      : totalRowCount !== undefined
+        ? Math.max(0, totalRowCount - countLeafRows(rows))
+        : null;
+  const hasActiveFiltering = !isLoading && hasActiveTableFiltering(table);
+  const showFilterSummary =
+    hasActiveFiltering &&
+    (mode === 'server' ||
+      (typeof hiddenLeafRowCount === 'number' && hiddenLeafRowCount > 0));
+
+  const handleClearFilters = useCallback(() => {
+    updateTableQuery(prev => ({ ...prev, filters: [], search: '' }));
+  }, [updateTableQuery]);
+
+  // Sticky group anchor needs to recompute on scroll only. rAF-throttled so
+  // the binary search runs at most once per frame regardless of how fast the
+  // scroll events fire (mousewheel can dispatch dozens per frame on macOS).
+  const rafIdRef = useRef<number | null>(null);
+  const handleScroll = useCallback(() => {
+    if (!(virtualized && stickyGroupHeader && isGrouped)) return;
+    if (rafIdRef.current !== null) return;
+    rafIdRef.current = requestAnimationFrame(() => {
+      rafIdRef.current = null;
+      recomputeStickyGroup();
+    });
+  }, [virtualized, stickyGroupHeader, isGrouped, recomputeStickyGroup]);
+
+  useEffect(
+    () => () => {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+    },
+    []
+  );
+
+  if (!isActive) return null;
+  // Render nothing when there's truly no data and no loading — sibling
+  // `<DataView.EmptyState>` / `<DataView.ZeroState>` handle messaging.
+  if (!hasData) return null;
+
+  const renderHeaderRow = () => {
+    if (!headersVisible) return null;
+    return (
+      <div
+        ref={headerMeasureRef}
+        role={ariaRole === 'table' ? 'rowgroup' : undefined}
+        className={cx(styles.listHeader, classNames.header)}
+      >
+        <div
+          role={ariaRole === 'table' ? 'row' : undefined}
+          className={styles.listHeaderRow}
+        >
+          {renderedAccessors.map(accessor => {
+            const spec = columnMap.get(accessor);
+            const header = headerByAccessor.get(accessor);
+            let content: React.ReactNode = null;
+            if (header) {
+              const source =
+                spec?.header !== undefined
+                  ? spec.header
+                  : header.column.columnDef.header;
+              content = flexRender(source, header.getContext());
+            } else if (spec?.header !== undefined) {
+              // Unmanaged column (e.g. selection): no TanStack header — render
+              // the spec's header with a minimal context.
+              content =
+                typeof spec.header === 'function'
+                  ? (
+                      spec.header as (ctx: {
+                        table: typeof table;
+                      }) => React.ReactNode
+                    )({ table })
+                  : (spec.header as React.ReactNode);
+            }
+            return (
+              <div
+                role={ariaRole === 'table' ? 'columnheader' : undefined}
+                key={accessor}
+                className={cx(
+                  styles.listHeaderCell,
+                  spec?.classNames?.header,
+                  classNames.headerCell
+                )}
+                style={spec?.styles?.header}
+              >
+                {content}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  };
+
+  const renderRowCells = (row: Row<TData>) =>
+    renderedAccessors.map(accessor => {
+      const spec = columnMap.get(accessor);
+      const cell = row.getVisibleCells().find(c => c.column.id === accessor);
+      let content: React.ReactNode = null;
+      if (cell) {
+        content = spec?.cell
+          ? flexRender(spec.cell, cell.getContext())
+          : ((cell.getValue() as React.ReactNode) ?? null);
+      } else if (spec?.cell !== undefined) {
+        // Unmanaged column (e.g. selection): no TanStack cell — render the
+        // spec's cell with a synthetic context covering the common reads.
+        content =
+          typeof spec.cell === 'function'
+            ? (
+                spec.cell as (ctx: {
+                  row: Row<TData>;
+                  table: typeof table;
+                }) => React.ReactNode
+              )({ row, table })
+            : (spec.cell as React.ReactNode);
+      }
+      return (
+        <div
+          role={ariaRole === 'table' ? 'cell' : undefined}
+          key={cell?.id ?? accessor}
+          className={cx(
+            styles.listCell,
+            spec?.classNames?.cell,
+            classNames.cell
+          )}
+          style={spec?.styles?.cell}
+        >
+          {content}
+        </div>
+      );
+    });
+
+  type RowVisualProps = {
+    style?: CSSProperties;
+    key?: string;
+    /** Virtualizer measure ref (auto-measurement). */
+    measure?: (el: HTMLElement | null) => void;
+    /** TanStack index, set so the virtualizer can reconcile measurements. */
+    dataIndex?: number;
+    /** When true, swap subgrid styles for inline grid-template-columns. */
+    isVirtual?: boolean;
+    hidden?: boolean;
+  };
+
+  const renderGroupHeader = (row: Row<TData>, props: RowVisualProps = {}) => {
+    const { style, key, measure, dataIndex, isVirtual, hidden } = props;
+    const data = row.original as GroupedData<unknown>;
+    const isStickyInFlow = !virtualized && stickyGroupHeader;
+    const composedStyle: CSSProperties = {
+      ...style,
+      ...(isStickyInFlow ? { top: headerHeight } : null),
+      ...(hidden ? { visibility: 'hidden' } : null)
+    };
+    return (
+      <div
+        key={key ?? row.id}
+        ref={measure}
+        data-index={dataIndex}
+        className={cx(
+          isVirtual ? styles.listGroupHeaderVirtual : styles.listGroupHeader,
+          isStickyInFlow && styles.listGroupHeaderSticky,
+          classNames.groupHeader
+        )}
+        style={composedStyle}
+        aria-hidden={hidden || undefined}
+      >
+        {data?.label}
+        {data?.showGroupCount ? (
+          <Badge variant='neutral'>{data?.count}</Badge>
+        ) : null}
+      </div>
+    );
+  };
+
+  const renderDataRow = (row: Row<TData>, props: RowVisualProps = {}) => {
+    const { style, key, measure, dataIndex, isVirtual } = props;
+    const composedStyle: CSSProperties = isVirtual
+      ? { ...style, gridTemplateColumns }
+      : (style ?? {});
+    return (
+      <div
+        role={ariaRole === 'table' ? 'row' : 'listitem'}
+        key={key ?? row.id}
+        ref={measure}
+        data-index={dataIndex}
+        className={cx(
+          isVirtual ? styles.listRowVirtual : styles.listRow,
+          dividers && styles.listRowDivider,
+          onRowClick && styles.clickable,
+          classNames.row
+        )}
+        style={composedStyle}
+        onClick={() => onRowClick?.(row.original)}
+      >
+        {renderRowCells(row)}
+      </div>
+    );
+  };
+
+  const renderLoaderRows = () => {
+    if (!isLoading) return null;
+    const count = Math.max(1, loadingRowCount);
+    return Array.from({ length: count }, (_, i) => (
+      <div
+        key={`__loader-${i}`}
+        role={ariaRole === 'table' ? 'row' : 'listitem'}
+        className={cx(styles.listLoaderRow, dividers && styles.listRowDivider)}
+        aria-busy='true'
+        style={{ minHeight: effectiveRowHeight }}
+      >
+        {renderedAccessors.map(accessor => {
+          const spec = columnMap.get(accessor);
+          return (
+            <div
+              role={ariaRole === 'table' ? 'cell' : undefined}
+              key={accessor}
+              className={cx(
+                styles.listCell,
+                spec?.classNames?.cell,
+                classNames.cell
+              )}
+              style={spec?.styles?.cell}
+            >
+              <Skeleton containerClassName={styles.skeletonFill} />
+            </div>
+          );
+        })}
+      </div>
+    ));
+  };
+
+  const renderVirtualBody = () => (
+    <div
+      role={ariaRole === 'table' ? 'rowgroup' : undefined}
+      className={styles.listBodyVirtual}
+      style={{ height: totalSize }}
+    >
+      {stickyGroup && stickyGroupHeader ? (
+        <div
+          aria-hidden='true'
+          className={cx(styles.listGroupAnchor, classNames.groupHeader)}
+          style={{ top: headerHeight }}
+        >
+          {stickyGroup.label}
+          {stickyGroup.showGroupCount ? (
+            <Badge variant='neutral'>{stickyGroup.count}</Badge>
+          ) : null}
+        </div>
+      ) : null}
+      {items.map(item => {
+        const row = rows[item.index];
+        if (!row) return null;
+        const isGroupHeader = row.subRows && row.subRows.length > 0;
+        const positionStyle: CSSProperties = {
+          transform: `translateY(${item.start}px)`
+        };
+        if (isGroupHeader) {
+          if (!showGroupHeaders) return null;
+          const hidden = stickyGroupIndex === item.index;
+          return renderGroupHeader(row, {
+            style: positionStyle,
+            key: row.id + '-' + item.index,
+            measure: measureRef,
+            dataIndex: item.index,
+            isVirtual: true,
+            hidden
+          });
+        }
+        return renderDataRow(row, {
+          style: positionStyle,
+          key: row.id + '-' + item.index,
+          measure: measureRef,
+          dataIndex: item.index,
+          isVirtual: true
+        });
+      })}
+    </div>
+  );
+
+  const renderFlatBody = () => (
+    <div
+      role={ariaRole === 'table' ? 'rowgroup' : undefined}
+      className={styles.listBody}
+    >
+      {rows.map(row => {
+        const isGroupHeader = row.subRows && row.subRows.length > 0;
+        if (isGroupHeader) {
+          return showGroupHeaders ? renderGroupHeader(row) : null;
+        }
+        return renderDataRow(row);
+      })}
+    </div>
+  );
+
+  return (
+    <div
+      ref={scrollRef}
+      className={cx(styles.listRoot, classNames.root)}
+      onScroll={handleScroll}
+    >
+      <div
+        role={ariaRole}
+        className={styles.listGrid}
+        style={{ gridTemplateColumns }}
+      >
+        {renderHeaderRow()}
+        {virtualized ? renderVirtualBody() : renderFlatBody()}
+        {renderLoaderRows()}
+        {/* Sentinel — triggers onLoadMore via IntersectionObserver in server mode. */}
+        <div
+          ref={sentinelRef}
+          className={styles.listSentinel}
+          aria-hidden='true'
+        />
+      </div>
+      {showFilterSummary ? (
+        <Flex
+          className={styles.filterSummaryFooter}
+          justify='center'
+          align='center'
+        >
+          {mode === 'server' && hiddenLeafRowCount === null ? (
+            <span className={styles.filterSummaryLabel}>
+              Some items might be hidden by filters
+            </span>
+          ) : (
+            <Flex align='center' gap={2}>
+              <span className={styles.filterSummaryCount}>
+                {hiddenLeafRowCount}
+              </span>
+              <span className={styles.filterSummaryLabel}>
+                items hidden by filters
+              </span>
+            </Flex>
+          )}
+          <Button
+            variant='text'
+            color='neutral'
+            size='small'
+            trailingIcon={<Cross2Icon />}
+            onClick={handleClearFilters}
+          >
+            Clear Filters
+          </Button>
+        </Flex>
+      ) : null}
+    </div>
+  );
+}
+
+DataViewList.displayName = 'DataView.List';

--- a/packages/raystack/components/data-view/components/ordering.tsx
+++ b/packages/raystack/components/data-view/components/ordering.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { TextAlignBottomIcon, TextAlignTopIcon } from '@radix-ui/react-icons';
+
+import { Flex } from '../../flex';
+import { IconButton } from '../../icon-button';
+import { Select } from '../../select';
+import { Text } from '../../text';
+import styles from '../data-view.module.css';
+import {
+  ColumnData,
+  DataViewSort,
+  SortOrders,
+  SortOrdersValues
+} from '../data-view.types';
+
+export interface OrderingProps {
+  columnList: ColumnData[];
+  onChange: (columnId: string, order: SortOrdersValues) => void;
+  value: DataViewSort;
+}
+
+export function Ordering({ columnList, onChange, value }: OrderingProps) {
+  const handleColumnChange = (columnId: string) =>
+    onChange(columnId, value.order);
+  const handleOrderChange = () => {
+    const newOrder =
+      value.order === SortOrders.ASC ? SortOrders.DESC : SortOrders.ASC;
+    onChange(value.name, newOrder);
+  };
+
+  return (
+    <Flex align='center' gap={5}>
+      <Text
+        size='small'
+        weight='medium'
+        variant='secondary'
+        className={styles['display-popover-properties-label']}
+      >
+        Ordering
+      </Text>
+      <Flex
+        gap={3}
+        align='center'
+        className={styles['display-popover-properties-control']}
+      >
+        <Select
+          onValueChange={handleColumnChange}
+          value={value.name}
+          disabled={columnList.length === 0}
+        >
+          <Select.Trigger
+            size='small'
+            className={styles['display-popover-properties-select']}
+          >
+            <Select.Value placeholder='Select value' />
+          </Select.Trigger>
+          <Select.Content data-variant='filter'>
+            {columnList.map(column => (
+              <Select.Item key={column.id} value={column.id}>
+                {column.label}
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select>
+        <IconButton
+          onClick={handleOrderChange}
+          size={4}
+          disabled={columnList.length === 0}
+        >
+          {value.order === SortOrders?.ASC ? (
+            <TextAlignBottomIcon
+              className={styles['display-popover-sort-icon']}
+            />
+          ) : (
+            <TextAlignTopIcon className={styles['display-popover-sort-icon']} />
+          )}
+        </IconButton>
+      </Flex>
+    </Flex>
+  );
+}

--- a/packages/raystack/components/data-view/components/search.tsx
+++ b/packages/raystack/components/data-view/components/search.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { ChangeEvent, type ComponentProps } from 'react';
+import { Search } from '../../search';
+import { useDataView } from '../hooks/useDataView';
+
+export interface DataViewSearchProps extends ComponentProps<typeof Search> {
+  /**
+   * Automatically disable search in zero state (no data and no active filters).
+   * @defaultValue true
+   */
+  autoDisableInZeroState?: boolean;
+}
+
+export function DataViewSearch({
+  autoDisableInZeroState = true,
+  disabled,
+  ...props
+}: DataViewSearchProps) {
+  const { updateTableQuery, tableQuery, shouldShowFilters } = useDataView();
+
+  const handleSearch = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    updateTableQuery(query => ({ ...query, search: value }));
+  };
+
+  const handleClear = () => {
+    updateTableQuery(query => ({ ...query, search: '' }));
+  };
+
+  // Keep enabled once the user has typed, even if zero-state otherwise applies.
+  const hasSearch = Boolean(
+    tableQuery?.search && tableQuery.search.trim() !== ''
+  );
+  const isDisabled =
+    disabled ?? (autoDisableInZeroState && !shouldShowFilters && !hasSearch);
+
+  return (
+    <Search
+      {...props}
+      onChange={handleSearch}
+      value={tableQuery?.search ?? ''}
+      onClear={handleClear}
+      disabled={isDisabled}
+    />
+  );
+}
+
+DataViewSearch.displayName = 'DataView.Search';

--- a/packages/raystack/components/data-view/components/toolbar.tsx
+++ b/packages/raystack/components/data-view/components/toolbar.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { cx } from 'class-variance-authority';
+import { PropsWithChildren } from 'react';
+import { Flex } from '../../flex';
+import styles from '../data-view.module.css';
+import { useDataView } from '../hooks/useDataView';
+import { DisplayControls } from './display-controls';
+import { Filters } from './filters';
+
+interface ToolbarProps {
+  className?: string;
+}
+
+/**
+ * Toolbar container for `DataView`. Visible whenever there is data OR an active
+ * query — pure zero state keeps it hidden. Consumers compose children
+ * (`<DataView.Search>`, `<DataView.Filters>`, `<DataView.DisplayControls>`,
+ * custom actions); omitting children renders the default
+ * `<Filters> + <DisplayControls>` pair.
+ */
+export function Toolbar<TData>({
+  className,
+  children
+}: PropsWithChildren<ToolbarProps>) {
+  const { shouldShowFilters } = useDataView<TData>();
+  if (!shouldShowFilters) return null;
+
+  if (children) {
+    return (
+      <Flex
+        className={cx(styles['toolbar'], className)}
+        justify='between'
+        gap={3}
+        align='start'
+      >
+        {children}
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex
+      className={cx(styles['toolbar'], className)}
+      justify='between'
+      gap={3}
+      align='start'
+    >
+      <Filters<TData> />
+      <DisplayControls<TData> />
+    </Flex>
+  );
+}
+
+Toolbar.displayName = 'DataView.Toolbar';

--- a/packages/raystack/components/data-view/components/view-switcher.tsx
+++ b/packages/raystack/components/data-view/components/view-switcher.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { cx } from 'class-variance-authority';
+import { Tabs } from '../../tabs';
+import styles from '../data-view.module.css';
+import { useDataView } from '../hooks/useDataView';
+
+export interface DataViewViewSwitcherProps {
+  className?: string;
+  size?: 'small' | 'medium' | 'large';
+}
+
+/**
+ * Tab-based switcher for the configured `views`. Reads `views` and `activeView`
+ * from `DataView` context and writes through `setActiveView`. Renders nothing
+ * when `views` is unset or has fewer than two entries.
+ */
+export function ViewSwitcher({
+  className,
+  size = 'small'
+}: DataViewViewSwitcherProps) {
+  const { views, activeView, setActiveView } = useDataView();
+  if (!views || views.length < 2) return null;
+  return (
+    <Tabs
+      value={activeView}
+      onValueChange={v => setActiveView(v)}
+      size={size}
+      className={cx(styles.viewSwitcher, className)}
+    >
+      <Tabs.List>
+        {views.map(v => (
+          <Tabs.Tab key={v.value} value={v.value} leadingIcon={v.icon}>
+            {v.label}
+          </Tabs.Tab>
+        ))}
+      </Tabs.List>
+    </Tabs>
+  );
+}
+
+ViewSwitcher.displayName = 'DataView.ViewSwitcher';

--- a/packages/raystack/components/data-view/components/view-switcher.tsx
+++ b/packages/raystack/components/data-view/components/view-switcher.tsx
@@ -1,36 +1,26 @@
 'use client';
 
-import { cx } from 'class-variance-authority';
 import { Tabs } from '../../tabs';
-import styles from '../data-view.module.css';
 import { useDataView } from '../hooks/useDataView';
 
-export interface DataViewViewSwitcherProps {
-  className?: string;
+interface ViewSwitcherProps {
   size?: 'small' | 'medium' | 'large';
 }
 
 /**
- * Tab-based switcher for the configured `views`. Reads `views` and `activeView`
- * from `DataView` context and writes through `setActiveView`. Renders nothing
- * when `views` is unset or has fewer than two entries.
+ * Tab-based switcher for the configured `views`. Internal to
+ * `DataView.DisplayControls` — reads `views` and `activeView` from context and
+ * writes through `setActiveView`. Renders nothing when `views` is unset or has
+ * fewer than two entries. Each tab shows the view's optional `leadingIcon`.
  */
-export function ViewSwitcher({
-  className,
-  size = 'small'
-}: DataViewViewSwitcherProps) {
+export function ViewSwitcher({ size = 'small' }: ViewSwitcherProps) {
   const { views, activeView, setActiveView } = useDataView();
   if (!views || views.length < 2) return null;
   return (
-    <Tabs
-      value={activeView}
-      onValueChange={v => setActiveView(v)}
-      size={size}
-      className={cx(styles.viewSwitcher, className)}
-    >
+    <Tabs value={activeView} onValueChange={v => setActiveView(v)} size={size}>
       <Tabs.List>
         {views.map(v => (
-          <Tabs.Tab key={v.value} value={v.value} leadingIcon={v.icon}>
+          <Tabs.Tab key={v.value} value={v.value} leadingIcon={v.leadingIcon}>
             {v.label}
           </Tabs.Tab>
         ))}
@@ -38,5 +28,3 @@ export function ViewSwitcher({
     </Tabs>
   );
 }
-
-ViewSwitcher.displayName = 'DataView.ViewSwitcher';

--- a/packages/raystack/components/data-view/components/zero-state.tsx
+++ b/packages/raystack/components/data-view/components/zero-state.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { cx } from 'class-variance-authority';
+import { ReactNode } from 'react';
+import styles from '../data-view.module.css';
+import { useDataView } from '../hooks/useDataView';
+
+export interface DataViewZeroStateProps {
+  /** Restrict to a specific view's `name`. */
+  forView?: string;
+  className?: string;
+  children: ReactNode;
+}
+
+/**
+ * Renders its children when there is no data and no active query (the
+ * "first-use" state). Reads `isZeroState` from `DataView` context.
+ */
+export function DataViewZeroState({
+  forView,
+  className,
+  children
+}: DataViewZeroStateProps) {
+  const { isZeroState, activeView } = useDataView();
+  if (!isZeroState) return null;
+  if (forView && activeView !== forView) return null;
+  return (
+    <div className={cx(styles.dataStateContainer, className)}>{children}</div>
+  );
+}
+
+DataViewZeroState.displayName = 'DataView.ZeroState';

--- a/packages/raystack/components/data-view/context.tsx
+++ b/packages/raystack/components/data-view/context.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import { createContext } from 'react';
+
+import { DataViewContextType } from './data-view.types';
+
+export const DataViewContext = createContext<DataViewContextType<any> | null>(
+  null
+);

--- a/packages/raystack/components/data-view/data-view.module.css
+++ b/packages/raystack/components/data-view/data-view.module.css
@@ -1,0 +1,317 @@
+/* Toolbar */
+.toolbar {
+  padding: var(--rs-space-3) var(--rs-space-7) var(--rs-space-3)
+    var(--rs-space-5);
+  align-self: stretch;
+  border-bottom: 0.5px solid var(--rs-color-border-base-primary);
+  background: var(--rs-color-background-base-primary);
+}
+
+.toolbar:has([data-has-filter-chips]) {
+  padding-left: var(--rs-space-7);
+}
+
+/* Display popover */
+.display-popover-content {
+  padding: 0px;
+  min-width: 320px;
+  max-width: 352px;
+  border-radius: var(--rs-radius-3);
+}
+
+.display-popover-properties-container {
+  padding: var(--rs-space-5);
+  border-bottom: 1px solid var(--rs-color-border-base-primary);
+}
+
+.display-popover-properties-label {
+  min-width: 100px;
+  flex-shrink: 0;
+}
+
+.display-popover-properties-control {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.display-popover-properties-select {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.display-popover-properties-select > span {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.display-popover-reset-container {
+  padding: var(--rs-space-3) var(--rs-space-5);
+}
+
+.display-popover-sort-icon {
+  height: var(--rs-space-6);
+  width: var(--rs-space-6);
+}
+
+.flex-1 {
+  flex: 1;
+}
+
+/* Filter container — chips wrap onto a new line when they overflow. */
+.filterContainer {
+  flex-wrap: wrap;
+}
+
+/* Filter-summary footer (inside renderer scroll container) */
+.filterSummaryFooter {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--rs-space-4);
+  width: 100%;
+  padding: var(--rs-space-9) 0;
+  box-sizing: border-box;
+}
+
+.filterSummaryCount {
+  color: var(--rs-color-foreground-base-primary);
+  font-family: var(--rs-font-body);
+  font-size: var(--rs-font-size-small);
+  font-style: normal;
+  font-weight: var(--rs-font-weight-medium);
+  line-height: var(--rs-line-height-small);
+  letter-spacing: var(--rs-letter-spacing-small);
+}
+
+.filterSummaryLabel {
+  color: var(--rs-color-foreground-base-secondary);
+  font-family: var(--rs-font-body);
+  font-size: var(--rs-font-size-small);
+  font-style: normal;
+  font-weight: var(--rs-font-weight-regular);
+  line-height: var(--rs-line-height-small);
+  letter-spacing: var(--rs-letter-spacing-small);
+}
+
+/* Generic row hover (used by Custom render-prop helpers) */
+.clickable {
+  cursor: pointer;
+}
+
+/* List renderer (handles both variant="table" and variant="list").
+   Implemented with CSS Grid + subgrid: `.listGrid` defines the column tracks
+   once; every row/header subgrid-inherits them so cells stay aligned without
+   per-cell width math. */
+.listRoot {
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background: var(--rs-color-background-base-primary);
+}
+
+.listGrid {
+  display: grid;
+  width: 100%;
+  align-items: stretch;
+}
+
+.listHeader {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: subgrid;
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  background: var(--rs-color-background-base-primary);
+  border-bottom: 0.5px solid var(--rs-color-border-base-primary);
+}
+
+.listHeaderRow {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: subgrid;
+}
+
+.listHeaderCell {
+  padding: var(--rs-space-3);
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  color: var(--rs-color-foreground-base-tertiary);
+  font-family: var(--rs-font-body);
+  font-size: var(--rs-font-size-small);
+  font-style: normal;
+  font-weight: var(--rs-font-weight-medium);
+  line-height: var(--rs-line-height-small);
+  letter-spacing: var(--rs-letter-spacing-small);
+  text-align: left;
+  box-sizing: border-box;
+}
+
+.listBody {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: subgrid;
+}
+
+/* Virtualized body: rows are absolutely positioned, so the body is pulled out
+   of the subgrid flow. Each virtual row re-declares its own column template
+   inline. */
+.listBodyVirtual {
+  grid-column: 1 / -1;
+  position: relative;
+}
+
+.listRow {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: subgrid;
+  align-items: center;
+  background: var(--rs-color-background-base-primary);
+  box-sizing: border-box;
+}
+
+.listRow:hover {
+  background: var(--rs-color-background-base-primary-hover);
+}
+
+/* Virtual row variant — positioned absolutely; gridTemplateColumns is set
+   inline so columns line up with the header. */
+.listRowVirtual {
+  display: grid;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  align-items: center;
+  background: var(--rs-color-background-base-primary);
+  box-sizing: border-box;
+}
+
+.listRowVirtual:hover {
+  background: var(--rs-color-background-base-primary-hover);
+}
+
+.listRowDivider {
+  border-bottom: 0.5px solid var(--rs-color-border-base-primary);
+}
+
+.listCell {
+  padding: var(--rs-space-4) var(--rs-space-3);
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  color: var(--rs-color-foreground-base-secondary);
+  font-family: var(--rs-font-body);
+  font-size: var(--rs-font-size-regular);
+  font-style: normal;
+  font-weight: var(--rs-font-weight-regular);
+  line-height: var(--rs-line-height-regular);
+  letter-spacing: var(--rs-letter-spacing-regular);
+  box-sizing: border-box;
+}
+
+.listGroupHeader {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: var(--rs-space-3);
+  background: var(--rs-color-background-neutral-primary);
+  color: var(--rs-color-foreground-base-primary);
+  padding: var(--rs-space-3);
+  font-size: var(--rs-font-size-small);
+  font-weight: var(--rs-font-weight-medium);
+  line-height: var(--rs-line-height-small);
+  letter-spacing: var(--rs-letter-spacing-small);
+  text-align: left;
+  box-sizing: border-box;
+}
+
+/* Virtualized group header — absolutely positioned within `.listBodyVirtual`. */
+.listGroupHeaderVirtual {
+  display: flex;
+  align-items: center;
+  gap: var(--rs-space-3);
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: var(--rs-color-background-neutral-primary);
+  color: var(--rs-color-foreground-base-primary);
+  padding: var(--rs-space-3);
+  font-size: var(--rs-font-size-small);
+  font-weight: var(--rs-font-weight-medium);
+  line-height: var(--rs-line-height-small);
+  letter-spacing: var(--rs-letter-spacing-small);
+  text-align: left;
+  box-sizing: border-box;
+}
+
+/* Non-virtualized sticky group header. `top` is set inline by the renderer to
+   the measured column-header height (0 when headers are hidden). */
+.listGroupHeaderSticky {
+  position: sticky;
+  z-index: 1;
+}
+
+/* Virtualized sticky group anchor — single element that swaps content as the
+   user scrolls past each natural group header. `top` is set inline. */
+.listGroupAnchor {
+  position: sticky;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: var(--rs-space-3);
+  grid-column: 1 / -1;
+  background: var(--rs-color-background-neutral-primary);
+  color: var(--rs-color-foreground-base-primary);
+  padding: var(--rs-space-3);
+  font-size: var(--rs-font-size-small);
+  font-weight: var(--rs-font-weight-medium);
+  line-height: var(--rs-line-height-small);
+  letter-spacing: var(--rs-letter-spacing-small);
+  box-sizing: border-box;
+  box-shadow: 0 0.5px 0 0 var(--rs-color-border-base-primary);
+}
+
+/* Loader skeleton row (virtualized + non-virtualized share this). Renders in
+   natural flow at the tail of the row pane. */
+.listLoaderRow {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: subgrid;
+  align-items: center;
+  box-sizing: border-box;
+}
+
+/* Lets <Skeleton/> fill the available width inside a flex .listCell —
+   matches DataTable's virtualized skeleton container. */
+.skeletonFill {
+  flex: 1;
+}
+
+/* IntersectionObserver sentinel — sits below the loader rows. Non-visual. */
+.listSentinel {
+  grid-column: 1 / -1;
+  height: 1px;
+  width: 100%;
+  pointer-events: none;
+}
+
+/* Empty/zero sibling container */
+.dataStateContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: var(--rs-space-9) 0;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* Multi-view switcher (inside DisplayControls or standalone) */
+.viewSwitcher {
+  flex-shrink: 0;
+}

--- a/packages/raystack/components/data-view/data-view.module.css
+++ b/packages/raystack/components/data-view/data-view.module.css
@@ -214,6 +214,11 @@
   box-sizing: border-box;
 }
 
+.listHeaderCell:first-child,
+.listCell:first-child {
+  padding-left: var(--rs-space-7);
+}
+
 .listGroupHeader {
   grid-column: 1 / -1;
   display: flex;
@@ -309,9 +314,4 @@
   padding: var(--rs-space-9) 0;
   width: 100%;
   box-sizing: border-box;
-}
-
-/* Multi-view switcher (inside DisplayControls or standalone) */
-.viewSwitcher {
-  flex-shrink: 0;
 }

--- a/packages/raystack/components/data-view/data-view.tsx
+++ b/packages/raystack/components/data-view/data-view.tsx
@@ -1,0 +1,317 @@
+'use client';
+
+import {
+  getCoreRowModel,
+  getExpandedRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  Updater,
+  useReactTable,
+  VisibilityState
+} from '@tanstack/react-table';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { DataViewCustom } from './components/custom';
+import { DisplayAccess } from './components/display-access';
+import { DisplayControls } from './components/display-controls';
+import { DataViewEmptyState } from './components/empty-state';
+import { Filters } from './components/filters';
+import { DataViewList } from './components/list';
+import { DataViewSearch } from './components/search';
+import { Toolbar } from './components/toolbar';
+import { ViewSwitcher } from './components/view-switcher';
+import { DataViewZeroState } from './components/zero-state';
+import { DataViewContext } from './context';
+import {
+  DataViewContextType,
+  DataViewField,
+  DataViewProps,
+  defaultGroupOption,
+  GroupedData,
+  InternalQuery,
+  TableQueryUpdateFn
+} from './data-view.types';
+import {
+  hasActiveQuery as computeHasActiveQuery,
+  fieldsToColumnDefs,
+  getDefaultTableQuery,
+  getInitialColumnVisibility,
+  groupData,
+  hasQueryChanged,
+  queryToTableState,
+  transformToDataViewQuery
+} from './utils';
+
+function DataViewRoot<TData>({
+  data = [],
+  fields,
+  query,
+  mode = 'client',
+  isLoading = false,
+  totalRowCount,
+  loadingRowCount = 3,
+  defaultSort,
+  children,
+  onTableQueryChange,
+  onLoadMore,
+  onRowClick,
+  onColumnVisibilityChange,
+  getRowId,
+  views,
+  defaultView,
+  view,
+  onViewChange,
+  groupByResolvers
+}: React.PropsWithChildren<DataViewProps<TData>>) {
+  const defaultTableQuery = useMemo(
+    () => getDefaultTableQuery(defaultSort, query),
+    [defaultSort, query]
+  );
+
+  // Active view (controlled / uncontrolled).
+  const isViewControlled = view !== undefined;
+  const [internalActiveView, setInternalActiveView] = useState<
+    string | undefined
+  >(defaultView ?? views?.[0]?.value);
+  const activeView = isViewControlled ? view : internalActiveView;
+  const setActiveView = useCallback(
+    (next: string) => {
+      if (!isViewControlled) setInternalActiveView(next);
+      onViewChange?.(next);
+    },
+    [isViewControlled, onViewChange]
+  );
+
+  // Per-view field overrides registered by mounted renderers.
+  const [fieldsByView, setFieldsByView] = useState<
+    Record<string, DataViewField<TData>[]>
+  >({});
+
+  const registerFieldsForView = useCallback(
+    (name: string, override: DataViewField<TData>[]) => {
+      setFieldsByView(prev => {
+        if (prev[name] === override) return prev;
+        return { ...prev, [name]: override };
+      });
+      return () => {
+        setFieldsByView(prev => {
+          if (!(name in prev)) return prev;
+          const next = { ...prev };
+          delete next[name];
+          return next;
+        });
+      };
+    },
+    []
+  );
+
+  const effectiveFields = useMemo(() => {
+    if (activeView && fieldsByView[activeView]) return fieldsByView[activeView];
+    return fields;
+  }, [activeView, fieldsByView, fields]);
+
+  const initialColumnVisibility = useMemo(
+    () => getInitialColumnVisibility(fields),
+    [fields]
+  );
+
+  const [columnVisibility, setColumnVisibilityState] =
+    useState<VisibilityState>(initialColumnVisibility);
+
+  const handleColumnVisibilityChange = useCallback(
+    (value: Updater<VisibilityState>) => {
+      setColumnVisibilityState(prev => {
+        const newValue = typeof value === 'function' ? value(prev) : value;
+        onColumnVisibilityChange?.(newValue);
+        return newValue;
+      });
+    },
+    [onColumnVisibilityChange]
+  );
+
+  const [tableQuery, setTableQuery] =
+    useState<InternalQuery>(defaultTableQuery);
+
+  const oldQueryRef = useRef<InternalQuery | null>(null);
+
+  const reactTableState = useMemo(
+    () => queryToTableState(tableQuery),
+    [tableQuery]
+  );
+
+  const onDisplaySettingsReset = useCallback(() => {
+    setTableQuery(prev => ({
+      ...prev,
+      ...defaultTableQuery,
+      sort: [defaultSort],
+      group_by: [defaultGroupOption.id]
+    }));
+    handleColumnVisibilityChange(initialColumnVisibility);
+  }, [
+    defaultSort,
+    defaultTableQuery,
+    initialColumnVisibility,
+    handleColumnVisibilityChange
+  ]);
+
+  const group_by = tableQuery.group_by?.[0];
+
+  // Column defs are derived from EFFECTIVE fields so toolbar + headless filter/
+  // sort/visibility reflect the active view's metadata override.
+  const columnDefs = useMemo(
+    () => fieldsToColumnDefs<TData>(effectiveFields, tableQuery.filters),
+    [effectiveFields, tableQuery.filters]
+  );
+
+  const groupedData = useMemo(
+    () => groupData(data, group_by, effectiveFields, groupByResolvers),
+    [data, group_by, effectiveFields, groupByResolvers]
+  );
+
+  useEffect(() => {
+    if (
+      tableQuery &&
+      onTableQueryChange &&
+      hasQueryChanged(oldQueryRef.current, tableQuery) &&
+      mode === 'server'
+    ) {
+      onTableQueryChange(transformToDataViewQuery(tableQuery));
+      oldQueryRef.current = tableQuery;
+    }
+  }, [tableQuery, onTableQueryChange, mode]);
+
+  const table = useReactTable({
+    data: groupedData as unknown as TData[],
+    columns: columnDefs,
+    getRowId,
+    getCoreRowModel: getCoreRowModel(),
+    getExpandedRowModel: getExpandedRowModel(),
+    getSubRows: row => (row as unknown as GroupedData<TData>)?.subRows || [],
+    getSortedRowModel: mode === 'server' ? undefined : getSortedRowModel(),
+    getFilteredRowModel: mode === 'server' ? undefined : getFilteredRowModel(),
+    manualSorting: mode === 'server',
+    manualFiltering: mode === 'server',
+    onColumnVisibilityChange: handleColumnVisibilityChange,
+    globalFilterFn: mode === 'server' ? undefined : 'auto',
+    initialState: { columnVisibility: initialColumnVisibility },
+    filterFromLeafRows: true,
+    state: {
+      ...reactTableState,
+      columnVisibility,
+      expanded:
+        group_by && group_by !== defaultGroupOption.id ? true : undefined
+    }
+  });
+
+  const updateTableQuery = useCallback((fn: TableQueryUpdateFn) => {
+    setTableQuery(prev => fn(prev));
+  }, []);
+
+  const loadMoreData = useCallback(() => {
+    if (mode === 'server' && onLoadMore) onLoadMore();
+  }, [mode, onLoadMore]);
+
+  const searchQuery = query?.search;
+  useEffect(() => {
+    if (searchQuery) {
+      setTableQuery(prev => ({ ...prev, search: searchQuery }));
+    }
+  }, [searchQuery]);
+
+  const rowCount = (() => {
+    try {
+      return table.getRowModel().rows.length;
+    } catch {
+      return data.length;
+    }
+  })();
+
+  const hasData = rowCount > 0 || isLoading;
+
+  const hasActiveQueryFlag = useMemo(
+    () => computeHasActiveQuery(tableQuery, defaultSort),
+    [tableQuery, defaultSort]
+  );
+
+  const isZeroState = !hasData && !hasActiveQueryFlag;
+  const isEmptyState = !hasData && hasActiveQueryFlag;
+
+  // The filter bar shows whenever there's data OR an active query. The pure
+  // zero state (no data + no query) keeps the surface clean.
+  const shouldShowFilters = hasData || hasActiveQueryFlag;
+
+  const contextValue: DataViewContextType<TData> = useMemo(
+    () => ({
+      table,
+      fields: effectiveFields,
+      rootFields: fields,
+      data,
+      mode,
+      isLoading,
+      loadMoreData,
+      tableQuery,
+      updateTableQuery,
+      onDisplaySettingsReset,
+      defaultSort,
+      totalRowCount,
+      loadingRowCount,
+      onRowClick,
+      shouldShowFilters,
+      columnVisibility,
+      setColumnVisibility: handleColumnVisibilityChange,
+      views,
+      activeView,
+      setActiveView,
+      registerFieldsForView,
+      hasData,
+      hasActiveQuery: hasActiveQueryFlag,
+      isZeroState,
+      isEmptyState
+    }),
+    [
+      table,
+      effectiveFields,
+      fields,
+      data,
+      mode,
+      isLoading,
+      loadMoreData,
+      tableQuery,
+      updateTableQuery,
+      onDisplaySettingsReset,
+      defaultSort,
+      totalRowCount,
+      loadingRowCount,
+      onRowClick,
+      shouldShowFilters,
+      columnVisibility,
+      handleColumnVisibilityChange,
+      views,
+      activeView,
+      setActiveView,
+      registerFieldsForView,
+      hasData,
+      hasActiveQueryFlag,
+      isZeroState,
+      isEmptyState
+    ]
+  );
+
+  return <DataViewContext value={contextValue}>{children}</DataViewContext>;
+}
+
+DataViewRoot.displayName = 'DataView';
+
+// biome-ignore lint/suspicious/noShadowRestrictedNames: public component name intentionally matches the package export
+export const DataView = Object.assign(DataViewRoot, {
+  List: DataViewList,
+  Custom: DataViewCustom,
+  DisplayAccess: DisplayAccess,
+  EmptyState: DataViewEmptyState,
+  ZeroState: DataViewZeroState,
+  ViewSwitcher: ViewSwitcher,
+  Toolbar: Toolbar,
+  Search: DataViewSearch,
+  Filters: Filters,
+  DisplayControls: DisplayControls
+});

--- a/packages/raystack/components/data-view/data-view.tsx
+++ b/packages/raystack/components/data-view/data-view.tsx
@@ -19,7 +19,6 @@ import { Filters } from './components/filters';
 import { DataViewList } from './components/list';
 import { DataViewSearch } from './components/search';
 import { Toolbar } from './components/toolbar';
-import { ViewSwitcher } from './components/view-switcher';
 import { DataViewZeroState } from './components/zero-state';
 import { DataViewContext } from './context';
 import {
@@ -309,7 +308,6 @@ export const DataView = Object.assign(DataViewRoot, {
   DisplayAccess: DisplayAccess,
   EmptyState: DataViewEmptyState,
   ZeroState: DataViewZeroState,
-  ViewSwitcher: ViewSwitcher,
   Toolbar: Toolbar,
   Search: DataViewSearch,
   Filters: Filters,

--- a/packages/raystack/components/data-view/data-view.types.tsx
+++ b/packages/raystack/components/data-view/data-view.types.tsx
@@ -1,0 +1,267 @@
+import type {
+  ColumnDef,
+  Table,
+  Updater,
+  VisibilityState
+} from '@tanstack/table-core';
+import type {
+  DataTableFilterOperatorTypes,
+  FilterOperatorTypes,
+  FilterSelectOption,
+  FilterTypes,
+  FilterValueType
+} from '~/types/filters';
+import type { BaseSelectProps } from '../select/select-root';
+
+export type DataViewMode = 'client' | 'server';
+
+export const SortOrders = {
+  ASC: 'asc',
+  DESC: 'desc'
+} as const;
+
+type SortOrdersKeys = keyof typeof SortOrders;
+export type SortOrdersValues = (typeof SortOrders)[SortOrdersKeys];
+
+export interface DataViewSort {
+  name: string;
+  order: SortOrdersValues;
+}
+
+export interface DataViewFilterValues {
+  value: any;
+  boolValue?: boolean;
+  stringValue?: string;
+  numberValue?: number;
+}
+
+export interface InternalFilter extends DataViewFilterValues {
+  _type?: FilterTypes;
+  _dataType?: FilterValueType;
+  name: string;
+  operator: FilterOperatorTypes;
+}
+
+export interface DataViewFilter extends DataViewFilterValues {
+  name: string;
+  operator: DataTableFilterOperatorTypes;
+}
+
+export interface InternalQuery {
+  filters?: InternalFilter[];
+  sort?: DataViewSort[];
+  group_by?: string[];
+  offset?: number;
+  limit?: number;
+  search?: string;
+}
+
+export interface DataViewQuery extends Omit<InternalQuery, 'filters'> {
+  filters?: DataViewFilter[];
+}
+
+/**
+ * Renderer-agnostic field metadata. One entry per logical column of the data
+ * model. Declared once on `<DataView>`; drives filter, sort, group, and
+ * visibility behaviour across every renderer. Cell/header rendering belongs on
+ * each renderer's own column spec, not here.
+ */
+export interface DataViewField<TData = any> {
+  accessorKey: string;
+  /** Human-readable label shown in filter chips, Display controls, and the default Table header. */
+  label: string;
+  icon?: React.ReactNode;
+
+  // filter capability
+  filterable?: boolean;
+  filterType?: FilterTypes;
+  dataType?: FilterValueType;
+  filterOptions?: FilterSelectOption[];
+  defaultFilterValue?: unknown;
+  filterProps?: {
+    select?: BaseSelectProps;
+  };
+
+  // ordering / grouping / visibility capability
+  sortable?: boolean;
+  groupable?: boolean;
+  hideable?: boolean;
+  defaultHidden?: boolean;
+
+  // group-header presentation (used by any renderer that groups)
+  showGroupCount?: boolean;
+  groupCountMap?: Record<string, number>;
+  groupLabelsMap?: Record<string, string>;
+}
+
+/**
+ * Unified column spec for `DataView.List`. The same shape is used for both
+ * `variant="table"` and `variant="list"`. The `header` slot is only rendered
+ * when headers are visible (default for `variant="table"`).
+ */
+export interface DataViewListColumn<TData, TValue = unknown> {
+  accessorKey: string;
+  /** TanStack-style cell renderer. */
+  cell?: ColumnDef<TData, TValue>['cell'];
+  /** TanStack-style header renderer. Overrides the field's `label`. */
+  header?: ColumnDef<TData, TValue>['header'];
+  /** CSS grid track width. `1fr`, `auto`, `'200px'`, `'minmax(80px, 1fr)'`, or a number (pixels). Defaults to `1fr`. */
+  width?: string | number;
+  classNames?: { cell?: string; header?: string };
+  styles?: { cell?: React.CSSProperties; header?: React.CSSProperties };
+}
+
+/**
+ * Multi-view configuration entry. `value` must match the `name` prop on a
+ * renderer; `label` is shown in the view switcher.
+ */
+export interface ViewSpec {
+  value: string;
+  label: string;
+  icon?: React.ReactNode;
+}
+
+/**
+ * Local resolver for a group_by key. Lets a string key in `group_by` (which
+ * stays on the wire untouched for server-mode round-trips) map to a function
+ * that returns a bucket id per row.
+ */
+export type GroupByResolver<TData> = (row: TData) => string;
+
+export interface DataViewProps<TData> {
+  data: TData[];
+  /** Renderer-agnostic field metadata. Drives filter/sort/group/visibility. */
+  fields: DataViewField<TData>[];
+  /** Initial query. Transformed to the internal shape on mount. */
+  query?: DataViewQuery;
+  mode?: DataViewMode;
+  isLoading?: boolean;
+  totalRowCount?: number;
+  loadingRowCount?: number;
+  onTableQueryChange?: (query: DataViewQuery) => void;
+  defaultSort: DataViewSort;
+  onLoadMore?: () => Promise<void> | void;
+  onRowClick?: (row: TData) => void;
+  onColumnVisibilityChange?: (columnVisibility: VisibilityState) => void;
+  /** Stable unique id per row (React key). */
+  getRowId?: (row: TData, index: number) => string;
+  /** Multi-view configuration. When set, `DataView.DisplayControls` renders a view switcher and renderers gate themselves on the active view via their `name` prop. */
+  views?: ViewSpec[];
+  /** Default active view (uncontrolled). Should match a `views[].value`. */
+  defaultView?: string;
+  /** Active view (controlled). */
+  view?: string;
+  /** Called when the active view changes. */
+  onViewChange?: (view: string) => void;
+  /**
+   * Optional local resolver map for non-accessor `group_by` keys. The wire
+   * format (`group_by: string[]`) stays unchanged; resolvers run in client mode
+   * to compute the bucket id per row when a key matches one in this map.
+   */
+  groupByResolvers?: Record<string, GroupByResolver<TData>>;
+}
+
+export type DataViewListClassNames = {
+  root?: string;
+  header?: string;
+  headerCell?: string;
+  row?: string;
+  cell?: string;
+  groupHeader?: string;
+};
+
+export interface DataViewListProps<TData, TValue = unknown> {
+  /** Multi-view name. When set, the renderer gates itself on the active view. */
+  name?: string;
+  /** Visual variant. `table` renders headers and uses `role="table"`; `list` renders no headers and uses `role="list"`. Default `list`. */
+  variant?: 'table' | 'list';
+  /** Override the header row visibility. Defaults to `variant === 'table'`. */
+  showHeaders?: boolean;
+  /** Override the ARIA role applied to the renderer root. Derived from `variant` by default. */
+  role?: 'table' | 'list';
+  /** Optional view-scoped field override. Full replacement of root `fields` for this view's active session. */
+  fields?: DataViewField<TData>[];
+
+  /** Column render specs (cell/header/width/styles). */
+  columns: DataViewListColumn<TData, TValue>[];
+  /**
+   * Initial row-height estimate (px). Rows are auto-measured after they paint,
+   * so this is only used until the first measurement. Default 40 for
+   * `variant="table"`, 56 for `variant="list"`.
+   */
+  estimatedRowHeight?: number;
+  /** When true, only viewport-visible rows render. Parent must have a fixed height. */
+  virtualized?: boolean;
+  /** Render thin dividers between rows. Defaults to true for `variant="table"`. */
+  showDividers?: boolean;
+  /** Show group section headers when grouping is active. Default true. */
+  showGroupHeaders?: boolean;
+  /** When true, group headers stick under the table header while scrolling. Default false. */
+  stickyGroupHeader?: boolean;
+  classNames?: DataViewListClassNames;
+}
+
+export type TableQueryUpdateFn = (query: InternalQuery) => InternalQuery;
+
+export type DataViewContextType<TData> = {
+  table: Table<TData>;
+  /** Effective fields for the active view (= override fields if registered, else root fields). */
+  fields: DataViewField<TData>[];
+  /** Root-declared fields, unchanged by view overrides. */
+  rootFields: DataViewField<TData>[];
+
+  // data
+  data: TData[];
+  isLoading?: boolean;
+  loadMoreData: () => void;
+  mode: DataViewMode;
+  defaultSort: DataViewSort;
+  tableQuery: InternalQuery;
+  totalRowCount?: number;
+  loadingRowCount?: number;
+  onDisplaySettingsReset: () => void;
+  updateTableQuery: (fn: TableQueryUpdateFn) => void;
+  onRowClick?: (row: TData) => void;
+  shouldShowFilters: boolean;
+
+  // visibility (lifted to context per RFC §"Unified Column Visibility via DisplayAccess")
+  columnVisibility: VisibilityState;
+  setColumnVisibility: (value: Updater<VisibilityState>) => void;
+
+  // multi-view
+  views?: ViewSpec[];
+  activeView?: string;
+  setActiveView: (view: string) => void;
+  /** Called by each renderer on mount to register its `fields` override for its `name`. Returns a cleanup function. */
+  registerFieldsForView: (
+    name: string,
+    fields: DataViewField<TData>[]
+  ) => () => void;
+
+  // global derived state — shared across all renderers and sibling components
+  hasData: boolean;
+  hasActiveQuery: boolean;
+  isZeroState: boolean;
+  isEmptyState: boolean;
+};
+
+export interface ColumnData {
+  label: string;
+  id: string;
+  isVisible?: boolean;
+}
+
+interface SubRows<_T> {}
+
+export interface GroupedData<T> extends SubRows<T> {
+  label: string;
+  group_key: string;
+  subRows: T[];
+  count?: number;
+  showGroupCount?: boolean;
+}
+
+export const defaultGroupOption = {
+  id: '--',
+  label: 'No grouping'
+};

--- a/packages/raystack/components/data-view/data-view.types.tsx
+++ b/packages/raystack/components/data-view/data-view.types.tsx
@@ -118,7 +118,8 @@ export interface DataViewListColumn<TData, TValue = unknown> {
 export interface ViewSpec {
   value: string;
   label: string;
-  icon?: React.ReactNode;
+  /** Optional icon rendered before the view's label in the switcher tab. */
+  leadingIcon?: React.ReactNode;
 }
 
 /**

--- a/packages/raystack/components/data-view/hooks/useDataView.tsx
+++ b/packages/raystack/components/data-view/hooks/useDataView.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { useContext } from 'react';
+
+import { DataViewContext } from '../context';
+import { DataViewContextType } from '../data-view.types';
+
+export const useDataView = <TData = any>(): DataViewContextType<TData> => {
+  const ctx = useContext(DataViewContext);
+  if (ctx === null) {
+    throw new Error('useDataView must be used inside of a <DataView> provider');
+  }
+  return ctx as DataViewContextType<TData>;
+};

--- a/packages/raystack/components/data-view/hooks/useElementHeight.tsx
+++ b/packages/raystack/components/data-view/hooks/useElementHeight.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Measures a DOM element's height and keeps it up to date via `ResizeObserver`.
+ * Returns a ref callback to attach to the element, plus the latest height.
+ *
+ * Used by the List renderer to track the column-header row's height so sticky
+ * group headers and the sticky-group anchor can position themselves directly
+ * underneath it, regardless of variant, custom header content, or hidden
+ * headers.
+ */
+export function useElementHeight() {
+  const [height, setHeight] = useState(0);
+  const observerRef = useRef<ResizeObserver | null>(null);
+  const elementRef = useRef<HTMLElement | null>(null);
+
+  const cleanup = useCallback(() => {
+    if (observerRef.current) {
+      observerRef.current.disconnect();
+      observerRef.current = null;
+    }
+  }, []);
+
+  const ref = useCallback(
+    (el: HTMLElement | null) => {
+      cleanup();
+      elementRef.current = el;
+      if (!el) {
+        setHeight(0);
+        return;
+      }
+      setHeight(el.getBoundingClientRect().height);
+      if (typeof ResizeObserver === 'undefined') return;
+      const observer = new ResizeObserver(entries => {
+        const entry = entries[0];
+        if (!entry) return;
+        const next = entry.contentRect.height;
+        setHeight(prev => (Math.abs(prev - next) < 0.5 ? prev : next));
+      });
+      observer.observe(el);
+      observerRef.current = observer;
+    },
+    [cleanup]
+  );
+
+  useEffect(() => cleanup, [cleanup]);
+
+  return [ref, height] as const;
+}

--- a/packages/raystack/components/data-view/hooks/useFilters.tsx
+++ b/packages/raystack/components/data-view/hooks/useFilters.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import {
+  FilterOperatorTypes,
+  FilterType,
+  filterOperators
+} from '~/types/filters';
+import { DataViewField } from '../data-view.types';
+import { getDataType } from '../utils/filter-operations';
+import { useDataView } from './useDataView';
+
+export function useFilters<TData>() {
+  const { updateTableQuery } = useDataView<TData>();
+
+  function onAddFilter(field: DataViewField<TData>) {
+    const options = field.filterOptions || [];
+    const filterType = field.filterType || FilterType.string;
+    const dataType = getDataType({ filterType, dataType: field.dataType });
+    const defaultFilter = filterOperators[filterType][0];
+    const defaultValue =
+      field.defaultFilterValue ??
+      (filterType === FilterType.date
+        ? new Date()
+        : filterType === FilterType.select
+          ? options[0]?.value
+          : '');
+
+    updateTableQuery(query => ({
+      ...query,
+      filters: [
+        ...(query.filters || []),
+        {
+          _dataType: dataType,
+          _type: filterType,
+          name: field.accessorKey,
+          value: defaultValue,
+          operator: defaultFilter.value
+        }
+      ]
+    }));
+  }
+
+  function handleRemoveFilter(fieldAccessor: string) {
+    updateTableQuery(query => ({
+      ...query,
+      filters: query.filters?.filter(f => f.name !== fieldAccessor)
+    }));
+  }
+
+  function handleFilterValueChange(fieldAccessor: string, value: any) {
+    updateTableQuery(query => ({
+      ...query,
+      filters: query.filters?.map(f =>
+        f.name === fieldAccessor ? { ...f, value } : f
+      )
+    }));
+  }
+
+  function handleFilterOperationChange(
+    fieldAccessor: string,
+    operator: FilterOperatorTypes
+  ) {
+    updateTableQuery(query => ({
+      ...query,
+      filters: query.filters?.map(f =>
+        f.name === fieldAccessor ? { ...f, operator } : f
+      )
+    }));
+  }
+
+  return {
+    onAddFilter,
+    handleRemoveFilter,
+    handleFilterValueChange,
+    handleFilterOperationChange
+  };
+}

--- a/packages/raystack/components/data-view/hooks/useInfiniteScroll.tsx
+++ b/packages/raystack/components/data-view/hooks/useInfiniteScroll.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+interface UseInfiniteScrollParams {
+  /** When false, no observer is attached. */
+  enabled: boolean;
+  /** Sentinel element observed near the end of the list. */
+  sentinelRef: React.RefObject<Element | null>;
+  /** Scroll container used as the IntersectionObserver root. */
+  scrollRef: React.RefObject<Element | null>;
+  /** Suppresses the trigger while a previous fetch is in flight. */
+  isLoading?: boolean;
+  /** Fires when the sentinel intersects the root viewport. */
+  onLoadMore?: () => void;
+  /**
+   * Distance past the bottom edge that still counts as "near the end". The
+   * sentinel fires once the user scrolls within this many pixels of it.
+   * Default 200.
+   */
+  rootMargin?: number;
+}
+
+/**
+ * Single sentinel-based load-more. Used by both virtualized and non-virtualized
+ * renderers so behaviour stays identical regardless of the row model.
+ *
+ * The sentinel itself is a sibling rendered after the rows by the caller; this
+ * hook only attaches the observer. `isLoading` and `onLoadMore` are tracked
+ * through refs so the observer doesn't re-attach on every render.
+ */
+export function useInfiniteScroll({
+  enabled,
+  sentinelRef,
+  scrollRef,
+  isLoading,
+  onLoadMore,
+  rootMargin = 200
+}: UseInfiniteScrollParams) {
+  const onLoadMoreRef = useRef(onLoadMore);
+  const isLoadingRef = useRef(isLoading);
+
+  onLoadMoreRef.current = onLoadMore;
+  isLoadingRef.current = isLoading;
+
+  useEffect(() => {
+    if (!enabled) return;
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const root = scrollRef.current ?? null;
+
+    const observer = new IntersectionObserver(
+      entries => {
+        const entry = entries[0];
+        if (!entry?.isIntersecting) return;
+        if (isLoadingRef.current) return;
+        onLoadMoreRef.current?.();
+      },
+      {
+        root,
+        rootMargin: `0px 0px ${rootMargin}px 0px`,
+        threshold: 0
+      }
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+    // sentinelRef/scrollRef are stable refs; re-attach only when enable flips.
+  }, [enabled, rootMargin, sentinelRef, scrollRef]);
+}

--- a/packages/raystack/components/data-view/hooks/useStickyGroupAnchor.tsx
+++ b/packages/raystack/components/data-view/hooks/useStickyGroupAnchor.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useCallback, useLayoutEffect, useState } from 'react';
+import { GroupedData } from '../data-view.types';
+
+interface UseStickyGroupAnchorParams<TData> {
+  enabled: boolean;
+  groupHeaderList: {
+    index: number;
+    start: number;
+    data: GroupedData<TData>;
+  }[];
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>;
+}
+
+interface UseStickyGroupAnchorResult<TData> {
+  stickyGroup: GroupedData<TData> | null;
+  stickyGroupIndex: number | null;
+  recompute: () => void;
+}
+
+/**
+ * Tracks the active group for a virtualized sticky group anchor. Picks the
+ * latest group whose `start` offset has been scrolled past so the anchor's
+ * content stays in sync with the natural section header underneath.
+ *
+ * The consumer hides the natural row at `stickyGroupIndex` so it doesn't slide
+ * past the anchor.
+ */
+export function useStickyGroupAnchor<TData>({
+  enabled,
+  groupHeaderList,
+  scrollContainerRef
+}: UseStickyGroupAnchorParams<TData>): UseStickyGroupAnchorResult<TData> {
+  const [stickyGroup, setStickyGroup] = useState<GroupedData<TData> | null>(
+    null
+  );
+  const [stickyGroupIndex, setStickyGroupIndex] = useState<number | null>(null);
+
+  const recompute = useCallback(() => {
+    if (!enabled || groupHeaderList.length === 0) {
+      setStickyGroup(null);
+      setStickyGroupIndex(null);
+      return;
+    }
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    const scrollTop = el.scrollTop;
+
+    // Binary search: largest `i` such that groupHeaderList[i].start <= scrollTop.
+    // `groupHeaderList` is built in row order so `start` is strictly increasing,
+    // which makes this safe for thousands of groups (typical large-dataset case).
+    let lo = 0;
+    let hi = groupHeaderList.length - 1;
+    let currentIdx = -1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      if (groupHeaderList[mid].start <= scrollTop) {
+        currentIdx = mid;
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+
+    if (currentIdx < 0) {
+      setStickyGroup(null);
+      setStickyGroupIndex(null);
+      return;
+    }
+
+    const next = groupHeaderList[currentIdx];
+    // React bails out on identical values, but we short-circuit before the
+    // setState calls anyway so we don't allocate or schedule needlessly.
+    setStickyGroupIndex(prev => (prev === next.index ? prev : next.index));
+    setStickyGroup(prev => (prev === next.data ? prev : next.data));
+  }, [enabled, groupHeaderList, scrollContainerRef]);
+
+  useLayoutEffect(() => {
+    recompute();
+  }, [recompute]);
+
+  return { stickyGroup, stickyGroupIndex, recompute };
+}

--- a/packages/raystack/components/data-view/hooks/useVirtualRows.tsx
+++ b/packages/raystack/components/data-view/hooks/useVirtualRows.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useVirtualizer, type VirtualItem } from '@tanstack/react-virtual';
+
+interface UseVirtualRowsParams<TRow> {
+  enabled: boolean;
+  rows: TRow[];
+  scrollRef: React.RefObject<HTMLElement | null>;
+  estimatedRowHeight: number;
+  estimateSize: (row: TRow | undefined, index: number) => number;
+  overscan?: number;
+}
+
+interface UseVirtualRowsResult {
+  totalSize: number;
+  items: VirtualItem[];
+  measureRef: ((el: HTMLElement | null) => void) | undefined;
+}
+
+const DEFAULT_OVERSCAN = 8;
+
+/**
+ * Wraps `useVirtualizer` with auto-measurement. Consumers pass an initial
+ * `estimatedRowHeight` and an `estimateSize(row, i)` that can return a
+ * different size for special rows (e.g. group headers). After paint, the
+ * virtualizer's `measureElement` re-measures each row so variable-height
+ * content settles correctly.
+ *
+ * When `enabled` is false the hook still calls `useVirtualizer` (so hook order
+ * stays stable) but reports `count: 0` and surfaces empty values — the
+ * consumer renders rows in natural flow instead.
+ */
+export function useVirtualRows<TRow>({
+  enabled,
+  rows,
+  scrollRef,
+  estimatedRowHeight,
+  estimateSize,
+  overscan = DEFAULT_OVERSCAN
+}: UseVirtualRowsParams<TRow>): UseVirtualRowsResult {
+  const virtualizer = useVirtualizer({
+    count: enabled ? rows.length : 0,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: index => estimateSize(rows[index], index),
+    overscan,
+    initialRect:
+      typeof window === 'undefined'
+        ? { width: 0, height: estimatedRowHeight * overscan }
+        : undefined
+  });
+
+  if (!enabled) {
+    return { totalSize: 0, items: [], measureRef: undefined };
+  }
+
+  return {
+    totalSize: virtualizer.getTotalSize(),
+    items: virtualizer.getVirtualItems(),
+    measureRef: virtualizer.measureElement
+  };
+}

--- a/packages/raystack/components/data-view/index.ts
+++ b/packages/raystack/components/data-view/index.ts
@@ -5,7 +5,6 @@ export type { DataViewDisplayAccessProps } from './components/display-access';
 export type { DataViewEmptyStateProps } from './components/empty-state';
 export type { DataViewFiltersProps } from './components/filters';
 export type { DataViewSearchProps } from './components/search';
-export type { DataViewViewSwitcherProps } from './components/view-switcher';
 export type { DataViewZeroStateProps } from './components/zero-state';
 
 export { DataView } from './data-view';

--- a/packages/raystack/components/data-view/index.ts
+++ b/packages/raystack/components/data-view/index.ts
@@ -1,0 +1,30 @@
+export { EmptyFilterValue } from '~/types/filters';
+
+export type { DataViewCustomProps } from './components/custom';
+export type { DataViewDisplayAccessProps } from './components/display-access';
+export type { DataViewEmptyStateProps } from './components/empty-state';
+export type { DataViewFiltersProps } from './components/filters';
+export type { DataViewSearchProps } from './components/search';
+export type { DataViewViewSwitcherProps } from './components/view-switcher';
+export type { DataViewZeroStateProps } from './components/zero-state';
+
+export { DataView } from './data-view';
+export type {
+  DataViewContextType,
+  DataViewField,
+  DataViewFilter,
+  DataViewListClassNames,
+  DataViewListColumn,
+  DataViewListProps,
+  DataViewMode,
+  DataViewProps,
+  DataViewQuery,
+  DataViewSort,
+  GroupByResolver,
+  InternalFilter,
+  InternalQuery,
+  SortOrdersValues,
+  ViewSpec
+} from './data-view.types';
+export { defaultGroupOption } from './data-view.types';
+export { useDataView } from './hooks/useDataView';

--- a/packages/raystack/components/data-view/utils/filter-operations.tsx
+++ b/packages/raystack/components/data-view/utils/filter-operations.tsx
@@ -1,0 +1,226 @@
+import type { FilterFn } from '@tanstack/table-core';
+import dayjs from 'dayjs';
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+
+import {
+  DataTableFilterOperatorTypes,
+  DateFilterOperatorType,
+  EmptyFilterValue,
+  FilterOperatorTypes,
+  FilterType,
+  FilterTypes,
+  FilterValue,
+  FilterValueType,
+  MultiSelectFilterOperatorType,
+  NumberFilterOperatorType,
+  SelectFilterOperatorType,
+  StringFilterOperatorType
+} from '~/types/filters';
+import { DataViewFilterValues } from '../data-view.types';
+
+dayjs.extend(isSameOrAfter);
+dayjs.extend(isSameOrBefore);
+
+export type FilterFunctionsMap = {
+  number: Record<NumberFilterOperatorType, FilterFn<unknown>>;
+  string: Record<StringFilterOperatorType, FilterFn<unknown>>;
+  date: Record<DateFilterOperatorType, FilterFn<unknown>>;
+  select: Record<SelectFilterOperatorType, FilterFn<unknown>>;
+  multiselect: Record<MultiSelectFilterOperatorType, FilterFn<unknown>>;
+};
+
+export const filterOperationsMap: FilterFunctionsMap = {
+  number: {
+    eq: (row, columnId, filterValue: FilterValue) =>
+      Number(row.getValue(columnId)) === Number(filterValue.value),
+    neq: (row, columnId, filterValue: FilterValue) =>
+      Number(row.getValue(columnId)) !== Number(filterValue.value),
+    lt: (row, columnId, filterValue: FilterValue) =>
+      Number(row.getValue(columnId)) < Number(filterValue.value),
+    lte: (row, columnId, filterValue: FilterValue) =>
+      Number(row.getValue(columnId)) <= Number(filterValue.value),
+    gt: (row, columnId, filterValue: FilterValue) =>
+      Number(row.getValue(columnId)) > Number(filterValue.value),
+    gte: (row, columnId, filterValue: FilterValue) =>
+      Number(row.getValue(columnId)) >= Number(filterValue.value)
+  },
+  string: {
+    eq: (row, columnId, filterValue: FilterValue) =>
+      String(row.getValue(columnId)).toLowerCase() ===
+      String(filterValue.value).toLowerCase(),
+    neq: (row, columnId, filterValue: FilterValue) =>
+      String(row.getValue(columnId)).toLowerCase() !==
+      String(filterValue.value).toLowerCase(),
+    contains: (row, columnId, filterValue: FilterValue) => {
+      const columnValue = String(row.getValue(columnId)).toLowerCase();
+      const filterStr = String(filterValue.value).toLowerCase();
+      return columnValue.includes(filterStr);
+    },
+    starts_with: (row, columnId, filterValue: FilterValue) => {
+      const columnValue = String(row.getValue(columnId)).toLowerCase();
+      const filterStr = String(filterValue.value).toLowerCase();
+      return columnValue.startsWith(filterStr);
+    },
+    ends_with: (row, columnId, filterValue: FilterValue) => {
+      const columnValue = String(row.getValue(columnId)).toLowerCase();
+      const filterStr = String(filterValue.value).toLowerCase();
+      return columnValue.endsWith(filterStr);
+    }
+  },
+  date: {
+    eq: (row, columnId, filterValue: FilterValue) =>
+      dayjs(row.getValue(columnId)).isSame(dayjs(filterValue.date), 'day'),
+    neq: (row, columnId, filterValue: FilterValue) =>
+      !dayjs(row.getValue(columnId)).isSame(dayjs(filterValue.date), 'day'),
+    lt: (row, columnId, filterValue: FilterValue) =>
+      dayjs(row.getValue(columnId)).isBefore(dayjs(filterValue.date), 'day'),
+    lte: (row, columnId, filterValue: FilterValue) =>
+      dayjs(row.getValue(columnId)).isSameOrBefore(
+        dayjs(filterValue.date),
+        'day'
+      ),
+    gt: (row, columnId, filterValue: FilterValue) =>
+      dayjs(row.getValue(columnId)).isAfter(dayjs(filterValue.date), 'day'),
+    gte: (row, columnId, filterValue: FilterValue) =>
+      dayjs(row.getValue(columnId)).isSameOrAfter(
+        dayjs(filterValue.date),
+        'day'
+      )
+  },
+  select: {
+    eq: (row, columnId, filterValue: FilterValue) => {
+      if (String(filterValue.value) === EmptyFilterValue)
+        return row.getValue(columnId) === '';
+      return String(row.getValue(columnId)) === String(filterValue.value);
+    },
+    neq: (row, columnId, filterValue: FilterValue) => {
+      if (String(filterValue.value) === EmptyFilterValue)
+        return row.getValue(columnId) !== '';
+      return String(row.getValue(columnId)) !== String(filterValue.value);
+    }
+  },
+  multiselect: {
+    in: (row, columnId, filterValue: FilterValue) => {
+      if (!Array.isArray(filterValue.value)) return false;
+      return filterValue.value
+        .map(value => (value === EmptyFilterValue ? '' : String(value)))
+        .includes(String(row.getValue(columnId)));
+    },
+    notin: (row, columnId, filterValue: FilterValue) => {
+      if (!Array.isArray(filterValue.value)) return false;
+      return !filterValue.value
+        .map(value => (value === EmptyFilterValue ? '' : String(value)))
+        .includes(String(row.getValue(columnId)));
+    }
+  }
+} as const;
+
+export function getFilterFn<T extends keyof FilterFunctionsMap>(
+  type: T,
+  operator: FilterOperatorTypes
+) {
+  // @ts-expect-error FilterOperatorTypes is a union of all possible operators
+  return filterOperationsMap[type][operator];
+}
+
+const handleStringBasedTypes = (
+  filterType: FilterTypes,
+  value: any,
+  operator?: FilterOperatorTypes | DataTableFilterOperatorTypes
+): DataViewFilterValues => {
+  switch (filterType) {
+    case FilterType.date: {
+      const dateValue = dayjs(value);
+      let stringValue = '';
+      if (dateValue.isValid()) {
+        try {
+          stringValue = dateValue.toISOString();
+        } catch {
+          stringValue = '';
+        }
+      }
+      return { value, stringValue };
+    }
+    case FilterType.select:
+      return {
+        stringValue: value === EmptyFilterValue ? '' : value,
+        value
+      };
+    case FilterType.multiselect:
+      return {
+        value,
+        stringValue: value
+          .map((v: any) => (v === EmptyFilterValue ? '' : String(v)))
+          .join()
+      };
+    case FilterType.string: {
+      let processedValue = value;
+      if (operator === 'contains') processedValue = `%${value}%`;
+      else if (operator === 'starts_with') processedValue = `${value}%`;
+      else if (operator === 'ends_with') processedValue = `%${value}`;
+      else if (operator === 'ilike') {
+        if (!value.includes('%')) processedValue = `%${value}%`;
+      }
+      return { stringValue: processedValue, value };
+    }
+    default:
+      return { stringValue: value, value };
+  }
+};
+
+export const getFilterOperator = ({
+  value,
+  filterType,
+  operator
+}: {
+  value: any;
+  filterType?: FilterTypes;
+  operator: FilterOperatorTypes;
+}): DataTableFilterOperatorTypes => {
+  if (value === EmptyFilterValue && filterType === FilterType.select)
+    return 'empty';
+  if (
+    filterType === FilterType.string &&
+    (operator === 'contains' ||
+      operator === 'starts_with' ||
+      operator === 'ends_with')
+  ) {
+    return 'ilike';
+  }
+  return operator as DataTableFilterOperatorTypes;
+};
+
+export const getFilterValue = ({
+  value,
+  dataType = 'string',
+  filterType = FilterType.string,
+  operator
+}: {
+  value: any;
+  dataType?: FilterValueType;
+  filterType?: FilterTypes;
+  operator?: FilterOperatorTypes | DataTableFilterOperatorTypes;
+}): DataViewFilterValues => {
+  if (dataType === 'boolean') return { boolValue: value, value };
+  if (dataType === 'number') return { numberValue: value, value };
+  return handleStringBasedTypes(filterType, value, operator);
+};
+
+export const getDataType = ({
+  filterType = FilterType.string,
+  dataType = 'string'
+}: {
+  dataType?: FilterValueType;
+  filterType?: FilterTypes;
+}): FilterValueType => {
+  switch (filterType) {
+    case FilterType.multiselect:
+    case FilterType.select:
+      return dataType;
+    case FilterType.date:
+      return 'string';
+    default:
+      return filterType;
+  }
+};

--- a/packages/raystack/components/data-view/utils/index.tsx
+++ b/packages/raystack/components/data-view/utils/index.tsx
@@ -1,0 +1,344 @@
+import type { ColumnDef, Row, Table } from '@tanstack/react-table';
+import { TableState } from '@tanstack/table-core';
+import dayjs from 'dayjs';
+
+import { FilterOperatorTypes, FilterType } from '~/types/filters';
+import {
+  DataViewField,
+  DataViewQuery,
+  DataViewSort,
+  defaultGroupOption,
+  GroupByResolver,
+  GroupedData,
+  InternalFilter,
+  InternalQuery,
+  SortOrders
+} from '../data-view.types';
+import {
+  getFilterFn,
+  getFilterOperator,
+  getFilterValue
+} from './filter-operations';
+
+export function queryToTableState(query: InternalQuery): Partial<TableState> {
+  const columnFilters =
+    query.filters
+      ?.filter(data => {
+        if (data._type === FilterType.date) return dayjs(data.value).isValid();
+        if (data.value !== '') return true;
+        return false;
+      })
+      ?.map(data => {
+        const valueObject =
+          data._type === FilterType.date
+            ? { date: data.value }
+            : { value: data.value };
+        return { value: valueObject, id: data?.name };
+      }) || [];
+
+  const sorting = query.sort?.map(data => ({
+    id: data?.name,
+    desc: data?.order === SortOrders.DESC
+  }));
+  return {
+    columnFilters,
+    sorting,
+    globalFilter: query.search
+  };
+}
+
+/**
+ * Convert field metadata to TanStack ColumnDefs. These carry filter/sort/group/
+ * visibility capability and the filter predicate. The `header` falls back to
+ * `field.label` so renderers that bypass their column spec still get the right
+ * default header text.
+ */
+export function fieldsToColumnDefs<TData>(
+  fields: DataViewField<TData>[] = [],
+  filters: InternalFilter[] = []
+): ColumnDef<TData>[] {
+  return fields.map(field => {
+    const colFilter = filters?.find(f => f.name === field.accessorKey);
+    const filterFn = colFilter?.operator
+      ? getFilterFn(field.filterType || FilterType.string, colFilter.operator)
+      : undefined;
+
+    return {
+      id: field.accessorKey,
+      accessorKey: field.accessorKey,
+      header: field.label,
+      enableColumnFilter: field.filterable ?? false,
+      enableSorting: field.sortable ?? false,
+      enableGrouping: field.groupable ?? false,
+      enableHiding: field.hideable ?? false,
+      filterFn
+    } as ColumnDef<TData>;
+  });
+}
+
+/**
+ * Bucket data into `GroupedData` entries keyed by `group_by`. When a resolver
+ * is supplied for that key, the resolver runs per-row; otherwise the field is
+ * accessed directly. Used in client mode only.
+ */
+export function groupData<TData>(
+  data: TData[],
+  group_by?: string,
+  fields: DataViewField<TData>[] = [],
+  resolvers: Record<string, GroupByResolver<TData>> = {}
+): GroupedData<TData>[] {
+  if (!data) return [];
+  if (!group_by || group_by === defaultGroupOption.id)
+    return data as GroupedData<TData>[];
+
+  const resolver = resolvers[group_by];
+
+  const groupMap = new Map<string, TData[]>();
+  data.forEach(currentData => {
+    const keyValue = resolver
+      ? resolver(currentData)
+      : ((currentData as Record<string, unknown>)[group_by] as string);
+    const bucketKey = keyValue == null ? '' : String(keyValue);
+    if (!groupMap.has(bucketKey)) groupMap.set(bucketKey, []);
+    groupMap.get(bucketKey)?.push(currentData);
+  });
+
+  const field = fields.find(f => f.accessorKey === group_by);
+  const showGroupCount = field?.showGroupCount || false;
+  const groupLabelsMap = field?.groupLabelsMap || {};
+  const groupCountMap = field?.groupCountMap || {};
+  const groupedData: GroupedData<TData>[] = [];
+
+  groupMap.forEach((value, key) => {
+    groupedData.push({
+      label: groupLabelsMap[key] || key,
+      group_key: key,
+      subRows: value,
+      count: groupCountMap[key] ?? value.length,
+      showGroupCount
+    });
+  });
+
+  return groupedData;
+}
+
+const generateFilterMap = (
+  filters: InternalFilter[] = []
+): Map<string, any> => {
+  return new Map(
+    filters
+      ?.filter(data => data._type === FilterType.select || data.value !== '')
+      .map(({ name, operator, value }) => [`${name}-${operator}`, value])
+  );
+};
+
+const generateSortMap = (sort: DataViewSort[] = []): Map<string, string> => {
+  return new Map(sort.map(({ name, order }) => [name, order]));
+};
+
+const isFilterChanged = (
+  oldFilters: InternalFilter[] = [],
+  newFilters: InternalFilter[] = []
+): boolean => {
+  const oldFilterMap = generateFilterMap(oldFilters);
+  const newFilterMap = generateFilterMap(newFilters);
+  if (oldFilterMap.size !== newFilterMap.size) return true;
+  return [...newFilterMap].some(
+    ([key, value]) => oldFilterMap.get(key) !== value
+  );
+};
+
+const isSortChanged = (
+  oldSort: DataViewSort[] = [],
+  newSort: DataViewSort[] = []
+): boolean => {
+  if (oldSort.length !== newSort.length) return true;
+  const oldSortMap = generateSortMap(oldSort);
+  const newSortMap = generateSortMap(newSort);
+  return [...newSortMap].some(([key, order]) => oldSortMap.get(key) !== order);
+};
+
+const isGroupChanged = (
+  oldGroupBy: string[] = [],
+  newGroupBy: string[] = []
+): boolean => {
+  if (oldGroupBy.length !== newGroupBy.length) return true;
+  const oldGroupSet = new Set(oldGroupBy);
+  return newGroupBy.some(item => !oldGroupSet.has(item));
+};
+
+const isSearchChanged = (oldSearch?: string, newSearch?: string): boolean =>
+  oldSearch !== newSearch;
+
+/**
+ * True when there's an active filter, search, or sort/group differing from the
+ * declared defaults. Used to distinguish zero state from empty state.
+ */
+export const hasActiveQuery = (
+  tableQuery: InternalQuery,
+  defaultSort: DataViewSort
+): boolean => {
+  const hasFilters =
+    (tableQuery?.filters && tableQuery.filters.length > 0) || false;
+  const hasSearch = Boolean(
+    tableQuery?.search && tableQuery.search.trim() !== ''
+  );
+  const sortChanged = isSortChanged([defaultSort], tableQuery.sort || []);
+  const groupChanged = isGroupChanged(
+    [defaultGroupOption.id],
+    tableQuery.group_by || []
+  );
+  return hasFilters || hasSearch || sortChanged || groupChanged;
+};
+
+export const hasQueryChanged = (
+  oldQuery: InternalQuery | null,
+  newQuery: InternalQuery
+): boolean => {
+  if (!oldQuery) return true;
+  return (
+    isFilterChanged(oldQuery.filters, newQuery.filters) ||
+    isSortChanged(oldQuery.sort, newQuery.sort) ||
+    isGroupChanged(oldQuery.group_by, newQuery.group_by) ||
+    isSearchChanged(oldQuery.search, newQuery.search)
+  );
+};
+
+export function getInitialColumnVisibility<TData>(
+  fields: DataViewField<TData>[] = []
+): Record<string, boolean> {
+  return fields.reduce<Record<string, boolean>>((acc, field) => {
+    acc[field.accessorKey] = field.defaultHidden ? false : true;
+    return acc;
+  }, {});
+}
+
+export function transformToDataViewQuery(query: InternalQuery): DataViewQuery {
+  const { group_by = [], filters = [], sort = [], ...rest } = query;
+  const sanitizedGroupBy = group_by?.filter(
+    key => key !== defaultGroupOption.id
+  );
+
+  const sanitizedFilters =
+    filters
+      ?.filter(data => {
+        if (data._type === FilterType.select) return true;
+        if (data._type === FilterType.date) return dayjs(data.value).isValid();
+        if (data.value !== '') return true;
+        return false;
+      })
+      ?.map(data => ({
+        name: data.name,
+        operator: getFilterOperator({
+          operator: data.operator,
+          value: data.value,
+          filterType: data._type
+        }),
+        ...getFilterValue({
+          value: data.value,
+          filterType: data._type,
+          dataType: data._dataType,
+          operator: data.operator
+        })
+      })) || [];
+
+  return {
+    ...rest,
+    sort,
+    group_by: sanitizedGroupBy,
+    filters: sanitizedFilters
+  };
+}
+
+/**
+ * Reverse of `transformToDataViewQuery`. The UI re-applies type information
+ * from field metadata once it sees a column, since the wire format strips it.
+ */
+export function dataViewQueryToInternal(query: DataViewQuery): InternalQuery {
+  const { filters, ...rest } = query;
+  if (!filters) return rest;
+
+  const internalFilters: InternalFilter[] = filters.map(filter => {
+    const {
+      operator,
+      value,
+      stringValue,
+      numberValue,
+      boolValue,
+      ...filterRest
+    } = filter;
+
+    let transformedFilter = {
+      operator: operator as FilterOperatorTypes,
+      value,
+      ...(stringValue !== undefined && { stringValue }),
+      ...(numberValue !== undefined && { numberValue }),
+      ...(boolValue !== undefined && { boolValue })
+    };
+
+    if (operator === 'ilike' && stringValue) {
+      if (stringValue.startsWith('%') && stringValue.endsWith('%')) {
+        transformedFilter = {
+          operator: 'contains',
+          value: stringValue.slice(1, -1)
+        };
+      } else if (stringValue.endsWith('%')) {
+        transformedFilter = {
+          operator: 'starts_with',
+          value: stringValue.slice(0, -1)
+        };
+      } else if (stringValue.startsWith('%')) {
+        transformedFilter = {
+          operator: 'ends_with',
+          value: stringValue.slice(1)
+        };
+      } else {
+        transformedFilter = { operator: 'contains', value: stringValue };
+      }
+    }
+
+    return {
+      ...filterRest,
+      ...transformedFilter,
+      _type: undefined,
+      _dataType: undefined
+    } as InternalFilter;
+  });
+
+  return { ...rest, filters: internalFilters };
+}
+
+/** Leaf count from the row tree. Not `flatRows`: with `filterFromLeafRows`, TanStack's filtered model leaves `flatRows` empty while `rows` is correct. */
+export function countLeafRows<T>(rows: Row<T>[]): number {
+  return rows.reduce(
+    (n, row) => n + (row.subRows?.length ? countLeafRows(row.subRows) : 1),
+    0
+  );
+}
+
+/** Difference between pre- and post-filter leaf rows (client mode only). */
+export function getClientHiddenLeafRowCount<T>(table: Table<T>): number {
+  const pre = table.getPreFilteredRowModel();
+  const post = table.getFilteredRowModel();
+  return Math.max(0, countLeafRows(pre.rows) - countLeafRows(post.rows));
+}
+
+export function hasActiveTableFiltering<T>(table: Table<T>): boolean {
+  const state = table.getState();
+  if (state.columnFilters?.length > 0) return true;
+  const gf = state.globalFilter;
+  if (gf === undefined || gf === null) return false;
+  return String(gf).trim() !== '';
+}
+
+export function getDefaultTableQuery(
+  defaultSort: DataViewSort,
+  oldQuery: DataViewQuery = {}
+): InternalQuery {
+  const internalQuery = dataViewQueryToInternal(oldQuery);
+  return {
+    sort: [defaultSort],
+    group_by: [defaultGroupOption.id],
+    ...internalQuery
+  };
+}

--- a/packages/raystack/index.tsx
+++ b/packages/raystack/index.tsx
@@ -38,10 +38,8 @@ export {
   DataViewProps,
   DataViewQuery,
   DataViewSort,
-  DataViewTableColumn,
-  DataViewTableProps,
   useDataView
-} from './components/data-view-beta';
+} from './components/data-view';
 export { Dialog } from './components/dialog';
 export { Drawer } from './components/drawer';
 export { EmptyState } from './components/empty-state';


### PR DESCRIPTION
## Summary

- Introduce `DataView`, a unified data primitive whose query state (filters, sort, group, search) drives swappable renderers — `DataView.List` (table + list presentations) and `DataView.Custom` (escape hatch for cards, kanban, etc.) — with client and server modes.
- Ship composable toolbar pieces (`Search`, `Filters`, `DisplayControls`) plus a single global column-visibility model exposed via `DisplayAccess`, and `EmptyState`/`ZeroState` sibling surfaces.
- Support multi-view configs: the view switcher lives inside the `DisplayControls` popover (shown when `views.length > 1`), with optional per-view `leadingIcon` and `hideViewSwitcher` / `hideOrdering` / `hideGrouping` / `hideDisplayProperties` toggles.
- Add virtualized rendering, grouping with sticky group headers, infinite-scroll load-more, and per-view field overrides.
- Add docs, live demos, and a 47-test suite covering the component.