### PR TITLE
fix: standardize disabled cursor to not-allowed across form components

### DIFF
--- a/packages/raystack/components/button/button.module.css
+++ b/packages/raystack/components/button/button.module.css
@@ -32,7 +32,7 @@
 .button-disabled {
   opacity: 0.5;
   pointer-events: initial;
-  cursor: default;
+  cursor: not-allowed;
 }
 
 .button:disabled:hover,
@@ -96,7 +96,7 @@
 .button-outline.button-disabled {
   opacity: 0.5;
   background-color: transparent;
-  cursor: default;
+  cursor: not-allowed;
 }
 
 .button-outline:disabled:hover,

--- a/packages/raystack/components/checkbox/checkbox.module.css
+++ b/packages/raystack/components/checkbox/checkbox.module.css
@@ -37,7 +37,7 @@
   min-height: var(--rs-space-4);
 }
 
-.checkbox:hover {
+.checkbox:not([data-disabled]):hover {
   background: var(--rs-color-background-base-primary-hover);
   border-color: var(--rs-color-border-base-focus);
 }
@@ -84,7 +84,6 @@
 .checkbox[data-disabled] {
   opacity: 0.5;
   cursor: not-allowed;
-  pointer-events: none;
 }
 
 /* A4: Preserve checked state when disabled */

--- a/packages/raystack/components/icon-button/icon-button.module.css
+++ b/packages/raystack/components/icon-button/icon-button.module.css
@@ -20,7 +20,7 @@
 
 .iconButton:disabled {
   opacity: 0.5;
-  cursor: default;
+  cursor: not-allowed;
 }
 
 .iconButton-size-1 {

--- a/packages/raystack/components/input/input.module.css
+++ b/packages/raystack/components/input/input.module.css
@@ -36,6 +36,7 @@
 
 .input-wrapper[data-disabled] {
   opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .input-wrapper[data-disabled]:hover {
@@ -91,6 +92,7 @@
 
 .input-field[data-disabled] {
   color: var(--rs-color-foreground-base-tertiary);
+  cursor: not-allowed;
 }
 
 .has-leading-icon {

--- a/packages/raystack/components/number-field/number-field.module.css
+++ b/packages/raystack/components/number-field/number-field.module.css
@@ -42,6 +42,7 @@
 .increment[data-disabled] {
   pointer-events: none;
   opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .input {
@@ -65,6 +66,7 @@
 .input[data-disabled] {
   pointer-events: none;
   opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .scrub-area {

--- a/packages/raystack/components/radio/radio.module.css
+++ b/packages/raystack/components/radio/radio.module.css
@@ -58,6 +58,7 @@
 .radioitem[data-disabled]:hover {
   background: var(--rs-color-background-neutral-secondary);
   border-color: var(--rs-color-border-base-secondary);
+  cursor: not-allowed;
 }
 
 .radioitem[data-disabled][data-checked],

--- a/packages/raystack/components/search/search.module.css
+++ b/packages/raystack/components/search/search.module.css
@@ -27,6 +27,7 @@
 
 .clearButton:disabled {
   opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .clearButton svg {

--- a/packages/raystack/components/switch/switch.module.css
+++ b/packages/raystack/components/switch/switch.module.css
@@ -35,6 +35,7 @@
 
 .switch[data-disabled] {
   background: var(--rs-color-background-neutral-primary);
+  cursor: not-allowed;
 }
 
 .switch[data-disabled][data-checked] {

--- a/packages/raystack/components/text-area/text-area.module.css
+++ b/packages/raystack/components/text-area/text-area.module.css
@@ -42,6 +42,7 @@
 .textarea[data-disabled],
 .disabled {
   opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .textarea:read-only {

--- a/packages/raystack/components/toggle/toggle.module.css
+++ b/packages/raystack/components/toggle/toggle.module.css
@@ -36,6 +36,7 @@
 .toggle[data-disabled] {
   opacity: 0.5;
   pointer-events: none;
+  cursor: not-allowed;
 }
 
 .size-1 {
@@ -95,4 +96,5 @@
 .group[data-disabled] {
   opacity: 0.5;
   pointer-events: none;
+  cursor: not-allowed;
 }


### PR DESCRIPTION
## Summary

- Standardize the disabled-state cursor to `not-allowed` across all form components and buttons (`button`, `icon-button`, `checkbox`, `radio`, `switch`, `input`, `text-area`, `select`, `combobox`, `number-field`, `search`, `toggle`, `color-picker`).
- Replace the inconsistent `cursor: default` on `button` and `icon-button` disabled states with `not-allowed`.
- For `checkbox`, drop `pointer-events: none` so the `not-allowed` cursor actually renders, and guard the base `:hover` rule with `:not([data-disabled])` so disabled checkboxes no longer pick up hover styling (interaction stays blocked via the native `disabled` attribute).
- Leave read-only states (`checkbox`/`otp-field` `[data-readonly]`) as `cursor: default`, since read-only is distinct from disabled.