### PR TITLE
fix: select autocomplete controlled issue

### DIFF
--- a/packages/raystack/components/select/select-content.tsx
+++ b/packages/raystack/components/select/select-content.tsx
@@ -30,7 +30,7 @@ export function SelectContent({
 
   if (autocomplete) {
     return (
-      <ComboboxPrimitive.Portal>
+      <ComboboxPrimitive.Portal keepMounted>
         <ComboboxPrimitive.Positioner
           sideOffset={sideOffset}
           side={side}


### PR DESCRIPTION
## Summary

- Fix controlled value handling in the Select autocomplete so the displayed value stays in sync with the controlled `value` prop
- Update `select-content.tsx` to correctly resolve the active item when used as a controlled component