### PR TITLE
fix: calendar picker open/close flicker and chevron buttons

### DIFF
--- a/packages/raystack/components/calendar/__tests__/date-picker.test.tsx
+++ b/packages/raystack/components/calendar/__tests__/date-picker.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import dayjs from 'dayjs';
 import type { ReactElement } from 'react';
 import { describe, expect, it, vi } from 'vitest';
@@ -587,6 +588,27 @@ describe('DatePicker', () => {
       expect(() => {
         fireEvent.change(input, { target: { value: '01/01/2020' } });
       }).not.toThrow();
+    });
+  });
+
+  describe('open/close on trigger click', () => {
+    /*
+     * Regression: Base UI's `Popover.Trigger` toggles open on every trigger
+     * click. The input's `onFocus` opens the picker, so the same click's
+     * trigger-press toggled it straight back closed — the popover flickered
+     * shut on the first click and only stuck open on the second. The hook's
+     * `onOpenChange` now ignores trigger-press *closes* (see use-picker-popover).
+     */
+    it('opens and stays open on the first click of the input', async () => {
+      const user = userEvent.setup();
+      render(<DatePicker />);
+
+      await user.click(screen.getByPlaceholderText('Select date'));
+      await act(async () => {
+        await new Promise(r => setTimeout(r, 0));
+      });
+
+      expect(screen.queryByRole('dialog')).toBeInTheDocument();
     });
   });
 });

--- a/packages/raystack/components/calendar/calendar.tsx
+++ b/packages/raystack/components/calendar/calendar.tsx
@@ -126,7 +126,7 @@ export const Calendar = function ({
         PreviousMonthButton: ({ children, ...props }) => (
           <IconButton
             {...props}
-            disabled={loadingData ?? props.disabled}
+            disabled={loadingData || props.disabled}
             className={cx(props.className, loadingData && styles.disabled)}
             size={3}
             aria-label='Previous month'
@@ -137,7 +137,7 @@ export const Calendar = function ({
         NextMonthButton: ({ children, ...props }) => (
           <IconButton
             {...props}
-            disabled={loadingData ?? props.disabled}
+            disabled={loadingData || props.disabled}
             className={cx(props.className, loadingData && styles.disabled)}
             size={3}
             aria-label='Next month'

--- a/packages/raystack/components/calendar/calendar.tsx
+++ b/packages/raystack/components/calendar/calendar.tsx
@@ -123,28 +123,28 @@ export const Calendar = function ({
       showOutsideDays={showOutsideDays}
       timeZone={timeZone}
       components={{
-        Chevron: props => {
-          const icon =
-            props.orientation === 'left' ? (
-              <ChevronLeftIcon />
-            ) : (
-              <ChevronRightIcon />
-            );
-
-          return (
-            <IconButton
-              {...props}
-              disabled={loadingData}
-              className={cx(props.className, loadingData && styles.disabled)}
-              size={3}
-              aria-label={
-                props.orientation === 'left' ? 'Previous month' : 'Next month'
-              }
-            >
-              {icon}
-            </IconButton>
-          );
-        },
+        PreviousMonthButton: ({ children, ...props }) => (
+          <IconButton
+            {...props}
+            disabled={loadingData ?? props.disabled}
+            className={cx(props.className, loadingData && styles.disabled)}
+            size={3}
+            aria-label='Previous month'
+          >
+            <ChevronLeftIcon />
+          </IconButton>
+        ),
+        NextMonthButton: ({ children, ...props }) => (
+          <IconButton
+            {...props}
+            disabled={loadingData ?? props.disabled}
+            className={cx(props.className, loadingData && styles.disabled)}
+            size={3}
+            aria-label='Next month'
+          >
+            <ChevronRightIcon />
+          </IconButton>
+        ),
         Dropdown: (props: DropdownProps) => (
           <DropDown
             {...props}

--- a/packages/raystack/components/calendar/date-picker.tsx
+++ b/packages/raystack/components/calendar/date-picker.tsx
@@ -239,9 +239,9 @@ export function DatePicker({
   return (
     <Popover
       open={isDisabled ? false : popover.isOpen}
-      onOpenChange={open => {
+      onOpenChange={(open, eventDetails) => {
         if (isDisabled) return;
-        popover.onOpenChange(open);
+        popover.onOpenChange(open, eventDetails?.reason);
       }}
     >
       <Popover.Trigger
@@ -255,18 +255,7 @@ export function DatePicker({
         side={popoverProps?.side ?? 'top'}
       >
         <Calendar
-          /*
-           * No `captionLayout` default — 'dropdown' renders Apsara Selects
-           * inside the popover whose unmount loops ("Maximum update depth").
-           * Consumers can opt in via `calendarProps.captionLayout`.
-           */
           {...calendarProps}
-          /*
-           * Must stay after spread: `required` is the discriminator for
-           * RDP's prop union, and a widened value would break the narrowing.
-           * `required={false}` is intentional — the picker now supports an
-           * unselected initial state when no value/defaultValue is passed.
-           */
           required={false}
           timeZone={timeZone}
           onDropdownOpen={popover.markDropdownOpen}

--- a/packages/raystack/components/calendar/use-picker-popover.ts
+++ b/packages/raystack/components/calendar/use-picker-popover.ts
@@ -13,7 +13,7 @@ export interface UsePickerPopoverReturn {
   contentRef: React.RefObject<HTMLDivElement | null>;
   handleInputFocus: () => void;
   handleInputBlur: (event: React.FocusEvent) => void;
-  onOpenChange: (open?: boolean) => void;
+  onOpenChange: (open?: boolean, reason?: string) => void;
   /*
    * Pass as Calendar's `onDropdownOpen` so the year/month dropdown isn't
    * treated as an outside click.
@@ -138,7 +138,7 @@ export function usePickerPopover({
     [isElementOutside, engage]
   );
 
-  const onOpenChange = useCallback((open?: boolean) => {
+  const onOpenChange = useCallback((open?: boolean, reason?: string) => {
     // Year/month dropdown opening inside the popover triggers an open-change
     // we don't want; swallow it and consume the flag.
     if (isDropdownOpenRef.current) {
@@ -146,10 +146,21 @@ export function usePickerPopover({
       return;
     }
     /*
+     * Base UI's `Popover.Trigger` wires `useClick`, which *toggles* the popover
+     * on every trigger click. The input's `onFocus` already opens the picker, so
+     * a single click both opens (focus) and then toggles back closed
+     * (trigger-press) — the popover flickers shut on the first click and only
+     * sticks open on the second. Ignore trigger-press *closes*: opening stays
+     * owned by focus (and trigger-press open), while closing is owned by our
+     * outside-click / blur / Enter / day-select logic — plus Base UI's own
+     * Escape/outside-press, which still flow through below.
+     */
+    if (reason === 'trigger-press' && open === false) return;
+    /*
      * Suppress only redundant *re-open* events fired by focus/click handlers
      * while the picker is already engaged + open. Explicit close requests
-     * (Escape key, trigger toggle, programmatic) must always go through, or
-     * users get stuck with no way to close.
+     * (Escape key, programmatic) must always go through, or users get stuck
+     * with no way to close.
      */
     if (open === true && isEngagedRef.current && isOpenRef.current) return;
     setIsOpen(Boolean(open));


### PR DESCRIPTION
## Summary

- Ignore Base UI `trigger-press` close events in `usePickerPopover` so the date picker no longer flickers shut on the first input click (focus opened it, then the same click's trigger toggle closed it).
- Thread the open-change `reason` through `DatePicker` → `usePickerPopover.onOpenChange` so close ownership stays with outside-click/blur/Enter/day-select logic while Escape and outside-press still flow through.
- Migrate calendar nav from the deprecated `Chevron` component to dedicated `PreviousMonthButton`/`NextMonthButton`, preserving disabled-state styling and respecting RDP's own disabled flag.
- Remove stale `captionLayout`/`required` comments from `DatePicker` after the calendar prop wiring change.
- Add a regression test verifying the picker opens and stays open on the first click of the input.