### PR TITLE
fix(callout): match Figma styles for all variants

### DIFF
--- a/apps/www/src/app/examples/page.tsx
+++ b/apps/www/src/app/examples/page.tsx
@@ -60,6 +60,7 @@ const Page = () => {
   const [selectValue1, setSelectValue1] = useState('');
   const [selectValue2, setSelectValue2] = useState('');
   const [inputValue, setInputValue] = useState('');
+  const [calloutDismissed, setCalloutDismissed] = useState(false);
   const [rangeValue, setRangeValue] = useState({
     from: dayjs('2027-11-15').toDate(),
     to: dayjs('2027-12-10').toDate()
@@ -2761,6 +2762,281 @@ const Page = () => {
                     ))}
                   </Flex>
                 </ScrollArea>
+              </Flex>
+            </Flex>
+
+            <Text
+              size='large'
+              weight='medium'
+              style={{ marginTop: '32px', marginBottom: '16px' }}
+            >
+              Callout
+            </Text>
+
+            <Flex direction='column' gap={6} style={{ maxWidth: '600px' }}>
+              {/* Types */}
+              <Flex direction='column' gap={3}>
+                <Text size='small' variant='secondary'>
+                  Types
+                </Text>
+                <Flex direction='column' gap={3}>
+                  <Callout width='100%' type='grey'>
+                    Grey callout (default)
+                  </Callout>
+                  <Callout width='100%' type='success'>
+                    Success callout
+                  </Callout>
+                  <Callout width='100%' type='alert'>
+                    Alert callout
+                  </Callout>
+                  <Callout width='100%' type='gradient'>
+                    Gradient callout
+                  </Callout>
+                  <Callout width='100%' type='accent'>
+                    Accent callout
+                  </Callout>
+                  <Callout width='100%' type='attention'>
+                    Attention callout
+                  </Callout>
+                  <Callout width='100%' type='normal'>
+                    Normal callout
+                  </Callout>
+                </Flex>
+              </Flex>
+
+              {/* Outline */}
+              <Flex direction='column' gap={3}>
+                <Text size='small' variant='secondary'>
+                  Outline
+                </Text>
+                <Callout width='100%' type='success'>
+                  Without outline
+                </Callout>
+                <Callout width='100%' type='success' outline>
+                  With outline
+                </Callout>
+              </Flex>
+
+              {/* High contrast */}
+              <Flex direction='column' gap={3}>
+                <Text size='small' variant='secondary'>
+                  High contrast
+                </Text>
+                <Callout width='100%' type='alert'>
+                  Normal contrast
+                </Callout>
+                <Callout width='100%' type='alert' highContrast>
+                  High contrast
+                </Callout>
+                <Callout width='100%' type='accent' outline highContrast>
+                  Outline + high contrast
+                </Callout>
+              </Flex>
+
+              {/* Custom icon */}
+              <Flex direction='column' gap={3}>
+                <Text size='small' variant='secondary'>
+                  Custom icon
+                </Text>
+                <Callout width='100%' type='attention' icon={<RadixBellIcon />}>
+                  Callout with a custom bell icon
+                </Callout>
+                <Callout width='100%' type='grey' icon={null}>
+                  Callout with no icon
+                </Callout>
+              </Flex>
+
+              {/* With action */}
+              <Flex direction='column' gap={3}>
+                <Text size='small' variant='secondary'>
+                  With action
+                </Text>
+                <Callout
+                  width='100%'
+                  type='accent'
+                  action={
+                    <Button size='small' variant='outline'>
+                      Upgrade
+                    </Button>
+                  }
+                >
+                  You&apos;re on the free plan
+                </Callout>
+              </Flex>
+
+              {/* Dismissible (controlled) */}
+              <Flex direction='column' gap={3}>
+                <Text size='small' variant='secondary'>
+                  Dismissible (controlled — consumer removes it in onDismiss)
+                </Text>
+                {calloutDismissed ? (
+                  <Button
+                    size='small'
+                    onClick={() => setCalloutDismissed(false)}
+                  >
+                    Restore callout
+                  </Button>
+                ) : (
+                  <Callout
+                    width='100%'
+                    type='success'
+                    dismissible
+                    onDismiss={() => setCalloutDismissed(true)}
+                  >
+                    Dismiss me
+                  </Callout>
+                )}
+              </Flex>
+
+              {/* Custom width */}
+              <Flex direction='column' gap={3}>
+                <Text size='small' variant='secondary'>
+                  Custom width
+                </Text>
+                <Callout type='gradient' width={240}>
+                  width = 240
+                </Callout>
+                <Callout type='gradient' width={480}>
+                  width = 480
+                </Callout>
+              </Flex>
+
+              {/*Figma replicas*/}
+              <Flex direction='column' gap={3}>
+                <Text size='small' variant='secondary'>
+                  Figma replicas
+                </Text>
+                <Callout type='normal' outline>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='success' outline>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='gradient'>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='accent'>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout
+                  type='grey'
+                  action={
+                    <Button variant='outline' color='neutral' size='small'>
+                      Button
+                    </Button>
+                  }
+                >
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='grey' dismissible>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout
+                  type='grey'
+                  action={
+                    <Button variant='outline' color='neutral' size='small'>
+                      Button
+                    </Button>
+                  }
+                >
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='gradient'>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='gradient' outline>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='gradient' highContrast>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='gradient' outline highContrast>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='normal'>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='normal' outline>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='normal' highContrast>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='normal' outline highContrast>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='grey'>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='grey' outline>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='grey' highContrast>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='grey' outline highContrast>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='accent'>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='accent' outline>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='accent' highContrast>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='accent' outline highContrast>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='alert'>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='alert' outline>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='alert' highContrast>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='alert' outline highContrast>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='success'>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='success' outline>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='success' highContrast>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='success' outline highContrast>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='attention'>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='attention' outline>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='attention' highContrast>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='attention' outline highContrast>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='gradient'>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='gradient' outline>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='gradient' highContrast>
+                  A short message to attract user’s attention
+                </Callout>
+                <Callout type='gradient' outline highContrast>
+                  A short message to attract user’s attention
+                </Callout>
               </Flex>
             </Flex>
 

--- a/apps/www/src/content/docs/components/callout/index.mdx
+++ b/apps/www/src/content/docs/components/callout/index.mdx
@@ -54,7 +54,9 @@ The Callout component supports high contrast mode for better visibility:
 
 ### Dismissible
 
-The Callout component can be made dismissible:
+The Callout component can be made dismissible. When `onDismiss` is provided, the
+consumer controls removal (the callout stays mounted); when it is omitted, the
+callout hides itself.
 
 <Demo data={dismissibleDemo} />
 
@@ -77,3 +79,4 @@ The Callout component includes appropriate ARIA attributes for accessibility:
 - Uses semantic HTML elements for proper structure
 - Dismiss button includes `aria-label` for screen readers
 - Interactive elements are keyboard accessible
+- Dismiss button shows a visible focus ring on keyboard focus

--- a/apps/www/src/content/docs/components/callout/props.ts
+++ b/apps/www/src/content/docs/components/callout/props.ts
@@ -39,13 +39,19 @@ export interface CalloutProps {
    */
   icon?: React.ReactNode;
 
-  /** Callback function when dismiss button is clicked */
+  /**
+   * Called when the dismiss button is clicked. When provided, the consumer owns
+   * removal (the callout stays mounted). When omitted, the callout hides itself.
+   */
   onDismiss?: () => void;
 
   /** Text content of the callout */
   children?: React.ReactNode;
 
-  /** Custom width for the callout */
+  /**
+   * Custom width for the callout
+   * @defaultValue 400
+   */
   width?: string | number;
 
   /** Additional CSS class names */

--- a/packages/raystack/components/callout/__tests__/callout.test.tsx
+++ b/packages/raystack/components/callout/__tests__/callout.test.tsx
@@ -230,9 +230,11 @@ describe('Callout', () => {
       expect(dismissButton).toHaveAttribute('type', 'button');
       expect(dismissButton).toHaveAttribute('aria-label', 'Dismiss message');
 
+      // The icon is decorative: IconButton wraps it in an aria-hidden element,
+      // so the button is announced only by its aria-label.
       const svg = dismissButton.querySelector('svg');
-      expect(svg).toHaveAttribute('aria-hidden', 'true');
-      expect(svg).toHaveAttribute('role', 'presentation');
+      expect(svg).toBeInTheDocument();
+      expect(svg?.closest('[aria-hidden="true"]')).toBeInTheDocument();
     });
   });
 });

--- a/packages/raystack/components/callout/__tests__/callout.test.tsx
+++ b/packages/raystack/components/callout/__tests__/callout.test.tsx
@@ -126,6 +126,31 @@ describe('Callout', () => {
       expect(onDismiss).toHaveBeenCalledTimes(1);
     });
 
+    it('stays mounted after dismiss when onDismiss is provided (controlled)', () => {
+      const onDismiss = vi.fn();
+      render(
+        <Callout dismissible onDismiss={onDismiss}>
+          Controlled message
+        </Callout>
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Dismiss message' }));
+
+      // Consumer owns removal — the callout must not hide itself.
+      expect(screen.getByText('Controlled message')).toBeInTheDocument();
+    });
+
+    it('hides itself after dismiss when onDismiss is omitted (uncontrolled)', () => {
+      render(<Callout dismissible>Uncontrolled message</Callout>);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Dismiss message' }));
+
+      expect(
+        screen.queryByText('Uncontrolled message')
+      ).not.toBeInTheDocument();
+      expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
+
     it('renders both action and dismissible button', () => {
       const onDismiss = vi.fn();
       render(
@@ -158,6 +183,22 @@ describe('Callout', () => {
 
       const callout = screen.getByRole('status');
       expect(callout).toHaveStyle({ width: '50%' });
+    });
+
+    it('applies width={0} instead of dropping it', () => {
+      render(<Callout width={0}>Zero width message</Callout>);
+
+      const callout = screen.getByRole('status');
+      expect(callout).toHaveStyle({ width: '0px' });
+    });
+
+    it('falls back to style.width when no width prop is given', () => {
+      render(
+        <Callout style={{ width: '200px' }}>Styled width message</Callout>
+      );
+
+      const callout = screen.getByRole('status');
+      expect(callout).toHaveStyle({ width: '200px' });
     });
   });
 

--- a/packages/raystack/components/callout/callout.module.css
+++ b/packages/raystack/components/callout/callout.module.css
@@ -1,6 +1,7 @@
 .callout {
   position: relative;
   width: 400px;
+  max-width: 100%;
   padding: var(--rs-space-3);
   border-radius: var(--rs-radius-2);
   font-style: normal;
@@ -43,6 +44,8 @@
 
 .message {
   flex-shrink: 1;
+  min-width: 0;
+  overflow-wrap: break-word;
 }
 
 .actionsContainer {
@@ -73,6 +76,10 @@
   opacity: 0.7;
 }
 
+.dismiss:focus-visible {
+  outline: 1px solid var(--rs-color-border-accent-emphasis);
+}
+
 /* Type Variants */
 .callout-grey {
   background: var(--rs-color-background-neutral-primary);
@@ -100,7 +107,11 @@
 }
 
 .callout-gradient {
-  background: radial-gradient(circle, oklch(0.5674 0.2831 312.58 / 0.2) 0%, oklch(0.5988 0.2445 29.12 / 0.2) 100%);
+  background: radial-gradient(
+    circle,
+    oklch(0.5674 0.2831 312.58 / 0.2) 0%,
+    oklch(0.5988 0.2445 29.12 / 0.2) 100%
+  );
   color: var(--rs-color-foreground-base-primary);
 }
 
@@ -199,7 +210,11 @@
  * untokenized — keep the two in sync if the gradient stops ever change.
  */
 .callout-outline.callout-gradient {
-  background: radial-gradient(circle, oklch(0.5674 0.2831 312.58 / 0.2) 0%, oklch(0.5988 0.2445 29.12 / 0.2) 100%);
+  background: radial-gradient(
+    circle,
+    oklch(0.5674 0.2831 312.58 / 0.2) 0%,
+    oklch(0.5988 0.2445 29.12 / 0.2) 100%
+  );
   border: 0.5px solid oklch(0.5988 0.2445 29.12 / 0.2667);
   color: var(--rs-color-foreground-base-primary);
 }

--- a/packages/raystack/components/callout/callout.module.css
+++ b/packages/raystack/components/callout/callout.module.css
@@ -60,26 +60,6 @@
   align-items: center;
 }
 
-.dismiss {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--rs-space-1);
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  border-radius: var(--rs-radius-1);
-  color: var(--rs-color-foreground-base-secondary);
-}
-
-.dismiss:hover {
-  opacity: 0.7;
-}
-
-.dismiss:focus-visible {
-  outline: 1px solid var(--rs-color-border-accent-emphasis);
-}
-
 /* Type Variants */
 .callout-grey {
   background: var(--rs-color-background-neutral-primary);

--- a/packages/raystack/components/callout/callout.module.css
+++ b/packages/raystack/components/callout/callout.module.css
@@ -1,6 +1,6 @@
 .callout {
   position: relative;
-  width: 318px;
+  width: 400px;
   padding: var(--rs-space-3);
   border-radius: var(--rs-radius-2);
   font-style: normal;
@@ -48,7 +48,7 @@
 .actionsContainer {
   display: flex;
   align-items: center;
-  gap: var(--rs-space-2);
+  gap: var(--rs-space-3);
   flex-shrink: 0;
 }
 
@@ -66,7 +66,7 @@
   background: transparent;
   cursor: pointer;
   border-radius: var(--rs-radius-1);
-  color: inherit;
+  color: var(--rs-color-foreground-base-secondary);
 }
 
 .dismiss:hover {
@@ -76,11 +76,10 @@
 /* Type Variants */
 .callout-grey {
   background: var(--rs-color-background-neutral-primary);
-  color: var(--rs-color-foreground-base-primary);
+  color: var(--rs-color-foreground-base-secondary);
 }
 
 .callout-success {
-  gap: var(--rs-space-10);
   background: var(--rs-color-background-success-primary);
   color: var(--rs-color-foreground-success-primary);
 }
@@ -112,7 +111,7 @@
 
 .callout-outline.callout-grey {
   background: var(--rs-color-background-neutral-primary);
-  border: 0.5px solid var(--rs-color-border-base-primary);
+  border: 0.5px solid var(--rs-color-border-base-tertiary);
 }
 
 .callout-outline.callout-success {
@@ -165,7 +164,7 @@
 /* Success + Outline + High Contrast */
 .callout-outline.callout-high-contrast.callout-success {
   background: var(--rs-color-background-success-primary);
-  border: 0.5px solid var(--rs-color-border-success-emphasis);
+  border: 0.5px solid var(--rs-color-border-success-primary);
   color: var(--rs-color-foreground-base-primary);
 }
 
@@ -189,17 +188,29 @@
 
 .callout-outline.callout-high-contrast.callout-attention {
   background: var(--rs-color-background-attention-primary);
-  border: 0.5px solid var(--rs-color-border-base-tertiary);
+  border: 0.5px solid var(--rs-color-border-attention-primary);
   color: var(--rs-color-foreground-base-primary);
 }
 
+/*
+ * Gradient + outline (no high contrast): keep the gradient fill and add a
+ * translucent border tinted to the gradient's warm endpoint. Intended behavior.
+ * The border is a one-off literal (no token) because the gradient itself is
+ * untokenized — keep the two in sync if the gradient stops ever change.
+ */
 .callout-outline.callout-gradient {
   background: radial-gradient(circle, oklch(0.5674 0.2831 312.58 / 0.2) 0%, oklch(0.5988 0.2445 29.12 / 0.2) 100%);
   border: 0.5px solid oklch(0.5988 0.2445 29.12 / 0.2667);
   color: var(--rs-color-foreground-base-primary);
 }
 
-/* High contrast gradient should match normal high contrast */
+/*
+ * High contrast gradient should match normal high contrast.
+ * Figma defines only one gradient variant (no outline/high-contrast states), so
+ * in high contrast — both on its own and combined with outline — we intentionally
+ * drop the gradient for the solid "normal" high-contrast surface. A gradient
+ * callout in high-contrast mode therefore reads identically to a normal one.
+ */
 .callout-high-contrast.callout-gradient {
   background: var(--rs-color-background-base-primary);
   color: var(--rs-color-foreground-base-primary);
@@ -214,13 +225,13 @@
 /* Normal variants */
 .callout-normal {
   background: var(--rs-color-background-base-primary);
-  color: var(--rs-color-foreground-base-primary);
+  color: var(--rs-color-foreground-base-secondary);
 }
 
 .callout-outline.callout-normal {
   background: var(--rs-color-background-base-primary);
-  border: 0.5px solid var(--rs-color-border-base-primary);
-  color: var(--rs-color-foreground-base-primary);
+  border: 0.5px solid var(--rs-color-border-base-tertiary);
+  color: var(--rs-color-foreground-base-secondary);
 }
 
 .callout-high-contrast.callout-normal {

--- a/packages/raystack/components/callout/callout.module.css
+++ b/packages/raystack/components/callout/callout.module.css
@@ -60,6 +60,15 @@
   align-items: center;
 }
 
+/* Dismiss button stays flat: keep the transparent background and base colour on
+   hover/active (overrides IconButton's hover feedback). The descendant selector
+   out-specifies `.iconButton:hover` regardless of stylesheet order. */
+.callout .dismiss:hover:not(:disabled),
+.callout .dismiss:active:not(:disabled) {
+  background-color: transparent;
+  color: var(--rs-color-foreground-base-secondary);
+}
+
 /* Type Variants */
 .callout-grey {
   background: var(--rs-color-background-neutral-primary);

--- a/packages/raystack/components/callout/callout.tsx
+++ b/packages/raystack/components/callout/callout.tsx
@@ -104,6 +104,7 @@ export function Callout({
           {dismissible && (
             <IconButton
               size={1}
+              className={styles.dismiss}
               onClick={handleDismiss}
               aria-label='Dismiss message'
             >

--- a/packages/raystack/components/callout/callout.tsx
+++ b/packages/raystack/components/callout/callout.tsx
@@ -2,7 +2,12 @@
 
 import { InfoCircledIcon } from '@radix-ui/react-icons';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { type ComponentProps, type CSSProperties, type ReactNode } from 'react';
+import {
+  type ComponentProps,
+  type CSSProperties,
+  type ReactNode,
+  useState
+} from 'react';
 
 import styles from './callout.module.css';
 
@@ -23,9 +28,6 @@ const callout = cva(styles.callout, {
     highContrast: {
       true: styles['callout-high-contrast']
     }
-  },
-  defaultVariants: {
-    type: 'grey'
   }
 });
 
@@ -34,7 +36,12 @@ export interface CalloutProps
     VariantProps<typeof callout> {
   children: ReactNode;
   action?: ReactNode;
+  /** Show a dismiss (close) button. */
   dismissible?: boolean;
+  /**
+   * Called when the dismiss button is clicked. When provided, the consumer owns
+   * removal (the callout stays mounted). When omitted, the callout hides itself.
+   */
   onDismiss?: () => void;
   width?: string | number;
   style?: CSSProperties;
@@ -55,27 +62,29 @@ export function Callout({
   icon = <InfoCircledIcon />,
   ...props
 }: CalloutProps) {
+  // Dismissal is controlled when `onDismiss` is given; otherwise fall back to
+  // uncontrolled and hide the callout internally.
+  const [dismissed, setDismissed] = useState(false);
+  const handleDismiss = () => {
+    onDismiss?.();
+    if (!onDismiss) setDismissed(true);
+  };
+  if (dismissed) return null;
+
+  // Resolve up front so `width={0}` is kept (a `width && …` guard would drop it).
+  const resolvedWidth = typeof width === 'number' ? `${width}px` : width;
   const combinedStyle = {
     ...style,
-    ...(width && { width: typeof width === 'number' ? `${width}px` : width })
+    width: resolvedWidth ?? style?.width
   };
 
-  const getRole = () => {
-    switch (type) {
-      case 'alert':
-        return 'alert';
-      case 'success':
-        return 'status';
-      default:
-        return 'status';
-    }
-  };
+  const role = type === 'alert' ? 'alert' : 'status';
 
   return (
     <div
       className={callout({ type, outline, highContrast, className })}
       style={combinedStyle}
-      role={getRole()}
+      role={role}
       aria-live={type === 'alert' ? 'assertive' : 'polite'}
       {...props}
     >
@@ -94,7 +103,7 @@ export function Callout({
           {dismissible && (
             <button
               className={styles.dismiss}
-              onClick={onDismiss}
+              onClick={handleDismiss}
               aria-label='Dismiss message'
               type='button'
             >

--- a/packages/raystack/components/callout/callout.tsx
+++ b/packages/raystack/components/callout/callout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { InfoCircledIcon } from '@radix-ui/react-icons';
+import { Cross1Icon, InfoCircledIcon } from '@radix-ui/react-icons';
 import { cva, type VariantProps } from 'class-variance-authority';
 import {
   type ComponentProps,
@@ -9,6 +9,7 @@ import {
   useState
 } from 'react';
 
+import { IconButton } from '../icon-button';
 import styles from './callout.module.css';
 
 const callout = cva(styles.callout, {
@@ -101,29 +102,13 @@ export function Callout({
         <div className={styles.actionsContainer}>
           {action && <div className={styles.action}>{action}</div>}
           {dismissible && (
-            <button
-              className={styles.dismiss}
+            <IconButton
+              size={1}
               onClick={handleDismiss}
               aria-label='Dismiss message'
-              type='button'
             >
-              <svg
-                width='12'
-                height='12'
-                viewBox='0 0 12 12'
-                fill='none'
-                xmlns='http://www.w3.org/2000/svg'
-                aria-hidden='true'
-                role='presentation'
-              >
-                <path
-                  fillRule='evenodd'
-                  clipRule='evenodd'
-                  d='M9.5066 3.3066C9.73115 3.08205 9.73115 2.71798 9.5066 2.49343C9.28205 2.26887 8.91798 2.26887 8.69343 2.49343L6.00001 5.18684L3.3066 2.49343C3.08205 2.26887 2.71798 2.26887 2.49343 2.49343C2.26887 2.71798 2.26887 3.08205 2.49343 3.3066L5.18684 6.00001L2.49343 8.69343C2.26887 8.91798 2.26887 9.28205 2.49343 9.5066C2.71798 9.73115 3.08205 9.73115 3.3066 9.5066L6.00001 6.81318L8.69343 9.5066C8.91798 9.73115 9.28205 9.73115 9.5066 9.5066C9.73115 9.28205 9.73115 8.91798 9.5066 8.69343L6.81318 6.00001L9.5066 3.3066Z'
-                  fill='currentColor'
-                />
-              </svg>
-            </button>
+              <Cross1Icon />
+            </IconButton>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Description

 Aligns the **Callout** component with the design spec across all 24 `type × outline × highContrast` variants, and fixes several component-quality issues surfaced during the audit.

Both the design colours and the CSS design tokens were resolved to OKLCH for exact comparison (not eyeballed).

  **Styling fixes:**
  - `attention` + outline + highContrast border → `border-attention-primary` (the reported bug — was a grey `base-tertiary` clashing with the cream fill); `success` had the same bug → `border-success-primary`
  - `grey` / `normal` (non-high-contrast): text/icon → `foreground-base-secondary`; outline border → `border-base-tertiary`
  - Dismiss (close) icon → updated with IconButton
  - Default width `318px` → `400px`; removed an inert `gap` on `.callout-success`
  - Documented the intentional gradient + high-contrast / outline behaviour in CSS

  **Component-quality fixes (found during audit):**
  - `width={0}` is now applied (was dropped by a truthiness guard); `style.width` honoured asfallback
  - `dismissible` without `onDismiss` now self-hides (uncontrolled fallback); stays controlled when `onDismiss` is provided
  - `max-width: 100%` + `overflow-wrap: break-word` to prevent overflow / long-word breakout
  - Simplified `getRole` and removed a duplicate `type` default

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [x] Test (adding missing tests or correcting existing tests)
- [x] Improvement (Improvements to existing code)
- [ ] Other (please specify)


Note: the default-width change (`318px → 400px`) and the uncontrolled-dismiss fallback are minor behaviour changes for consumers who relied on the old defaults — flagging for reviewer awareness.

## How Has This Been Tested?

  - **Automated design audit** — resolved all 24 variants' fills/borders/text and the CSS tokens to OKLCH; every measurable property (colours, border 0.5px, radius 4px, padding 8px, icon 16px, gaps 8px, typography) matches.
  - **Unit tests** — added 4 (controlled vs uncontrolled dismiss, `width={0}`, `style.width` fallback). Callout: **29/29 passing**; full raystack suite: **1875/1875 passing**.
  - **`tsc`** clean (no callout errors) and **Biome** clean on all changed files.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (.mdx files)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

N/A

## Related Issues

N/A
