### PR TITLE
fix(button,select): match transition timing and remove theme-change flicker

### DIFF
--- a/apps/www/src/app/layout.tsx
+++ b/apps/www/src/app/layout.tsx
@@ -1,7 +1,7 @@
-import { ThemeProvider } from '@/components/theme';
 import { NextProvider } from 'fumadocs-core/framework/next';
 import { Inter } from 'next/font/google';
 import type { ReactNode } from 'react';
+import { ThemeProvider } from '@/components/theme';
 import '@/styles.css';
 import '@raystack/apsara/normalize.css';
 import '@raystack/apsara/style.css';
@@ -20,7 +20,7 @@ export default function Layout({ children }: { children: ReactNode }) {
       </head>
       <body className={styles.body}>
         <NextProvider>
-          <NextThemeProvider>
+          <NextThemeProvider disableTransitionOnChange>
             <ThemeProvider>{children}</ThemeProvider>
           </NextThemeProvider>
         </NextProvider>

--- a/apps/www/src/components/theme.tsx
+++ b/apps/www/src/components/theme.tsx
@@ -3,8 +3,8 @@
 import { ThemeProvider as ApsaraThemeProvider } from '@raystack/apsara';
 import { useTheme as useNextTheme } from 'next-themes';
 import {
-  ReactNode,
   createContext,
+  ReactNode,
   useCallback,
   useContext,
   useState
@@ -55,6 +55,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     >
       <ApsaraThemeProvider
         key={key}
+        disableTransitionOnChange
         forcedTheme={theme}
         accentColor={options.accentColor}
         grayColor={options.grayColor}

--- a/packages/raystack/components/button/button.module.css
+++ b/packages/raystack/components/button/button.module.css
@@ -210,7 +210,7 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .button {
-    transition: all 0.2s ease-in-out;
+    transition: all 0.2s ease;
   }
 }
 

--- a/packages/raystack/components/select/select.module.css
+++ b/packages/raystack/components/select/select.module.css
@@ -71,7 +71,12 @@
   letter-spacing: var(--rs-letter-spacing-small);
   user-select: none;
   -webkit-user-select: none;
-  transition: all 0.2s ease;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .trigger {
+    transition: all 0.2s ease;
+  }
 }
 
 .trigger-outline {


### PR DESCRIPTION


## Description

Fixes the visible flicker on Button and Select Trigger when switching themes.

Two mismatches and one structural issue were causing it:

1. **Easing mismatch** — Button used `transition: all 0.2s ease-in-out` while Select Trigger used `all 0.2s ease`, so their colors interpolated at different rates during a theme flip. Button now uses `ease`, matching Select Trigger and the `--rs-transition-interactive` token convention.
2. **Reduced-motion asymmetry** — Button's transition was gated behind `@media (prefers-reduced-motion: no-preference)` but Select Trigger's was not, so with OS-level Reduce Motion enabled the Button snapped while the Trigger faded. Select Trigger's transition is now gated identically.
3. **Theme-change flash** — even with matched transitions, components that transition color properties fade for 200ms against the instantly-switching page background (most visible on `outline`/`ghost` variants, whose background is the same variable as the page background). CSS cannot distinguish theme-driven variable changes from hover-driven ones, so the docs app now passes `disableTransitionOnChange` to both the next-themes and Apsara theme providers — transitions are suppressed only for the frame the theme attribute flips; hover/press animations are unaffected.

Out of scope carving out `--rs-duration-*` / `--rs-easing-*` tokens and migrating the remaining ad-hoc transitions (text area, field, filter-chip).

**Note for consumers**: product apps using Apsara's `ThemeProvider` directly should also pass `disableTransitionOnChange` to get the same fix; defaulting it to `true` in the library is a follow-up decision.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

- Rebuilt `@raystack/apsara` and ran the docs app locally
- Toggled light/dark theme on the Button docs page (Variant section) and Select docs page — the outline/ghost flash on theme change is gone
- Verified hover/press transitions on Button and Select Trigger still animate normally
- Audited all `transition` declarations across `packages/raystack/components/**/*.module.css` to confirm Button and Select Trigger are now byte-identical in transition behavior.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (.mdx files)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

N/A

## Related Issues

N/A
