### PR TITLE
 fix(docs): rebuild spotlight search on new Command API

### DIFF
--- a/apps/www/src/components/docs/search.module.css
+++ b/apps/www/src/components/docs/search.module.css
@@ -2,111 +2,74 @@
   border-radius: var(--rs-radius-5);
   overflow: hidden;
 }
-.searchCommand {
-  border: none;
-  border-radius: 0;
-  box-shadow: none;
-}
 .inputContainer {
   position: relative;
-}
-.inputContainer svg {
-  color: var(--rs-color-foreground-base-primary);
-  opacity: 1;
-}
-.inputContainer div[cmdk-input-wrapper] {
-  flex: 1;
-  color: var(--rs-color-foreground-base-primary);
-}
-.inputContainer div[cmdk-input-wrapper]:focus-within {
-  border-color: var(--rs-color-border-accent-emphasis);
+  padding-block: var(--rs-space-2);
+  border-bottom: 1px solid var(--rs-color-border-base-primary);
 }
 
-.input {
-  padding: var(--rs-space-5) 0;
-  font-size: var(--rs-font-size-small);
-  font-weight: var(--rs-font-weight-regular);
-  line-height: var(--rs-line-height-small);
-  letter-spacing: var(--rs-letter-spacing-small);
-}
-.input::placeholder {
-  color: var(--rs-color-foreground-base-tertiary);
-}
 .searchClearButton {
   position: absolute;
   right: var(--rs-space-4);
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 .searchList {
-  padding-top: var(--rs-space-2);
-  padding-bottom: var(--rs-space-2);
-  background: var(--rs-color-background-base-primary, #fff);
-  max-height: 400px;
+  max-height: 440px;
 }
-.searchList:focus {
-  outline: none;
+
+.searchEmpty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 320px;
 }
-.searchGroup {
-  padding: var(--rs-space-5) var(--rs-space-3) var(--rs-space-2)
-    var(--rs-space-3);
-}
-.searchGroup [cmdk-group-heading] {
-  color: var(--rs-color-foreground-base-tertiary);
-  font-size: var(--rs-font-size-mini);
-  font-weight: var(--rs-font-weight-medium);
-  line-height: var(--rs-line-height-mini);
-  letter-spacing: var(--rs-letter-spacing-mini);
+
+.searchList .searchGroupLabel {
+  font-size: var(--rs-font-size-small);
+  line-height: var(--rs-line-height-small);
   text-transform: capitalize;
 }
 
-.searchItem {
-  padding: var(--rs-space-3);
-  border-radius: var(--rs-radius-2);
-  display: flex;
-  flex-direction: column;
-  gap: var(--rs-space-1);
-  margin-top: var(--rs-space-2);
+.searchList .searchItem {
+  font-size: var(--rs-font-size-regular);
+  line-height: var(--rs-line-height-regular);
 }
-.searchItem:first-child {
-  margin-top: 0;
-}
+
 .searchSubItemsContainer {
-  margin-left: var(--rs-space-3);
-  padding-left: var(--rs-space-3);
-  border-left: 0.5px solid var(--rs-color-border-base-secondary);
+  margin-left: var(--rs-space-4);
+  padding-left: var(--rs-space-4);
+  border-left: 1.5px solid var(--rs-color-border-base-tertiary);
 }
 
-.searchItem[data-selected="true"],
-.searchItem:hover {
-  background: rgba(15, 15, 15, 0.04);
-}
-
-.searchItemIcon {
-  width: 32px;
-  height: 32px;
-  border-radius: 12px;
-  background: var(--rs-color-background-base-secondary, #f3f3f3);
+.searchAccordionToggle {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--rs-color-text-base-secondary, #5f5f5f);
+  padding: var(--rs-space-1);
+  margin: calc(-1 * var(--rs-space-1));
+  border: none;
+  background: transparent;
+  border-radius: var(--rs-radius-2);
+  color: var(--rs-color-foreground-base-tertiary);
+  cursor: pointer;
 }
 
-.searchItemText {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  flex: 1;
+.searchAccordionToggle:hover {
+  background: var(--rs-color-background-base-primary-hover);
+  color: var(--rs-color-foreground-base-secondary);
 }
 
-.searchItemTitle {
-  font-weight: 500;
-  color: var(--rs-color-text-base-primary, #1f1f1f);
+.searchChevron,
+.searchChevronOpen {
+  transition: transform 150ms ease;
 }
 
-.searchItemMeta {
-  font-size: var(--rs-font-size-body-small, 12px);
-  color: var(--rs-color-text-base-secondary, #6f6f6f);
+.searchChevron {
+  transform: rotate(-90deg);
+}
+
+.searchChevronOpen {
+  transform: rotate(0deg);
 }

--- a/apps/www/src/components/docs/search.tsx
+++ b/apps/www/src/components/docs/search.tsx
@@ -1,18 +1,21 @@
 'use client';
 import {
+  ChevronDownIcon,
+  ColorWheelIcon,
+  ComponentInstanceIcon,
+  CornersIcon,
   Cross1Icon,
+  DashboardIcon,
   ExclamationTriangleIcon,
-  MagnifyingGlassIcon
+  MagnifyingGlassIcon,
+  MixIcon,
+  ReaderIcon,
+  RocketIcon,
+  ShadowIcon,
+  SpaceBetweenVerticallyIcon,
+  TextIcon
 } from '@radix-ui/react-icons';
-import {
-  Command,
-  Dialog,
-  EmptyState,
-  Flex,
-  IconButton,
-  Text
-} from '@raystack/apsara';
-import { cx } from 'class-variance-authority';
+import { Command, Dialog, EmptyState, IconButton } from '@raystack/apsara';
 import {
   flattenTree,
   type Item as PageItem,
@@ -33,9 +36,34 @@ type SearchItems = {
   items: Item[];
 };
 
+// Docs pages carry no icon in their data, so map known page slugs to icons
+// (overview + foundations pages get meaningful ones). Everything else —
+// components and any future pages — falls back to a generic icon so every
+// top-level row stays icon-aligned.
+const PAGE_ICONS: Record<string, typeof MagnifyingGlassIcon> = {
+  docs: ReaderIcon,
+  'getting-started': RocketIcon,
+  styling: MixIcon,
+  overview: DashboardIcon,
+  colors: ColorWheelIcon,
+  typography: TextIcon,
+  spacing: SpaceBetweenVerticallyIcon,
+  radius: CornersIcon,
+  effects: ShadowIcon
+};
+const FallbackPageIcon = ComponentInstanceIcon;
+
+const getPageIcon = (url: string): typeof MagnifyingGlassIcon =>
+  PAGE_ICONS[getFileFromUrl(url)] ?? FallbackPageIcon;
+
 export default function DocsSearch({ pageTree }: { pageTree: Root }) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
+  // Per-result manual expand/collapse overrides; reset whenever the query
+  // changes so the auto-open rule re-applies for the fresh result set.
+  const [openOverrides, setOpenOverrides] = useState<Record<string, boolean>>(
+    {}
+  );
 
   const { search, setSearch, query } = useDocsSearch({
     type: 'fetch'
@@ -58,16 +86,18 @@ export default function DocsSearch({ pageTree }: { pageTree: Root }) {
     const flattened = flattenTree(pageTree.children);
     if (!flattened.length) return [];
 
-    const items = flattened
-      .slice(0, 10)
-      .reduce<Record<string, Item[]>>((acc, item) => {
-        const folder = getFolderFromUrl(item.url);
-        if (!acc[folder]) {
-          acc[folder] = [];
-        }
-        acc[folder].push({ ...item, id: item.url });
-        return acc;
-      }, {});
+    // Default view shows the overview + foundations (theme) pages grouped by
+    // folder. Components are intentionally excluded — there are dozens of them,
+    // so they only surface once the user actually searches.
+    const items = flattened.reduce<Record<string, Item[]>>((acc, item) => {
+      const folder = getFolderFromUrl(item.url);
+      if (folder === 'components') return acc;
+      if (!acc[folder]) {
+        acc[folder] = [];
+      }
+      acc[folder].push({ ...item, id: item.url });
+      return acc;
+    }, {});
     return Object.entries(items).map(([heading, items]) => ({
       heading,
       items
@@ -113,7 +143,6 @@ export default function DocsSearch({ pageTree }: { pageTree: Root }) {
       },
       {}
     );
-    console.log('grouped', grouped);
 
     return Object.entries(grouped).map(([heading, items]) => ({
       heading,
@@ -122,6 +151,36 @@ export default function DocsSearch({ pageTree }: { pageTree: Root }) {
   }, [results]);
 
   const items = !isSearching ? defaultItems : searchResults;
+
+  // The `items` prop opts the Command out of its built-in per-item filtering
+  // and group-unwrapping: results are already filtered by fumadocs, and the
+  // grouped layout must stay intact while searching. An empty array is still
+  // truthy, so `hasItems` stays true even when there are no results.
+  const itemValues = useMemo(
+    () =>
+      items.flatMap(section =>
+        section.items.flatMap(item => [
+          item.id,
+          ...(item.items?.map(sub => sub.id) ?? [])
+        ])
+      ),
+    [items]
+  );
+
+  // A result's sub-details collapse behaves like an accordion: open it only
+  // when the match came from a sub-detail rather than the page title (e.g.
+  // "Toolbar" surfacing for "button" via its Button section). When the title
+  // itself matches, the page is the hit, so keep its sub-details collapsed.
+  const queryLower = trimmedQuery.toLowerCase();
+  const titleMatches = (item: Item) =>
+    typeof item.name === 'string' &&
+    item.name.toLowerCase().includes(queryLower);
+  const autoOpen = (item: Item) =>
+    isSearching && (item.items?.length ?? 0) > 0 && !titleMatches(item);
+  const isOpen = (item: Item) =>
+    item.id in openOverrides ? openOverrides[item.id] : autoOpen(item);
+  const toggleOpen = (item: Item) =>
+    setOpenOverrides(prev => ({ ...prev, [item.id]: !isOpen(item) }));
 
   const handleSelect = useCallback(
     (url: string) => {
@@ -137,15 +196,25 @@ export default function DocsSearch({ pageTree }: { pageTree: Root }) {
       <Dialog.Trigger render={<IconButton size={3} aria-label='Search docs' />}>
         <MagnifyingGlassIcon />
       </Dialog.Trigger>
-      <Dialog.Content width={512} className={styles.searchContainer}>
-        <Command className={styles.searchCommand} filter={() => 1}>
-          <Flex className={styles.inputContainer} align='center'>
+      <Dialog.Content
+        width={512}
+        showCloseButton={false}
+        className={styles.searchContainer}
+      >
+        <Command
+          items={itemValues}
+          mode='none'
+          value={search}
+          onValueChange={value => {
+            setSearch(value);
+            setOpenOverrides({});
+          }}
+        >
+          <div className={styles.inputContainer}>
             <Command.Input
+              leadingIcon={<MagnifyingGlassIcon />}
               placeholder='Search docs'
-              value={search}
-              onValueChange={setSearch}
               autoComplete='off'
-              className={styles.input}
             />
             {search.length > 0 && (
               <IconButton
@@ -157,9 +226,9 @@ export default function DocsSearch({ pageTree }: { pageTree: Root }) {
                 <Cross1Icon />
               </IconButton>
             )}
-          </Flex>
+          </div>
           <Command.Content className={styles.searchList}>
-            <Command.Empty>
+            <Command.Empty className={styles.searchEmpty}>
               <EmptyState
                 variant='empty1'
                 heading='No result found'
@@ -168,51 +237,71 @@ export default function DocsSearch({ pageTree }: { pageTree: Root }) {
               />
             </Command.Empty>
             {items.map((section, index) => (
-              <div key={section.heading}>
-                <Command.Group
-                  heading={section.heading}
-                  className={styles.searchGroup}
-                >
-                  {section.items.map(item => (
-                    <Fragment key={item.url}>
-                      <Command.Item
-                        key={item.id}
-                        value={item.id}
-                        onSelect={() => handleSelect(item.url)}
-                        className={styles.searchItem}
-                      >
-                        <Text size='small' variant='primary' lineClamp={1}>
+              <Fragment key={section.heading}>
+                <Command.Group>
+                  <Command.Label className={styles.searchGroupLabel}>
+                    {section.heading}
+                  </Command.Label>
+                  {section.items.map(item => {
+                    const ItemIcon = getPageIcon(item.url);
+                    const hasSubItems = (item.items?.length ?? 0) > 0;
+                    const expanded = isOpen(item);
+                    return (
+                      <Fragment key={item.id}>
+                        <Command.Item
+                          value={item.id}
+                          onClick={() => handleSelect(item.url)}
+                          leadingIcon={<ItemIcon />}
+                          trailingIcon={
+                            hasSubItems ? (
+                              <button
+                                type='button'
+                                aria-label={
+                                  expanded
+                                    ? 'Collapse section'
+                                    : 'Expand section'
+                                }
+                                aria-expanded={expanded}
+                                className={styles.searchAccordionToggle}
+                                onPointerDown={e => e.stopPropagation()}
+                                onClick={e => {
+                                  e.stopPropagation();
+                                  toggleOpen(item);
+                                }}
+                              >
+                                <ChevronDownIcon
+                                  className={
+                                    expanded
+                                      ? styles.searchChevronOpen
+                                      : styles.searchChevron
+                                  }
+                                />
+                              </button>
+                            ) : undefined
+                          }
+                          className={styles.searchItem}
+                        >
                           {item.name}
-                        </Text>
-                      </Command.Item>
-                      {item.items?.length && item.items.length > 0 && (
-                        <div className={styles.searchSubItemsContainer}>
-                          {item.items?.map(subItem => (
-                            <Command.Item
-                              key={subItem.id}
-                              value={subItem.id}
-                              onSelect={() => handleSelect(subItem.url)}
-                              className={cx(
-                                styles.searchItem,
-                                styles.searchSubItem
-                              )}
-                            >
-                              <Text
-                                size='small'
-                                variant='primary'
-                                lineClamp={1}
+                        </Command.Item>
+                        {hasSubItems && expanded ? (
+                          <div className={styles.searchSubItemsContainer}>
+                            {item.items?.map(subItem => (
+                              <Command.Item
+                                key={subItem.id}
+                                value={subItem.id}
+                                onClick={() => handleSelect(subItem.url)}
                               >
                                 {subItem.name}
-                              </Text>
-                            </Command.Item>
-                          ))}
-                        </div>
-                      )}
-                    </Fragment>
-                  ))}
+                              </Command.Item>
+                            ))}
+                          </div>
+                        ) : null}
+                      </Fragment>
+                    );
+                  })}
                 </Command.Group>
-                {index < defaultItems.length - 1 && <Command.Separator />}
-              </div>
+                {index < items.length - 1 && <Command.Separator />}
+              </Fragment>
             ))}
           </Command.Content>
         </Command>


### PR DESCRIPTION
## Description

Repairs the Apsara docs ⌘K spotlight search, which broke when the `Command` component migrated from cmdk → Base UI Autocomplete (#748) — only a `Command.List`→`Command.Content` rename was applied to the docs search, leaving the rest written against the old library (dead CSS, dropped group labels, double-filtered results, duplicate close buttons, non-firing selection).

This PR rebuilds the search against the new Command API, aligns the styling to Figma, fixes the default-view content, adds per-page icons, and turns result sub-details into an accordion.

**Structural fixes**
- Drive the `Command` root with `items` + `mode='none'` so fumadocs stays the only filter and grouped results stay intact while typing.
- Controlled query on the root; `onSelect` → `onClick`; `showCloseButton={false}` (single clear ✕ in the input row); leading search icon; removed `console.log` and fixed the separator group guard.
- Replaced all dead cmdk CSS selectors with token-based styles.

**Styling (matched to Figma)**
- Input hairline + roomier row, 12px group labels, 14px items (sub-details 12px), taller list, centered "No result found" empty state.

**Content & UX**
- Default view shows Overview + Theme only (removed the arbitrary `slice(0,10)` that surfaced a lone "Accordion" under Components); components appear on search.
- Per-page leading icons via a `slug→icon` map with a generic fallback.
- Result sub-details collapse like an accordion, auto-opening only when the match is in a sub-detail rather than the page title (chevron toggles, row navigates).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [x] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

Verified locally against the running docs app via headless Chrome (CDP), in both light and dark themes:

- **Default view** — Overview + Theme groups with correct labels/icons; no stray "Components → Accordion" section.
- **No-result state** — single clear ✕ in the input row, centered empty state.
- **Grouped results** — query "button" returns all 109 hits, grouped, unfiltered.
- **Accordion** — title matches (`Button`, `Copy Button`, `IconButton`) stay collapsed; sub-detail matches (`Toolbar`, `Search`, …) auto-expand. Chevron toggles without navigating; row body navigates and closes the dialog.
- `tsc --noEmit` and `biome check` clean on the changed files; full-app type-error count unchanged (no new errors introduced).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (.mdx files)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

N/A

## Related Issues

N/A
