### PR TITLE
fix(data-table): align defaultSort optionality across internal types and fix sort icon direction

### DIFF
--- a/packages/raystack/components/data-table/components/ordering.tsx
+++ b/packages/raystack/components/data-table/components/ordering.tsx
@@ -17,15 +17,16 @@ import {
 export interface OrderingProps {
   columnList: ColumnData[];
   onChange: (columnId: string, order: SortOrdersValues) => void;
-  value: DataTableSort;
+  value?: DataTableSort;
 }
 
 export function Ordering({ columnList, onChange, value }: OrderingProps) {
   function handleColumnChange(columnId: string) {
-    onChange(columnId, value.order);
+    onChange(columnId, value?.order ?? SortOrders.ASC);
   }
 
   function handleOrderChange() {
+    if (!value) return;
     const newOrder =
       value.order === SortOrders.ASC ? SortOrders.DESC : SortOrders.ASC;
     onChange(value.name, newOrder);
@@ -48,7 +49,7 @@ export function Ordering({ columnList, onChange, value }: OrderingProps) {
       >
         <Select
           onValueChange={handleColumnChange}
-          value={value.name}
+          value={value?.name}
           disabled={columnList.length === 0}
         >
           <Select.Trigger
@@ -70,12 +71,12 @@ export function Ordering({ columnList, onChange, value }: OrderingProps) {
           size={4}
           disabled={columnList.length === 0}
         >
-          {value.order === SortOrders?.ASC ? (
+          {value?.order === SortOrders?.ASC ? (
+            <TextAlignTopIcon className={styles['display-popover-sort-icon']} />
+          ) : (
             <TextAlignBottomIcon
               className={styles['display-popover-sort-icon']}
             />
-          ) : (
-            <TextAlignTopIcon className={styles['display-popover-sort-icon']} />
           )}
         </IconButton>
       </Flex>

--- a/packages/raystack/components/data-table/components/ordering.tsx
+++ b/packages/raystack/components/data-table/components/ordering.tsx
@@ -71,7 +71,7 @@ export function Ordering({ columnList, onChange, value }: OrderingProps) {
           size={4}
           disabled={columnList.length === 0}
         >
-          {value?.order === SortOrders?.ASC ? (
+          {(value?.order ?? SortOrders.ASC) === SortOrders.ASC ? (
             <TextAlignTopIcon className={styles['display-popover-sort-icon']} />
           ) : (
             <TextAlignBottomIcon

--- a/packages/raystack/components/data-table/components/ordering.tsx
+++ b/packages/raystack/components/data-table/components/ordering.tsx
@@ -21,14 +21,16 @@ export interface OrderingProps {
 }
 
 export function Ordering({ columnList, onChange, value }: OrderingProps) {
+  const currentOrder = value?.order ?? SortOrders.ASC;
+
   function handleColumnChange(columnId: string) {
-    onChange(columnId, value?.order ?? SortOrders.ASC);
+    onChange(columnId, currentOrder);
   }
 
   function handleOrderChange() {
     if (!value) return;
     const newOrder =
-      value.order === SortOrders.ASC ? SortOrders.DESC : SortOrders.ASC;
+      currentOrder === SortOrders.ASC ? SortOrders.DESC : SortOrders.ASC;
     onChange(value.name, newOrder);
   }
 
@@ -71,7 +73,7 @@ export function Ordering({ columnList, onChange, value }: OrderingProps) {
           size={4}
           disabled={columnList.length === 0}
         >
-          {(value?.order ?? SortOrders.ASC) === SortOrders.ASC ? (
+          {currentOrder === SortOrders.ASC ? (
             <TextAlignTopIcon className={styles['display-popover-sort-icon']} />
           ) : (
             <TextAlignBottomIcon

--- a/packages/raystack/components/data-table/data-table.tsx
+++ b/packages/raystack/components/data-table/data-table.tsx
@@ -86,7 +86,7 @@ function DataTableRoot<TData, TValue>({
     setTableQuery(prev => ({
       ...prev,
       ...defaultTableQuery,
-      sort: [defaultSort],
+      sort: defaultSort ? [defaultSort] : [],
       group_by: [defaultGroupOption.id]
     }));
     handleColumnVisibilityChange(initialColumnVisibility);

--- a/packages/raystack/components/data-table/data-table.types.tsx
+++ b/packages/raystack/components/data-table/data-table.types.tsx
@@ -157,7 +157,7 @@ export type TableContextType<TData, TValue> = {
   isLoading?: boolean;
   loadMoreData: () => void;
   mode: DataTableMode;
-  defaultSort: DataTableSort;
+  defaultSort?: DataTableSort;
   tableQuery?: InternalQuery;
   totalRowCount?: number;
   loadingRowCount?: number;

--- a/packages/raystack/components/data-table/utils/index.tsx
+++ b/packages/raystack/components/data-table/utils/index.tsx
@@ -168,7 +168,7 @@ const isSearchChanged = (oldSearch?: string, newSearch?: string): boolean => {
  */
 export const hasActiveQuery = (
   tableQuery: InternalQuery,
-  defaultSort: DataTableSort
+  defaultSort?: DataTableSort
 ): boolean => {
   const hasFilters =
     (tableQuery?.filters && tableQuery.filters.length > 0) || false;
@@ -345,7 +345,7 @@ export function hasActiveTableFiltering<T>(table: Table<T>): boolean {
 }
 
 export function getDefaultTableQuery(
-  defaultSort: DataTableSort,
+  defaultSort?: DataTableSort,
   oldQuery: DataTableQuery = {}
 ): InternalQuery {
   // Convert DataTableQuery to InternalQuery


### PR DESCRIPTION
## Description

This PR contains two changes to the `data-table` component's `Ordering` control and surrounding types.

**1. Corrected the sort direction icons.** In the `Ordering` toggle the ascending/descending icons were swapped — ascending (`asc`) showed the "align bottom" icon and descending (`desc`) showed the "align top" icon. They are now correct: `asc` shows `TextAlignTopIcon` and `desc` shows `TextAlignBottomIcon`, so the icon matches the actual sort direction.

**2. Fixed `defaultSort` type-safety issues.** The `defaultSort` prop is **optional** on the public `DataTableProps`, but several internal types incorrectly required it (`DataTableSort` instead of `DataTableSort | undefined`), producing latent type errors and a possible runtime crash in the `Ordering` control when no `defaultSort` is provided.

Changes:
- Swapped the ascending/descending sort icons in `Ordering` so the direction shown matches the applied sort order.
- Relaxed `getDefaultTableQuery` and `hasActiveQuery` parameters to optional `defaultSort?` (their bodies already guarded for `undefined`).
- Made `TableContextType.defaultSort` optional to match the public prop.
- Guarded the display-settings reset handler so it builds `sort: defaultSort ? [defaultSort] : []` instead of `[undefined]`.
- Made `Ordering`'s `value` optional and guarded its internal accesses (`value?.name`, `value?.order`, early-return in the order toggle), preventing a deref of a possibly-undefined value.

The public API is unchanged — `defaultSort` remains optional and the change is fully backward-compatible.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

- Type-checked the full `raystack` package; the four changed files (`ordering.tsx`, `data-table.tsx`, `data-table.types.tsx`, `utils/index.tsx`) produce zero type errors, and no new cross-errors were introduced in any other file.
- Ran the data-table test suite — **164 passed** (`data-table.test.tsx`, `utils/index.test.tsx`, `utils/filter-operations.test.tsx`).
- Ran the sibling `data-view` / `data-view-beta` suites as a sanity check (they keep independent copies of these utils/components) — **59 passed, 1 skipped**, unaffected.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (.mdx files)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

[Add screenshots here]

## Related Issues

[Link any related issues here using #issue-number]
