### PR TITLE
fix: design-system audit — motion, interaction states, focus & accessibility

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,0 @@
-module.exports = {
-  // This project uses Biome instead of ESLint
-  // Keep this file for backwards compatibility only
-  root: true,
-  extends: [],
-  rules: {}
-};

--- a/.eslintrs.js
+++ b/.eslintrs.js
@@ -1,7 +1,0 @@
-module.exports = {
-  // This project uses Biome instead of ESLint
-  // Keep this file for backwards compatibility and to avoid eslint conflicts
-  root: true,
-  extends: [],
-  rules: {},
-};

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,10 +222,10 @@ Apsara follows an automated release process using GitHub Actions and semantic ve
    # Ensure you're on the correct branch
    git checkout main  # for production release
    # OR
-   git checkout develop  # for release candidate
+   git checkout release/x.y  # for release candidate
    
    # Pull latest changes
-   git pull origin main  # or develop
+   git pull origin main  # or the release branch
    ```
 
 2. **Create and push a tag**:
@@ -255,7 +255,7 @@ The release process includes these automated steps:
 3. **Install** dependencies
 4. **Build** the library using `pnpm ci:build`
 5. **Bump version** in package.json based on the git tag
-6. **Publish** to NPM using `release-it`
+6. **Publish** to NPM using `pnpm publish` (both `@raystack/apsara` and `@raystack/tools-config`)
 7. **Generate** GitHub release notes
 
 ### NPM Publishing

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -83,10 +83,9 @@ apsara/
 ├── apps/
 │   ├── www/                    # Documentation website (Fumadocs)
 ├── packages/
-│   ├── eslint-config-custom/   # Shared ESLint configuration
 │   ├── plugin-vscode/          # VS Code extension for Apsara
 │   ├── raystack/              # Main Apsara component library
-│   └── tsconfig/              # Shared TypeScript configurations
+│   └── tools-config/          # Shared Biome and TypeScript configurations
 ├── .github/
 │   └── workflows/             # GitHub Actions for CI/CD
 ├── pnpm-workspace.yaml        # pnpm workspace configuration
@@ -277,14 +276,7 @@ Configuration files:
 
 ### Common Issues
 
-1. **ESLint Configuration Errors**:
-   ```bash
-   # If you encounter ESLint parsing errors
-   # The build process will still work, but linting may fail
-   # This is a known configuration issue with the current setup
-   ```
-
-2. **Node.js Version Issues**:
+1. **Node.js Version Issues**:
    ```bash
    # Ensure you're using Node.js 22+
    node --version
@@ -293,7 +285,7 @@ Configuration files:
    nvm use 22
    ```
 
-3. **pnpm Version Issues**:
+2. **pnpm Version Issues**:
    ```bash
    # Ensure you're using the correct pnpm version
    pnpm --version
@@ -302,7 +294,7 @@ Configuration files:
    npm install -g pnpm@9.3.0
    ```
 
-4. **Build Failures**:
+3. **Build Failures**:
    ```bash
    # Clean and reinstall if builds fail
    pnpm clean
@@ -311,7 +303,7 @@ Configuration files:
    pnpm build:apsara
    ```
 
-5. **Test Failures**:
+4. **Test Failures**:
    ```bash
    # Some tests may be failing in the current codebase
    # Focus on not introducing new test failures

--- a/apps/www/src/components/docs/search.tsx
+++ b/apps/www/src/components/docs/search.tsx
@@ -15,13 +15,7 @@ import {
   SpaceBetweenVerticallyIcon,
   TextIcon
 } from '@radix-ui/react-icons';
-import {
-  Command,
-  Dialog,
-  EmptyState,
-  IconButton,
-  Spinner
-} from '@raystack/apsara';
+import { Command, EmptyState, IconButton, Spinner } from '@raystack/apsara';
 import {
   flattenTree,
   type Item as PageItem,
@@ -190,15 +184,13 @@ export default function DocsSearch({ pageTree }: { pageTree: Root }) {
   );
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <Dialog.Trigger render={<IconButton size={3} aria-label='Search docs' />}>
-        <MagnifyingGlassIcon />
-      </Dialog.Trigger>
-      <Dialog.Content
-        style={{ width: 512 }}
-        showCloseButton={false}
-        className={styles.searchContainer}
+    <Command.Dialog open={open} onOpenChange={setOpen}>
+      <Command.DialogTrigger
+        render={<IconButton size={3} aria-label='Search docs' />}
       >
+        <MagnifyingGlassIcon />
+      </Command.DialogTrigger>
+      <Command.DialogContent width={512} className={styles.searchContainer}>
         <Command
           items={itemValues}
           mode='none'
@@ -307,7 +299,7 @@ export default function DocsSearch({ pageTree }: { pageTree: Root }) {
             ))}
           </Command.Content>
         </Command>
-      </Dialog.Content>
-    </Dialog>
+      </Command.DialogContent>
+    </Command.Dialog>
   );
 }

--- a/apps/www/src/components/playground/otp-field-examples.tsx
+++ b/apps/www/src/components/playground/otp-field-examples.tsx
@@ -26,6 +26,27 @@ function ControlledOTP() {
   );
 }
 
+function InvalidOTP() {
+  const [error, setError] = useState<string>();
+  return (
+    <Field
+      label='Verification code'
+      description='The correct code is 123456.'
+      error={error}
+    >
+      <OTPField
+        length={6}
+        onValueChange={() => setError(undefined)}
+        onValueComplete={value => {
+          if (value !== '123456') setError('Incorrect code. Try again.');
+        }}
+      >
+        {renderSlots(6)}
+      </OTPField>
+    </Field>
+  );
+}
+
 function CompleteOTP() {
   const [submitted, setSubmitted] = useState('');
   return (
@@ -91,6 +112,11 @@ export function OTPFieldExamples() {
       <Flex direction='column' gap={9}>
         <Text>onValueComplete:</Text>
         <CompleteOTP />
+      </Flex>
+
+      <Flex direction='column' gap={9}>
+        <Text>Invalid (a wrong code shakes):</Text>
+        <InvalidOTP />
       </Flex>
 
       <Flex direction='column' gap={9}>

--- a/apps/www/src/content/docs/components/command/index.mdx
+++ b/apps/www/src/content/docs/components/command/index.mdx
@@ -109,7 +109,7 @@ A `<kbd>` element for keyboard hints. Typically passed as `trailingIcon` on `Com
 
 #### DialogContent
 
-Renders the portal, backdrop, viewport, and popup for the command palette. The backdrop is not blurred by default — pass `overlay={{ blur: true }}` to enable it. Unlike `Dialog.Content`, there is no close button; users dismiss the palette via `Escape` or by clicking the backdrop.
+Renders the portal, viewport, and popup for the command palette. There is no backdrop overlay. Unlike `Dialog.Content`, there is no close button; users dismiss the palette via `Escape` or by clicking outside it.
 
 <auto-type-table path="./props.ts" name="CommandDialogContentProps" />
 

--- a/apps/www/src/content/docs/components/command/props.ts
+++ b/apps/www/src/content/docs/components/command/props.ts
@@ -160,16 +160,6 @@ export interface CommandDialogContentProps {
   /** Additional CSS class names applied to the dialog popup. */
   className?: string;
 
-  /**
-   * Props forwarded to the backdrop element. Set `blur` to `true` to enable
-   * a backdrop blur.
-   * @defaultValue `{ blur: false }`
-   */
-  overlay?: {
-    blur?: boolean;
-    className?: string;
-  };
-
   /** Explicit width for the dialog popup. */
   width?: string | number;
 }

--- a/apps/www/src/content/docs/components/table/props.ts
+++ b/apps/www/src/content/docs/components/table/props.ts
@@ -16,6 +16,12 @@ export interface TableBodyProps {
 export interface TableRowProps {
   /** Additional CSS class names. */
   className?: string;
+  /**
+   * Enables clickable-row styling: a pointer cursor plus hover and active
+   * background states. Use for rows that respond to clicks.
+   * @default false
+   */
+  interactive?: boolean;
 }
 
 export interface TableHeadProps {

--- a/docs/V1-migration.md
+++ b/docs/V1-migration.md
@@ -1326,6 +1326,16 @@ The `render` prop also supports render functions for full control:
 
 **TypeScript:** `HeadlineProps['size']` is now `'t1' | 't2' | 't3' | 't4'` (was `'t1' | 't2' | 't3' | 't4' | 'small' | 'medium' | 'large'`).
 
+**Base `width: 100%` removed (scoped to the `truncate` variant).** The base Headline no longer stretches to fill its container. A `display: block` heading already fills the width in normal flow, so this only affects flex or grid parents, where a Headline used to claim the full row/track. If you relied on that — for example a centered heading, or a Headline used as a full-row flex child — set the width back where you need it:
+
+```tsx
+// Before: filled the row automatically
+<Headline>Section title</Headline>
+
+// After: opt back in where the old behavior was intentional
+<Headline className={styles.fullWidth}>Section title</Headline> // width: 100%
+```
+
 ---
 
 ### Input (formerly InputField)

--- a/packages/raystack/.np-config.json
+++ b/packages/raystack/.np-config.json
@@ -1,3 +1,0 @@
-{
-  "cleanup": false
-}

--- a/packages/raystack/README.md
+++ b/packages/raystack/README.md
@@ -1,24 +1,12 @@
-# Apsara
+# Apsara 🧚‍♀️
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg?logo=apache)](LICENSE) [![Formatted with Biome](https://img.shields.io/badge/Formatted_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev/) [![Linted with Biome](https://img.shields.io/badge/Linted_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev) [![Checked with Biome](https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev)
+[![npm version](https://img.shields.io/npm/v/@raystack/apsara?logo=npm&color=cb3837)](https://www.npmjs.com/package/@raystack/apsara)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg?logo=apache)](LICENSE)
+[![Biome](https://img.shields.io/badge/Biome-60a5fa?logo=biome&logoColor=white)](https://biomejs.dev/)
 
-Apsara 🧚‍♀️ is an open-source React UI component library built on Base UI primitives. It provides enterprise-grade, accessible components designed for building complex data interfaces.
+Apsara is an open-source React component library for building accessible, data-heavy interfaces. It is built on [Base UI](https://base-ui.com/) primitives and written in TypeScript.
 
-<p align="center"><img width=80% src="./apps/www/public/banner.png" /></p>
-
-## Key Features
-
-- **Accessible Components**: Built on Base UI primitives ensuring ARIA compliance and keyboard navigation
-- **Flexible Styling**: Uses vanilla CSS with HTML data-attributes for powerful theming and style customization
-- **Enterprise Ready**: Designed for complex data-driven applications with components like:
-  - Data Tables
-  - Navigation Systems
-  - Form Controls
-  - Feedback Components
-- **Type Safe**: Written in TypeScript with comprehensive type definitions
-- **Modern Stack**: Support for React 18+ and modern development practices
-
-## Installation
+## Install
 
 ```sh
 npm install @raystack/apsara
@@ -26,98 +14,53 @@ npm install @raystack/apsara
 pnpm add @raystack/apsara
 ```
 
+Requires React 19.
+
 ## Usage
 
 ```jsx
-// Add Style import in the root of the project.
+// Import the styles once, at the root of your app.
 import "@raystack/apsara/style.css";
 
-// Import components
 import { Button, Flex } from "@raystack/apsara";
 
-function App() {
+export default function App() {
   return (
     <Flex>
-      <Button type="primary">I am using 🧚‍♀️ Apsara!</Button>
+      <Button variant="solid">Hello from Apsara 🧚‍♀️</Button>
     </Flex>
   );
 }
 ```
 
-## Component Categories
+Icons and hooks ship as separate entry points:
 
-### Layout
+```jsx
+import { ChevronDownIcon } from "@raystack/apsara/icons";
+import { useCopyToClipboard } from "@raystack/apsara/hooks";
+```
 
-- `Box` - Basic layout container
-- `Flex` - Flexbox container
-- `Container` - Responsive wrapper
-- `Sidebar` - Collapsible navigation panel
+## What's inside
 
-### Navigation
+Over 70 components, styled with plain CSS and `data-*` attributes so you can theme them with CSS variables. A few highlights:
 
-- `Breadcrumb` - Navigation breadcrumbs
-- `Tabs` - Tabbed interface
-- `Command` - Command palette interface
+- **Layout** — Box, Flex, Grid, Container, Sidebar, ScrollArea
+- **Navigation** — Tabs, Breadcrumb, Command, Menu, Navbar, Toolbar
+- **Data** — Table, DataTable, DataView, Avatar, Badge, Chip, Meter
+- **Forms** — Input, Select, Combobox, Checkbox, Radio, Switch, Slider, Calendar, ColorPicker
+- **Feedback** — Toast, Tooltip, Callout, Spinner, Indicator
+- **Overlay** — Dialog, Popover, Drawer, ContextMenu
 
-### Data Display
-
-- `Table` - Data table component
-- `Avatar` - User avatar display
-- `Badge` - Status indicators
-- `EmptyState` - Empty state messaging
-
-### Forms
-
-- `Select` - Dropdown selection
-- `Radio` - Radio button groups
-- `IconButton` - Icon-only buttons
-
-### Feedback
-
-- `Tooltip` - Contextual tooltips
-- `Callout` - Informational callouts
-- `Indicator` - Status indicators
-
-### Overlay
-
-- `Popover` - Contextual overlays
-- `Drawer` - Slide-out panels with swipe-to-dismiss
-- `Dialog` - Modal dialogs
-
-## Documentation
-
-Visit our [documentation site](https://apsara.raystack.org) for:
-
-- Interactive examples
-- API references
-- Theme customization
-- Accessibility guidelines
-- Migration guides
+See the [documentation site](https://apsara.raystack.org) for the full list, live examples, and API references.
 
 ## Contributing
 
-We welcome contributions! Here's how you can help:
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'feat: add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-### Development Setup
+Contributions are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the workflow and [DEVELOPMENT.md](./DEVELOPMENT.md) for local setup.
 
 ```sh
-# Install dependencies
-pnpm install
-
-# Start development server
-pnpm dev
-
-# Run tests
-pnpm test
-
-# Build library
-pnpm build
+pnpm install   # install dependencies
+pnpm start     # run the library and docs site
+pnpm test      # run tests
 ```
 
 ## License

--- a/packages/raystack/components/accordion/accordion.module.css
+++ b/packages/raystack/components/accordion/accordion.module.css
@@ -31,9 +31,18 @@
   border-top: none;
 }
 
-.accordion-trigger:hover,
-.accordion-trigger:focus-visible {
+.accordion-trigger:hover {
   background-color: var(--rs-color-background-base-primary-hover);
+}
+
+/* Trigger sits flush in a clipped container: keep the ring inside. */
+.accordion-trigger:focus-visible {
+  outline: var(--rs-focus-ring);
+  outline-offset: var(--rs-focus-ring-offset-inset);
+}
+
+.accordion-trigger:active:not(:disabled) {
+  background-color: var(--rs-color-background-neutral-secondary);
 }
 
 .accordion-trigger:disabled {
@@ -80,10 +89,10 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .accordion-icon {
-    transition: transform 150ms ease-in-out;
+    transition: transform var(--rs-duration-fast) var(--rs-ease-in-out);
   }
 
   .accordion-content {
-    transition: height 150ms ease-out;
+    transition: height var(--rs-duration-fast) var(--rs-ease-out);
   }
 }

--- a/packages/raystack/components/accordion/accordion.module.css
+++ b/packages/raystack/components/accordion/accordion.module.css
@@ -35,10 +35,11 @@
   background-color: var(--rs-color-background-base-primary-hover);
 }
 
-/* Trigger sits flush in a clipped container: keep the ring inside. */
+/* Trigger has its own border: hug it with the ring so they don't read as
+   two separate lines. */
 .accordion-trigger:focus-visible {
   outline: var(--rs-focus-ring);
-  outline-offset: var(--rs-focus-ring-offset-inset);
+  outline-offset: var(--rs-focus-ring-offset-inset-border);
 }
 
 .accordion-trigger:active:not(:disabled) {

--- a/packages/raystack/components/accordion/accordion.module.css
+++ b/packages/raystack/components/accordion/accordion.module.css
@@ -95,4 +95,8 @@
   .accordion-content {
     transition: height var(--rs-duration-fast) var(--rs-ease-out);
   }
+
+  .accordion-trigger {
+    transition: var(--rs-transition-interactive);
+  }
 }

--- a/packages/raystack/components/amount/amount.module.css
+++ b/packages/raystack/components/amount/amount.module.css
@@ -1,0 +1,3 @@
+.amount {
+  font-variant-numeric: tabular-nums;
+}

--- a/packages/raystack/components/amount/amount.tsx
+++ b/packages/raystack/components/amount/amount.tsx
@@ -1,4 +1,6 @@
+import { cx } from 'class-variance-authority';
 import { type ComponentProps } from 'react';
+import styles from './amount.module.css';
 
 export interface AmountProps extends ComponentProps<'span'> {
   /**
@@ -167,6 +169,7 @@ export const Amount = ({
   groupDigits = true,
   valueInMinorUnits = true,
   hideCurrency = false,
+  className,
   ...props
 }: AmountProps) => {
   try {
@@ -265,10 +268,18 @@ export const Amount = ({
           finalBaseValue
         );
 
-    return <span {...props}>{formattedValue}</span>;
+    return (
+      <span {...props} className={cx(styles.amount, className)}>
+        {formattedValue}
+      </span>
+    );
   } catch (error) {
     console.error('Error formatting amount:', error);
-    return <span {...props}>{String(value)}</span>;
+    return (
+      <span {...props} className={cx(styles.amount, className)}>
+        {String(value)}
+      </span>
+    );
   }
 };
 

--- a/packages/raystack/components/announcement-bar/announcement-bar.module.css
+++ b/packages/raystack/components/announcement-bar/announcement-bar.module.css
@@ -51,18 +51,29 @@
   font: inherit;
   color: inherit;
   border-radius: var(--rs-radius-1);
-  transition: var(--rs-transition-interactive);
 }
 
 .action-btn:hover {
   opacity: 0.8;
 }
 
+/* Press reads as scale, not a second dim — 0.64 text mid-press is barely
+   legible on the gradient variant, and hover's 0.8 still applies. */
 .action-btn:active {
-  opacity: 0.64;
+  transform: scale(var(--rs-scale-pressed));
 }
 
 .action-btn:focus-visible {
   outline: 1px solid currentColor;
   outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .action-btn {
+    transition: var(--rs-transition-interactive);
+  }
+
+  .action-btn:active {
+    transition: var(--rs-transition-pressed);
+  }
 }

--- a/packages/raystack/components/announcement-bar/announcement-bar.module.css
+++ b/packages/raystack/components/announcement-bar/announcement-bar.module.css
@@ -50,4 +50,19 @@
   padding: 0;
   font: inherit;
   color: inherit;
+  border-radius: var(--rs-radius-1);
+  transition: var(--rs-transition-interactive);
+}
+
+.action-btn:hover {
+  opacity: 0.8;
+}
+
+.action-btn:active {
+  opacity: 0.64;
+}
+
+.action-btn:focus-visible {
+  outline: 1px solid currentColor;
+  outline-offset: 2px;
 }

--- a/packages/raystack/components/avatar/avatar.module.css
+++ b/packages/raystack/components/avatar/avatar.module.css
@@ -11,10 +11,11 @@
   width: var(--rs-space-9, 32px);
   height: var(--rs-space-9, 32px);
   --fallback-font-size: calc(var(--rs-space-9, 32px) * 0.4);
+  --fallback-letter-spacing: 0.03em;
 }
 
-.avatar-full {
-  border-radius: var(--rs-radius-full) !important;
+.avatar.avatar-full {
+  border-radius: var(--rs-radius-full);
 }
 
 .avatar-disabled {
@@ -228,6 +229,18 @@
   vertical-align: middle;
 }
 
+@keyframes avatar-image-in {
+  from {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .image-fade-in {
+    animation: avatar-image-in var(--rs-duration-fast) var(--rs-ease-out);
+  }
+}
+
 .fallback {
   width: 100%;
   height: 100%;
@@ -236,14 +249,15 @@
   justify-content: center;
   font-size: var(--fallback-font-size);
   font-weight: var(--rs-font-weight-medium);
-  line-height: var(--rs-line-height-large);
-  letter-spacing: var(--rs-letter-spacing-large);
+  line-height: 1;
+  letter-spacing: var(--fallback-letter-spacing, 0.03em);
 }
 
 .avatar-size-1 {
   width: var(--rs-space-5, 16px);
   height: var(--rs-space-5, 16px);
   --fallback-font-size: calc(var(--rs-space-5, 16px) * 0.4);
+  --fallback-letter-spacing: 0.05em;
   border-radius: var(--rs-radius-2);
 }
 
@@ -251,6 +265,7 @@
   width: var(--rs-space-6, 20px);
   height: var(--rs-space-6, 20px);
   --fallback-font-size: calc(var(--rs-space-6, 20px) * 0.4);
+  --fallback-letter-spacing: 0.05em;
   border-radius: var(--rs-radius-2);
 }
 
@@ -258,6 +273,7 @@
   width: var(--rs-space-7, 24px);
   height: var(--rs-space-7, 24px);
   --fallback-font-size: calc(var(--rs-space-7, 24px) * 0.4);
+  --fallback-letter-spacing: 0.04em;
   border-radius: var(--rs-radius-2);
 }
 
@@ -265,6 +281,7 @@
   width: var(--rs-space-8, 28px);
   height: var(--rs-space-8, 28px);
   --fallback-font-size: calc(var(--rs-space-8, 28px) * 0.35);
+  --fallback-letter-spacing: 0.04em;
   border-radius: var(--rs-radius-2);
 }
 
@@ -272,6 +289,7 @@
   width: var(--rs-space-9, 32px);
   height: var(--rs-space-9, 32px);
   --fallback-font-size: calc(var(--rs-space-9, 32px) * 0.4);
+  --fallback-letter-spacing: 0.03em;
   border-radius: var(--rs-radius-2);
 }
 
@@ -279,6 +297,7 @@
   width: var(--rs-space-10, 40px);
   height: var(--rs-space-10, 40px);
   --fallback-font-size: calc(var(--rs-space-10, 40px) * 0.35);
+  --fallback-letter-spacing: 0.02em;
   border-radius: var(--rs-radius-4);
 }
 
@@ -286,6 +305,7 @@
   width: var(--rs-space-11, 48px);
   height: var(--rs-space-11, 48px);
   --fallback-font-size: calc(var(--rs-space-11, 48px) * 0.35);
+  --fallback-letter-spacing: 0.01em;
   border-radius: var(--rs-radius-4);
 }
 
@@ -293,6 +313,7 @@
   width: var(--rs-space-12, 56px);
   height: var(--rs-space-12, 56px);
   --fallback-font-size: calc(var(--rs-space-12, 56px) * 0.3);
+  --fallback-letter-spacing: 0.01em;
   border-radius: var(--rs-radius-4);
 }
 
@@ -300,6 +321,7 @@
   width: var(--rs-space-13, 64px);
   height: var(--rs-space-13, 64px);
   --fallback-font-size: calc(var(--rs-space-13, 64px) * 0.3);
+  --fallback-letter-spacing: 0em;
   border-radius: var(--rs-radius-4);
 }
 
@@ -307,6 +329,7 @@
   width: var(--rs-space-14, 72px);
   height: var(--rs-space-14, 72px);
   --fallback-font-size: calc(var(--rs-space-14, 72px) * 0.3);
+  --fallback-letter-spacing: 0em;
   border-radius: var(--rs-radius-5);
 }
 
@@ -314,6 +337,7 @@
   width: var(--rs-space-15, 80px);
   height: var(--rs-space-15, 80px);
   --fallback-font-size: calc(var(--rs-space-15, 80px) * 0.3);
+  --fallback-letter-spacing: 0em;
   border-radius: var(--rs-radius-5);
 }
 
@@ -321,6 +345,7 @@
   width: var(--rs-space-16, 96px);
   height: var(--rs-space-16, 96px);
   --fallback-font-size: calc(var(--rs-space-16, 96px) * 0.3);
+  --fallback-letter-spacing: -0.005em;
   border-radius: var(--rs-radius-5);
 }
 
@@ -328,6 +353,7 @@
   width: var(--rs-space-17, 120px);
   height: var(--rs-space-17, 120px);
   --fallback-font-size: calc(var(--rs-space-17, 120px) * 0.3);
+  --fallback-letter-spacing: -0.01em;
   border-radius: var(--rs-radius-5);
 }
 

--- a/packages/raystack/components/avatar/avatar.module.css
+++ b/packages/raystack/components/avatar/avatar.module.css
@@ -4,7 +4,9 @@
   justify-content: center;
   overflow: hidden;
   position: relative;
-  border: none;
+  /* Hairline media edge; outline paints above the full-bleed image child. */
+  outline: 0.5px solid var(--rs-color-overlay-base-a2);
+  outline-offset: -0.5px;
   border-radius: var(--rs-radius-full);
   background-color: var(--rs-color-background-neutral-secondary);
   color: var(--rs-color-foreground-base-primary);
@@ -379,6 +381,8 @@
 .avatarGroup .avatar {
   border: 1px solid var(--rs-color-background-base-primary);
   box-sizing: content-box;
+  /* The separator border is the edge here; the media hairline would double it. */
+  outline: none;
 }
 
 /* Avatar Group Size Variants */

--- a/packages/raystack/components/avatar/avatar.tsx
+++ b/packages/raystack/components/avatar/avatar.tsx
@@ -1,8 +1,20 @@
+'use client';
+
 import { Avatar as AvatarPrimitive } from '@base-ui/react/avatar';
 import { cva, cx, VariantProps } from 'class-variance-authority';
-import { ComponentProps, isValidElement, ReactElement, ReactNode } from 'react';
+import {
+  ComponentProps,
+  isValidElement,
+  ReactElement,
+  ReactNode,
+  useRef,
+  useState
+} from 'react';
 import styles from './avatar.module.css';
 import { AVATAR_COLORS } from './utils';
+
+// Matches Base UI's AvatarRoot ImageLoadingStatus union.
+type ImageLoadingStatus = 'idle' | 'loading' | 'loaded' | 'error';
 
 const avatar = cva(styles.avatar, {
   variants: {
@@ -164,21 +176,42 @@ const AvatarRoot = ({
   variant,
   color,
   ...props
-}: AvatarProps) => (
-  <AvatarPrimitive.Root
-    className={cx(
-      styles.imageWrapper,
-      avatar({ size, radius, variant, color }),
-      className
-    )}
-    {...props}
-  >
-    <AvatarPrimitive.Image className={image()} src={src} alt={alt} />
-    <AvatarPrimitive.Fallback className={styles.fallback}>
-      {fallback}
-    </AvatarPrimitive.Fallback>
-  </AvatarPrimitive.Root>
-);
+}: AvatarProps) => {
+  const sawLoadingRef = useRef(false);
+  const [fadeIn, setFadeIn] = useState(false);
+  const handleLoadingStatusChange = (status: ImageLoadingStatus) => {
+    if (status === 'loading') {
+      sawLoadingRef.current = true;
+      setFadeIn(false);
+    } else if (status === 'loaded') {
+      // A cached image reports 'loaded' with no 'loading' phase (Base UI never
+      // emits it), so it stays instant; only network loads fade in.
+      setFadeIn(sawLoadingRef.current);
+      sawLoadingRef.current = false;
+    }
+  };
+
+  return (
+    <AvatarPrimitive.Root
+      className={cx(
+        styles.imageWrapper,
+        avatar({ size, radius, variant, color }),
+        className
+      )}
+      {...props}
+    >
+      <AvatarPrimitive.Image
+        className={cx(image(), fadeIn && styles['image-fade-in'])}
+        src={src}
+        alt={alt}
+        onLoadingStatusChange={handleLoadingStatusChange}
+      />
+      <AvatarPrimitive.Fallback className={styles.fallback}>
+        {fallback}
+      </AvatarPrimitive.Fallback>
+    </AvatarPrimitive.Root>
+  );
+};
 
 AvatarRoot.displayName = 'Avatar';
 

--- a/packages/raystack/components/breadcrumb/breadcrumb.module.css
+++ b/packages/raystack/components/breadcrumb/breadcrumb.module.css
@@ -50,9 +50,7 @@
 }
 
 .breadcrumb-link:focus-visible {
-  outline: none;
-  background-color: var(--rs-color-background-base-primary-hover);
-  color: var(--rs-color-foreground-base-secondary);
+  outline: var(--rs-focus-ring);
   border-radius: var(--rs-radius-1);
 }
 
@@ -95,8 +93,7 @@
 }
 
 .breadcrumb-dropdown-trigger:focus-visible {
-  background-color: var(--rs-color-background-base-primary-hover);
-  color: var(--rs-color-foreground-base-primary);
+  outline: var(--rs-focus-ring);
   border-radius: var(--rs-radius-1);
 }
 

--- a/packages/raystack/components/breadcrumb/breadcrumb.module.css
+++ b/packages/raystack/components/breadcrumb/breadcrumb.module.css
@@ -39,8 +39,21 @@
   cursor: pointer;
 }
 
+@media (prefers-reduced-motion: no-preference) {
+  .breadcrumb-link {
+    transition: color var(--rs-duration-fast) var(--rs-ease-out);
+  }
+}
+
 .breadcrumb-link:hover {
   color: var(--rs-color-foreground-base-secondary);
+}
+
+.breadcrumb-link:focus-visible {
+  outline: none;
+  background-color: var(--rs-color-background-base-primary-hover);
+  color: var(--rs-color-foreground-base-secondary);
+  border-radius: var(--rs-radius-1);
 }
 
 .breadcrumb-link-active {
@@ -79,6 +92,12 @@
   font-weight: inherit;
   outline: none;
   padding: 0;
+}
+
+.breadcrumb-dropdown-trigger:focus-visible {
+  background-color: var(--rs-color-background-base-primary-hover);
+  color: var(--rs-color-foreground-base-primary);
+  border-radius: var(--rs-radius-1);
 }
 
 .breadcrumb-dropdown-icon {

--- a/packages/raystack/components/button/button.module.css
+++ b/packages/raystack/components/button/button.module.css
@@ -203,16 +203,6 @@
   background-color: transparent;
 }
 
-.button-loading {
-  display: flex;
-  align-items: center;
-}
-
-.button-loading:hover,
-.button-loading:active {
-  background-color: inherit;
-}
-
 .button:active:not(:disabled):not(.button-disabled):not(.button-loading) {
   transform: scale(var(--rs-scale-pressed));
 }

--- a/packages/raystack/components/button/button.module.css
+++ b/packages/raystack/components/button/button.module.css
@@ -16,11 +16,16 @@
 }
 
 .button:focus-visible {
-  outline: 1px solid var(--rs-color-border-accent-emphasis);
+  outline: var(--rs-focus-ring);
 }
 
-.button:focus {
+.button:focus:not(:focus-visible) {
   outline: none;
+}
+
+/* Accent-filled solid: push the ring off the same-coloured fill. */
+.button-solid-accent:focus-visible {
+  outline-offset: var(--rs-focus-ring-offset-accent);
 }
 
 .button:before,
@@ -208,9 +213,17 @@
   background-color: inherit;
 }
 
+.button:active:not(:disabled):not(.button-disabled):not(.button-loading) {
+  transform: scale(var(--rs-scale-pressed));
+}
+
 @media (prefers-reduced-motion: no-preference) {
   .button {
-    transition: all 0.2s ease;
+    transition: var(--rs-transition-interactive);
+  }
+
+  .button:active {
+    transition: var(--rs-transition-pressed);
   }
 }
 

--- a/packages/raystack/components/button/button.module.css
+++ b/packages/raystack/components/button/button.module.css
@@ -23,8 +23,19 @@
   outline: none;
 }
 
-/* Accent-filled solid: push the ring off the same-coloured fill. */
-.button-solid-accent:focus-visible {
+/* Ring color follows the button color; neutral keeps the accent ring. */
+.button-color-danger:focus-visible {
+  outline-color: var(--rs-color-border-danger-emphasis);
+}
+
+.button-color-success:focus-visible {
+  outline-color: var(--rs-color-border-success-emphasis);
+}
+
+/* Color-filled solids: push the ring off the same-coloured fill. */
+.button-solid-accent:focus-visible,
+.button-solid-danger:focus-visible,
+.button-solid-success:focus-visible {
   outline-offset: var(--rs-focus-ring-offset-accent);
 }
 
@@ -86,14 +97,9 @@
   border: 0.5px solid var(--rs-color-border-accent-emphasis);
 }
 
-.button-outline:hover {
-  background-color: var(--rs-color-background-accent-primary);
-  border-color: var(--rs-color-border-accent-emphasis);
-}
-
+.button-outline:hover,
 .button-outline:active {
-  background-color: var(--rs-color-background-accent-emphasis);
-  color: var(--rs-color-foreground-accent-emphasis);
+  background-color: var(--rs-color-background-accent-primary);
   border-color: var(--rs-color-border-accent-emphasis);
 }
 
@@ -249,10 +255,7 @@
   color: var(--rs-color-foreground-accent-emphasis);
 }
 
-.button-solid-accent:hover {
-  background-color: var(--rs-color-background-accent-emphasis-hover);
-}
-
+.button-solid-accent:hover,
 .button-solid-accent:active {
   background-color: var(--rs-color-background-accent-emphasis-hover);
 }
@@ -262,10 +265,7 @@
   color: var(--rs-color-foreground-danger-emphasis);
 }
 
-.button-solid-danger:hover {
-  background-color: var(--rs-color-background-danger-emphasis-hover);
-}
-
+.button-solid-danger:hover,
 .button-solid-danger:active {
   background-color: var(--rs-color-background-danger-emphasis-hover);
 }
@@ -284,10 +284,7 @@
   color: var(--rs-color-foreground-base-primary);
 }
 
-.button-solid-neutral:hover {
-  background-color: var(--rs-color-background-neutral-secondary-hover);
-}
-
+.button-solid-neutral:hover,
 .button-solid-neutral:active {
   background-color: var(--rs-color-background-neutral-secondary-hover);
 }
@@ -309,10 +306,7 @@
   color: var(--rs-color-foreground-success-emphasis);
 }
 
-.button-solid-success:hover {
-  background-color: var(--rs-color-background-success-emphasis-hover);
-}
-
+.button-solid-success:hover,
 .button-solid-success:active {
   background-color: var(--rs-color-background-success-emphasis-hover);
 }
@@ -332,13 +326,9 @@
   color: var(--rs-color-foreground-accent-primary);
 }
 
-.button-outline-accent:hover {
-  background-color: var(--rs-color-background-accent-primary);
-}
-
+.button-outline-accent:hover,
 .button-outline-accent:active {
-  background-color: var(--rs-color-background-accent-emphasis);
-  color: var(--rs-color-foreground-accent-emphasis);
+  background-color: var(--rs-color-background-accent-primary);
 }
 
 .button-outline-danger {
@@ -346,15 +336,10 @@
   color: var(--rs-color-foreground-danger-primary);
 }
 
-.button-outline-danger:hover {
+.button-outline-danger:hover,
+.button-outline-danger:active {
   border-color: var(--rs-color-border-danger-emphasis-hover);
   background-color: var(--rs-color-background-danger-primary);
-}
-
-.button-outline-danger:active {
-  background-color: var(--rs-color-background-danger-emphasis);
-  color: var(--rs-color-foreground-danger-emphasis);
-  border-color: transparent;
 }
 
 .button-outline-danger.button-loading:hover {
@@ -375,15 +360,10 @@
   border-color: var(--rs-color-border-base-tertiary);
 }
 
-.button-outline-neutral:hover {
-  background-color: var(--rs-color-background-base-primary-hover);
-  border-color: var(--rs-color-border-base-tertiary-hover);
-}
-
+.button-outline-neutral:hover,
 .button-outline-neutral:active {
   background-color: var(--rs-color-background-base-primary-hover);
-  color: var(--rs-color-foreground-base-primary);
-  border-color: transparent;
+  border-color: var(--rs-color-border-base-tertiary-hover);
 }
 
 .button-outline-neutral.button-disabled:hover,
@@ -398,15 +378,10 @@
   color: var(--rs-color-foreground-success-primary);
 }
 
-.button-outline-success:hover {
+.button-outline-success:hover,
+.button-outline-success:active {
   background-color: var(--rs-color-background-success-primary);
   border-color: var(--rs-color-border-success-emphasis-hover);
-}
-
-.button-outline-success:active {
-  background-color: var(--rs-color-background-success-emphasis);
-  color: var(--rs-color-foreground-success-emphasis);
-  border-color: transparent;
 }
 
 .button-outline-success.button-loading:hover {

--- a/packages/raystack/components/calendar/calendar.module.css
+++ b/packages/raystack/components/calendar/calendar.module.css
@@ -73,7 +73,7 @@
   width: var(--rs-space-10, 40px);
   height: var(--rs-space-10, 40px);
   background-color: var(--rs-color-background-base-primary);
-  border-radius: var(--rs-radius-2);
+  border-radius: var(--rs-radius-5);
   color: var(--rs-color-foreground-base-primary);
   font-style: normal;
   text-align: center;
@@ -92,9 +92,20 @@
   width: var(--rs-space-10, 40px);
   height: var(--rs-space-10, 40px);
   flex-shrink: 0;
-  border-radius: var(--rs-radius-5);
   border: 1px solid var(--rs-color-border-accent-emphasis-hover);
   background-color: transparent;
+}
+
+.day:not(.disabled):not(.outside):not(.selected) .dayButton:active {
+  background-color: var(--rs-color-background-base-primary-hover);
+}
+
+.selected:not(.rangeMiddle) .dayButton:active {
+  background-color: var(--rs-color-background-accent-emphasis-hover);
+}
+
+.rangeMiddle .dayButton:active {
+  background-color: var(--rs-color-background-neutral-secondary);
 }
 
 .selected:not(.rangeMiddle) {
@@ -287,6 +298,65 @@
   margin-top: var(--rs-space-2);
 }
 
+.monthGridWrap {
+  position: relative;
+}
+
+.monthGridSkeleton {
+  position: absolute;
+  inset: 0;
+  /* Solid backing so the grid underneath doesn't ghost through mid-fade */
+  background: var(--rs-color-background-base-primary);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.monthGridSkeleton[data-visible] {
+  opacity: 1;
+  visibility: visible;
+  /* Block clicks on the day grid underneath while loading */
+  pointer-events: auto;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .monthGridSkeleton {
+    /* Exiting: fade opacity, then flip visibility after the fade */
+    transition:
+      opacity var(--rs-duration-fast) var(--rs-ease-out),
+      visibility 0s linear var(--rs-duration-fast);
+  }
+
+  .monthGridSkeleton[data-visible] {
+    /* Entering: visibility flips immediately, opacity fades in */
+    transition: opacity var(--rs-duration-fast) var(--rs-ease-out);
+  }
+}
+
 .datePickerInput {
   text-align: left;
+}
+
+.datePickerError {
+  display: block;
+  /* Reserved line: the space exists whether or not an error is showing,
+     so appearing/disappearing errors never shift the layout below. */
+  min-height: var(--rs-line-height-mini);
+  margin-top: var(--rs-space-1);
+  color: var(--rs-color-foreground-danger-primary);
+  font-weight: var(--rs-font-weight-regular);
+  font-size: var(--rs-font-size-mini);
+  line-height: var(--rs-line-height-mini);
+  letter-spacing: var(--rs-letter-spacing-mini);
+  opacity: 0;
+}
+
+.datePickerError[data-visible] {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .datePickerError {
+    transition: opacity var(--rs-duration-fast) var(--rs-ease-out);
+  }
 }

--- a/packages/raystack/components/calendar/calendar.module.css
+++ b/packages/raystack/components/calendar/calendar.module.css
@@ -257,6 +257,13 @@
   position: relative;
 }
 
+/* Inset ring: day cells pack edge-to-edge in the week row, so a flush or
+   outward ring would collide with the neighbouring day. */
+.dayButton:focus-visible {
+  outline: var(--rs-focus-ring);
+  outline-offset: var(--rs-focus-ring-offset-inset);
+}
+
 .dayButtonWithInfo {
   display: grid;
   place-content: center;

--- a/packages/raystack/components/calendar/calendar.tsx
+++ b/packages/raystack/components/calendar/calendar.tsx
@@ -176,6 +176,7 @@ export const Calendar = function ({
                 render={
                   <button
                     {...buttonProps}
+                    disabled={loadingData || buttonProps.disabled}
                     className={cx(
                       buttonProps.className,
                       hasDateInfo && styles.dayButtonWithInfo
@@ -194,17 +195,23 @@ export const Calendar = function ({
             </Tooltip>
           );
         },
-        MonthGrid: props =>
-          loadingData ? (
-            <Skeleton
-              count={5}
-              height='18px'
-              width='252px'
-              style={{ marginBottom: 'var(--rs-space-6)' }}
-            />
-          ) : (
-            <table {...props} />
-          )
+        MonthGrid: props => (
+          <div className={styles.monthGridWrap}>
+            <table {...props} aria-busy={loadingData || undefined} />
+            <div
+              className={styles.monthGridSkeleton}
+              data-visible={loadingData || undefined}
+              aria-hidden='true'
+            >
+              <Skeleton
+                count={5}
+                height='18px'
+                width='252px'
+                style={{ marginBottom: 'var(--rs-space-6)' }}
+              />
+            </div>
+          </div>
+        )
       }}
       classNames={{
         caption_label: styles.captionLabel,

--- a/packages/raystack/components/calendar/date-picker.tsx
+++ b/packages/raystack/components/calendar/date-picker.tsx
@@ -208,20 +208,29 @@ export function DatePicker({
   }
 
   const defaultTrigger = (
-    <Input
-      size='small'
-      placeholder='Select date'
-      aria-invalid={!!error}
-      className={styles.datePickerInput}
-      trailingIcon={showCalendarIcon ? <CalendarIcon /> : undefined}
-      {...inputProps}
-      ref={popover.inputRef}
-      value={inputValue}
-      onChange={handleInputChange}
-      onFocus={popover.handleInputFocus}
-      onBlur={popover.handleInputBlur}
-      onKeyUp={handleKeyUp}
-    />
+    <>
+      <Input
+        size='small'
+        placeholder='Select date'
+        aria-invalid={!!error}
+        className={styles.datePickerInput}
+        trailingIcon={showCalendarIcon ? <CalendarIcon /> : undefined}
+        {...inputProps}
+        ref={popover.inputRef}
+        value={inputValue}
+        onChange={handleInputChange}
+        onFocus={popover.handleInputFocus}
+        onBlur={popover.handleInputBlur}
+        onKeyUp={handleKeyUp}
+      />
+      <span
+        className={styles.datePickerError}
+        data-visible={error ? '' : undefined}
+        role='alert'
+      >
+        {error}
+      </span>
+    </>
   );
 
   /*

--- a/packages/raystack/components/calendar/date-picker.tsx
+++ b/packages/raystack/components/calendar/date-picker.tsx
@@ -6,7 +6,7 @@ import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import { PropsBase } from 'react-day-picker';
 import { Input } from '../input';
 import { InputProps } from '../input/input';
@@ -207,6 +207,15 @@ export function DatePicker({
     }
   }
 
+  const errorId = useId();
+  // Link the error text to the input so a user tabbing into an already-erroring
+  // field hears the reason, not just "invalid" (role="alert" alone only fires
+  // when the message first appears). Merge with any consumer-supplied value.
+  const describedBy =
+    [inputProps['aria-describedby'], error ? errorId : undefined]
+      .filter(Boolean)
+      .join(' ') || undefined;
+
   const defaultTrigger = (
     <>
       <Input
@@ -216,6 +225,7 @@ export function DatePicker({
         className={styles.datePickerInput}
         trailingIcon={showCalendarIcon ? <CalendarIcon /> : undefined}
         {...inputProps}
+        aria-describedby={describedBy}
         ref={popover.inputRef}
         value={inputValue}
         onChange={handleInputChange}
@@ -224,6 +234,7 @@ export function DatePicker({
         onKeyUp={handleKeyUp}
       />
       <span
+        id={errorId}
         className={styles.datePickerError}
         data-visible={error ? '' : undefined}
         role='alert'

--- a/packages/raystack/components/callout/__tests__/callout.test.tsx
+++ b/packages/raystack/components/callout/__tests__/callout.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { Callout } from '../callout';
 import styles from '../callout.module.css';
@@ -141,14 +141,26 @@ describe('Callout', () => {
     });
 
     it('hides itself after dismiss when onDismiss is omitted (uncontrolled)', () => {
-      render(<Callout dismissible>Uncontrolled message</Callout>);
+      vi.useFakeTimers();
+      try {
+        render(<Callout dismissible>Uncontrolled message</Callout>);
 
-      fireEvent.click(screen.getByRole('button', { name: 'Dismiss message' }));
+        fireEvent.click(
+          screen.getByRole('button', { name: 'Dismiss message' })
+        );
 
-      expect(
-        screen.queryByText('Uncontrolled message')
-      ).not.toBeInTheDocument();
-      expect(screen.queryByRole('status')).not.toBeInTheDocument();
+        // Exit transition plays first; the callout unmounts after EXIT_MS.
+        act(() => {
+          vi.advanceTimersByTime(200);
+        });
+
+        expect(
+          screen.queryByText('Uncontrolled message')
+        ).not.toBeInTheDocument();
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('renders both action and dismissible button', () => {

--- a/packages/raystack/components/callout/callout.module.css
+++ b/packages/raystack/components/callout/callout.module.css
@@ -264,12 +264,17 @@
 
 .transitionInner {
   min-height: 0;
-  overflow: hidden;
 }
 
 .transitionShell[data-state="closing"] {
   grid-template-rows: 0fr;
   opacity: 0;
+}
+
+/* Clip only while collapsing; when open, let content (focus rings, popovers)
+   overflow the box freely. */
+.transitionShell[data-state="closing"] .transitionInner {
+  overflow: hidden;
 }
 
 @keyframes callout-enter {

--- a/packages/raystack/components/callout/callout.module.css
+++ b/packages/raystack/components/callout/callout.module.css
@@ -60,13 +60,18 @@
   align-items: center;
 }
 
-/* Dismiss button stays flat: keep the transparent background and base colour on
-   hover/active (overrides IconButton's hover feedback). The descendant selector
+/* Dismiss button stays flat: keep the transparent background and base colour
+   on hover (overrides IconButton's hover feedback). The descendant selector
    out-specifies `.iconButton:hover` regardless of stylesheet order. */
-.callout .dismiss:hover:not(:disabled),
-.callout .dismiss:active:not(:disabled) {
+.callout .dismiss:hover:not(:disabled) {
   background-color: transparent;
   color: var(--rs-color-foreground-base-secondary);
+}
+
+/* Pressed: background stays flat by design; the glyph darkens one step. */
+.callout .dismiss:active:not(:disabled) {
+  background-color: transparent;
+  color: var(--rs-color-foreground-base-primary);
 }
 
 /* Type Variants */
@@ -247,4 +252,37 @@
   background: var(--rs-color-background-base-primary);
   border: 0.5px solid var(--rs-color-border-base-tertiary);
   color: var(--rs-color-foreground-base-primary);
+}
+
+/* Enter/exit shell. Grid rows animate 1fr -> 0fr so the dismiss collapses the
+   callout's height without JS measurement; the inner wrapper clips the
+   shrinking row. */
+.transitionShell {
+  display: grid;
+  grid-template-rows: 1fr;
+}
+
+.transitionInner {
+  min-height: 0;
+  overflow: hidden;
+}
+
+.transitionShell[data-state="closing"] {
+  grid-template-rows: 0fr;
+  opacity: 0;
+}
+
+@keyframes callout-enter {
+  from {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .transitionShell {
+    animation: callout-enter var(--rs-duration-normal) var(--rs-ease-out);
+    transition:
+      grid-template-rows var(--rs-duration-normal) var(--rs-ease-out),
+      opacity var(--rs-duration-normal) var(--rs-ease-out);
+  }
 }

--- a/packages/raystack/components/callout/callout.tsx
+++ b/packages/raystack/components/callout/callout.tsx
@@ -6,11 +6,15 @@ import {
   type ComponentProps,
   type CSSProperties,
   type ReactNode,
+  useEffect,
   useState
 } from 'react';
 
 import { IconButton } from '../icon-button';
 import styles from './callout.module.css';
+
+/** Exit duration. Keep in sync with --rs-duration-normal (styles/effects.css:38). */
+const EXIT_MS = 200;
 
 const callout = cva(styles.callout, {
   variants: {
@@ -65,45 +69,56 @@ export function Callout({
   ...props
 }: CalloutProps) {
   // Dismissal is controlled when `onDismiss` is given; otherwise fall back to
-  // uncontrolled and hide the callout internally.
-  const [dismissed, setDismissed] = useState(false);
+  // uncontrolled: play the exit transition, then unmount.
+  const [state, setState] = useState<'open' | 'closing' | 'closed'>('open');
+
+  useEffect(() => {
+    if (state !== 'closing') return;
+    const timer = setTimeout(() => setState('closed'), EXIT_MS);
+    return () => clearTimeout(timer);
+  }, [state]);
+
   const handleDismiss = () => {
     onDismiss?.();
-    if (!onDismiss) setDismissed(true);
+    if (!onDismiss) setState('closing');
   };
-  if (dismissed) return null;
+  if (state === 'closed') return null;
 
   const role = type === 'alert' ? 'alert' : 'status';
 
   return (
-    <div
-      className={callout({ type, variant, highContrast, className })}
-      role={role}
-      aria-live={type === 'alert' ? 'assertive' : 'polite'}
-      {...props}
-    >
-      <div className={styles.container}>
-        <div className={styles.messageContainer}>
-          {icon && (
-            <div className={styles.icon} aria-hidden='true'>
-              {icon}
+    <div className={styles.transitionShell} data-state={state}>
+      <div className={styles.transitionInner}>
+        <div
+          className={callout({ type, variant, highContrast, className })}
+          role={role}
+          aria-live={type === 'alert' ? 'assertive' : 'polite'}
+          {...props}
+        >
+          <div className={styles.container}>
+            <div className={styles.messageContainer}>
+              {icon && (
+                <div className={styles.icon} aria-hidden='true'>
+                  {icon}
+                </div>
+              )}
+              <div className={styles.message}>{children}</div>
             </div>
-          )}
-          <div className={styles.message}>{children}</div>
-        </div>
 
-        <div className={styles.actionsContainer}>
-          {action && <div className={styles.action}>{action}</div>}
-          {dismissible && (
-            <IconButton
-              size={1}
-              className={styles.dismiss}
-              onClick={handleDismiss}
-              aria-label='Dismiss message'
-            >
-              <Cross1Icon />
-            </IconButton>
-          )}
+            <div className={styles.actionsContainer}>
+              {action && <div className={styles.action}>{action}</div>}
+              {dismissible && (
+                <IconButton
+                  size={1}
+                  className={styles.dismiss}
+                  onClick={handleDismiss}
+                  aria-label='Dismiss message'
+                >
+                  <Cross1Icon />
+                </IconButton>
+              )}
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/raystack/components/checkbox/checkbox.module.css
+++ b/packages/raystack/components/checkbox/checkbox.module.css
@@ -20,6 +20,9 @@
   border: 1px solid var(--rs-color-border-base-secondary);
   cursor: pointer;
   flex-shrink: 0;
+  transition:
+    background-color var(--rs-duration-fast) var(--rs-ease-out),
+    border-color var(--rs-duration-fast) var(--rs-ease-out);
 }
 
 /* Size variants */
@@ -40,6 +43,28 @@
 .checkbox:not([data-disabled]):hover {
   background: var(--rs-color-background-base-primary-hover);
   border-color: var(--rs-color-border-base-focus);
+}
+
+.checkbox:focus-visible {
+  outline: var(--rs-focus-ring);
+}
+
+/* Checked = accent fill: offset the ring so it clears it. */
+.checkbox[data-checked]:focus-visible {
+  outline-offset: var(--rs-focus-ring-offset-accent);
+}
+
+.checkbox:active:not([data-disabled]):not([data-readonly]) {
+  transform: scale(var(--rs-scale-pressed-strong));
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .checkbox {
+    transition:
+      background-color var(--rs-duration-fast) var(--rs-ease-out),
+      border-color var(--rs-duration-fast) var(--rs-ease-out),
+      transform var(--rs-duration-press) var(--rs-ease-out);
+  }
 }
 
 .checkbox[data-checked] {
@@ -107,6 +132,26 @@
   width: 100%;
   height: 100%;
   color: var(--rs-color-foreground-accent-emphasis);
+  transition: opacity var(--rs-duration-fast) var(--rs-ease-out);
+}
+
+.indicator[data-starting-style],
+.indicator[data-ending-style],
+.indicator[data-unchecked] {
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .indicator {
+    transition:
+      opacity var(--rs-duration-fast) var(--rs-ease-out),
+      transform var(--rs-duration-fast) var(--rs-ease-out);
+  }
+
+  .indicator[data-starting-style],
+  .indicator[data-ending-style] {
+    transform: scale(0.8);
+  }
 }
 
 .icon {

--- a/packages/raystack/components/checkbox/checkbox.module.css
+++ b/packages/raystack/components/checkbox/checkbox.module.css
@@ -102,7 +102,6 @@
 .checkbox[data-invalid][data-checked],
 .checkbox[data-invalid][data-indeterminate] {
   background: var(--rs-color-background-danger-primary);
-  border-color: var(--rs-color-border-danger-primary);
 }
 
 /* A4: Disabled state */

--- a/packages/raystack/components/checkbox/checkbox.tsx
+++ b/packages/raystack/components/checkbox/checkbox.tsx
@@ -3,6 +3,7 @@
 import { Checkbox as CheckboxPrimitive } from '@base-ui/react/checkbox';
 import { CheckboxGroup as CheckboxGroupPrimitive } from '@base-ui/react/checkbox-group';
 import { cva, cx, type VariantProps } from 'class-variance-authority';
+import { useRef } from 'react';
 import { useFieldContext } from '../field';
 
 import styles from './checkbox.module.css';
@@ -94,6 +95,12 @@ function CheckboxItem({
 }: CheckboxItemProps) {
   const fieldContext = useFieldContext();
   const resolvedRequired = required ?? fieldContext?.required;
+  // Remember which icon is showing while the indicator is up. During the exit
+  // (transitionStatus 'ending') Base UI has already flipped checked/
+  // indeterminate to the new value, so reading it live would flash the
+  // checkmark for a frame on an indeterminate → unchecked change. Render the
+  // remembered icon during the exit instead.
+  const shownIconRef = useRef<'check' | 'indeterminate'>('check');
 
   return (
     <CheckboxPrimitive.Root
@@ -106,18 +113,30 @@ function CheckboxItem({
         keepMounted
         render={
           render ??
-          ((props, state) => (
-            <span {...props}>
-              {(state.checked ||
-                state.indeterminate ||
-                state.transitionStatus === 'ending') &&
-                (state.indeterminate ? (
-                  <IndeterminateIcon />
-                ) : (
-                  <CheckMarkIcon />
-                ))}
-            </span>
-          ))
+          ((props, state) => {
+            const isEnding = state.transitionStatus === 'ending';
+            if (!isEnding) {
+              shownIconRef.current = state.indeterminate
+                ? 'indeterminate'
+                : 'check';
+            }
+            const showIcon = state.checked || state.indeterminate || isEnding;
+            const icon = isEnding
+              ? shownIconRef.current
+              : state.indeterminate
+                ? 'indeterminate'
+                : 'check';
+            return (
+              <span {...props}>
+                {showIcon &&
+                  (icon === 'indeterminate' ? (
+                    <IndeterminateIcon />
+                  ) : (
+                    <CheckMarkIcon />
+                  ))}
+              </span>
+            );
+          })
         }
       />
     </CheckboxPrimitive.Root>

--- a/packages/raystack/components/checkbox/checkbox.tsx
+++ b/packages/raystack/components/checkbox/checkbox.tsx
@@ -103,11 +103,19 @@ function CheckboxItem({
     >
       <CheckboxPrimitive.Indicator
         className={styles.indicator}
+        keepMounted
         render={
           render ??
           ((props, state) => (
             <span {...props}>
-              {state.indeterminate ? <IndeterminateIcon /> : <CheckMarkIcon />}
+              {(state.checked ||
+                state.indeterminate ||
+                state.transitionStatus === 'ending') &&
+                (state.indeterminate ? (
+                  <IndeterminateIcon />
+                ) : (
+                  <CheckMarkIcon />
+                ))}
             </span>
           ))
         }

--- a/packages/raystack/components/chip/__tests__/chip.test.tsx
+++ b/packages/raystack/components/chip/__tests__/chip.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { Chip } from '../chip';
 import styles from '../chip.module.css';
@@ -150,8 +151,28 @@ describe('Chip', () => {
       const onClick = vi.fn();
       render(<Chip onClick={onClick}>Clickable Chip</Chip>);
 
-      const chip = screen.getByRole('status');
+      const chip = screen.getByRole('button', { name: 'Clickable Chip' });
       fireEvent.click(chip);
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders a real button element for clickable chips', () => {
+      render(<Chip onClick={vi.fn()}>Clickable Chip</Chip>);
+
+      const chip = screen.getByRole('button', { name: 'Clickable Chip' });
+      expect(chip.tagName).toBe('BUTTON');
+      expect(chip).toHaveAttribute('type', 'button');
+    });
+
+    it('activates via keyboard Enter when focused', async () => {
+      const user = userEvent.setup();
+      const onClick = vi.fn();
+      render(<Chip onClick={onClick}>Clickable Chip</Chip>);
+
+      const chip = screen.getByRole('button', { name: 'Clickable Chip' });
+      chip.focus();
+      await user.keyboard('{Enter}');
 
       expect(onClick).toHaveBeenCalledTimes(1);
     });
@@ -188,7 +209,7 @@ describe('Chip', () => {
         </Chip>
       );
 
-      const chip = screen.getByRole('status');
+      const chip = screen.getByRole('button', { name: 'Disabled Chip' });
       fireEvent.click(chip);
       expect(onClick).not.toHaveBeenCalled();
     });

--- a/packages/raystack/components/chip/chip.module.css
+++ b/packages/raystack/components/chip/chip.module.css
@@ -130,3 +130,33 @@
   align-items: center;
   justify-content: center;
 }
+
+.chip-interactive {
+  cursor: pointer;
+  appearance: none;
+  font-family: inherit;
+}
+
+.chip-interactive:focus,
+.dismiss-button:focus {
+  outline: none;
+}
+
+.chip-interactive:focus-visible {
+  outline: var(--rs-focus-ring);
+}
+
+.dismiss-button:focus-visible {
+  outline: var(--rs-focus-ring);
+  border-radius: var(--rs-radius-1);
+}
+
+.dismiss-button:active {
+  transform: scale(var(--rs-scale-pressed-strong));
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .dismiss-button {
+    transition: transform var(--rs-duration-press) var(--rs-ease-out);
+  }
+}

--- a/packages/raystack/components/chip/chip.tsx
+++ b/packages/raystack/components/chip/chip.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { cva, type VariantProps } from 'class-variance-authority';
+import { cva, cx, type VariantProps } from 'class-variance-authority';
 import { ComponentProps, ReactNode } from 'react';
 
 import styles from './chip.module.css';
@@ -48,7 +48,7 @@ export const Chip = ({
   className,
   onDismiss,
   onClick,
-  role = 'status',
+  role,
   disabled,
   'aria-label': ariaLabel,
   ...props
@@ -58,17 +58,16 @@ export const Chip = ({
     onDismiss?.();
   };
 
-  return (
-    <span
-      {...props}
-      className={chip({ variant, size, color, className })}
-      role={role}
-      aria-label={
-        ariaLabel ?? (typeof children === 'string' ? children : undefined)
-      }
-      onClick={disabled ? undefined : onClick}
-      data-disabled={disabled || undefined}
-    >
+  const isInteractive = !!onClick && !isDismissible;
+
+  const sharedProps = {
+    'aria-label':
+      ariaLabel ?? (typeof children === 'string' ? children : undefined),
+    'data-disabled': disabled || undefined
+  };
+
+  const content = (
+    <>
       {leadingIcon && (
         <span
           className={styles['leading-icon']}
@@ -114,6 +113,41 @@ export const Chip = ({
           {trailingIcon}
         </span>
       ) : null}
+    </>
+  );
+
+  if (isInteractive) {
+    return (
+      <button
+        {...(props as React.ComponentProps<'button'>)}
+        {...sharedProps}
+        type='button'
+        disabled={disabled}
+        role={role}
+        className={chip({
+          variant,
+          size,
+          color,
+          className: cx(styles['chip-interactive'], className)
+        })}
+        onClick={
+          onClick as unknown as React.MouseEventHandler<HTMLButtonElement>
+        }
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return (
+    <span
+      {...props}
+      {...sharedProps}
+      className={chip({ variant, size, color, className })}
+      role={role ?? 'status'}
+      onClick={disabled ? undefined : onClick}
+    >
+      {content}
     </span>
   );
 };

--- a/packages/raystack/components/code-block/__tests__/code-block.test.tsx
+++ b/packages/raystack/components/code-block/__tests__/code-block.test.tsx
@@ -13,11 +13,9 @@ vi.mock('~/hooks/useCopyToClipboard', () => ({
 }));
 
 // Mock icon components used inside CopyButton to avoid invalid element errors
-vi.mock('~/icons', () => ({
-  CheckCircleFilledIcon: () => null
-}));
 vi.mock('@radix-ui/react-icons', () => ({
   CopyIcon: () => null,
+  CheckIcon: () => null,
   ChevronDownIcon: () => null
 }));
 

--- a/packages/raystack/components/code-block/__tests__/code-block.test.tsx
+++ b/packages/raystack/components/code-block/__tests__/code-block.test.tsx
@@ -16,7 +16,8 @@ vi.mock('~/hooks/useCopyToClipboard', () => ({
 vi.mock('@radix-ui/react-icons', () => ({
   CopyIcon: () => null,
   CheckIcon: () => null,
-  ChevronDownIcon: () => null
+  ChevronDownIcon: () => null,
+  CaretSortIcon: () => null
 }));
 
 const JAVASCRIPT_CODE = `function hello() {

--- a/packages/raystack/components/code-block/code-block.module.css
+++ b/packages/raystack/components/code-block/code-block.module.css
@@ -95,12 +95,19 @@
   border: 0.5px solid var(--rs-color-border-base-tertiary);
   background: var(--rs-color-background-base-primary);
   box-shadow: var(--rs-shadow-feather);
+  /* Re-compose the IconButton base transition so hover color feedback is
+     kept, then override its opacity entry with the fast reveal tier.
+     (Duplicate properties in a transition list: the last one wins.) */
+  transition:
+    var(--rs-transition-interactive),
+    opacity var(--rs-duration-fast) var(--rs-ease-out);
 }
 .floatingCopyButton svg {
   width: var(--rs-space-4);
   height: var(--rs-space-5);
 }
 
-.content:hover .floatingCopyButton {
+.content:hover .floatingCopyButton,
+.floatingCopyButton:focus-visible {
   opacity: 1;
 }

--- a/packages/raystack/components/code-block/code-block.module.css
+++ b/packages/raystack/components/code-block/code-block.module.css
@@ -3,6 +3,8 @@
   border-radius: var(--rs-radius-2);
   overflow: hidden;
   width: 100%;
+  border: 0.5px solid var(--rs-color-overlay-base-a2);
+  box-sizing: border-box;
 }
 
 /* Code Block Content */

--- a/packages/raystack/components/code-block/code-block.module.css
+++ b/packages/raystack/components/code-block/code-block.module.css
@@ -105,7 +105,7 @@
     opacity var(--rs-duration-fast) var(--rs-ease-out);
 }
 .floatingCopyButton svg {
-  width: var(--rs-space-4);
+  width: var(--rs-space-5);
   height: var(--rs-space-5);
 }
 

--- a/packages/raystack/components/collapsible/collapsible.module.css
+++ b/packages/raystack/components/collapsible/collapsible.module.css
@@ -3,6 +3,10 @@
   outline: none;
 }
 
+.trigger:focus-visible {
+  outline: var(--rs-focus-ring);
+}
+
 .trigger:disabled {
   pointer-events: none;
   opacity: 0.5;
@@ -20,6 +24,6 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .panel {
-    transition: height 150ms ease-out;
+    transition: height var(--rs-duration-fast) var(--rs-ease-out);
   }
 }

--- a/packages/raystack/components/color-picker/__tests__/color-picker.test.tsx
+++ b/packages/raystack/components/color-picker/__tests__/color-picker.test.tsx
@@ -96,6 +96,48 @@ describe('ColorPicker', () => {
       // assert the background string directly.)
       expect(area.querySelector('canvas')).not.toBeInTheDocument();
     });
+
+    it('is focusable with an accessible slider name', () => {
+      render(
+        <ColorPicker>
+          <ColorPicker.Area />
+        </ColorPicker>
+      );
+
+      const area = screen.getByRole('slider', { name: /color area/i });
+      area.focus();
+      expect(area).toHaveFocus();
+    });
+
+    it('updates the color with arrow keys in oklch mode', () => {
+      const onValueChange = vi.fn();
+      render(
+        <ColorPicker mode='oklch' onValueChange={onValueChange}>
+          <ColorPicker.Area />
+        </ColorPicker>
+      );
+
+      const area = screen.getByRole('slider', { name: /color area/i });
+      area.focus();
+      fireEvent.keyDown(area, { key: 'ArrowRight' });
+
+      expect(onValueChange).toHaveBeenCalled();
+    });
+
+    it('updates the color with arrow keys in hex mode', () => {
+      const onValueChange = vi.fn();
+      render(
+        <ColorPicker mode='hex' onValueChange={onValueChange}>
+          <ColorPicker.Area />
+        </ColorPicker>
+      );
+
+      const area = screen.getByRole('slider', { name: /color area/i });
+      area.focus();
+      fireEvent.keyDown(area, { key: 'ArrowRight' });
+
+      expect(onValueChange).toHaveBeenCalled();
+    });
   });
 
   describe('ColorPicker.Hue', () => {

--- a/packages/raystack/components/color-picker/color-picker-area.tsx
+++ b/packages/raystack/components/color-picker/color-picker-area.tsx
@@ -91,8 +91,8 @@ const OklchArea = ({ className, ...props }: ColorPickerAreaProps) => {
     if (!thumbRef.current) return;
     const x = clamp01(chroma / CHROMA_MAX);
     const y = clamp01(1 - lightness);
-    thumbRef.current.style.left = `${x * 100}%`;
-    thumbRef.current.style.top = `${y * 100}%`;
+    thumbRef.current.style.setProperty('--thumb-x', String(x));
+    thumbRef.current.style.setProperty('--thumb-y', String(y));
     if (!isThumbVisible.current) {
       isThumbVisible.current = true;
       thumbRef.current.style.opacity = '1';
@@ -185,8 +185,8 @@ const HslArea = ({ className, ...props }: ColorPickerAreaProps) => {
     const x = clamp01(hsl.s / 100);
     const topLightness = x < 0.01 ? 100 : 50 + 50 * (1 - x);
     const y = clamp01(1 - hsl.l / topLightness);
-    thumbRef.current.style.left = `${x * 100}%`;
-    thumbRef.current.style.top = `${y * 100}%`;
+    thumbRef.current.style.setProperty('--thumb-x', String(x));
+    thumbRef.current.style.setProperty('--thumb-y', String(y));
     if (!isThumbVisible.current) {
       isThumbVisible.current = true;
       thumbRef.current.style.opacity = '1';

--- a/packages/raystack/components/color-picker/color-picker-area.tsx
+++ b/packages/raystack/components/color-picker/color-picker-area.tsx
@@ -3,6 +3,7 @@
 import { cx } from 'class-variance-authority';
 import {
   ComponentProps,
+  KeyboardEvent as ReactKeyboardEvent,
   PointerEvent as ReactPointerEvent,
   useCallback,
   useEffect,
@@ -23,6 +24,11 @@ import {
 // container size; a 96² grid is the sweet spot between a smooth gradient and
 // keeping the per-hue repaint comfortably inside one frame.
 const CANVAS_RES = 96;
+
+// Keyboard nudge sizes in the same normalized 0..1 pad space the pointer
+// uses: 1% of an axis per Arrow press, 10% for Shift+Arrow and PageUp/Down.
+const STEP = 0.01;
+const STEP_LARGE = 0.1;
 
 export type ColorPickerAreaProps = ComponentProps<'div'>;
 
@@ -99,6 +105,16 @@ const OklchArea = ({ className, ...props }: ColorPickerAreaProps) => {
     }
   }, [lightness, chroma]);
 
+  // Shared color-computation path. Takes normalized 0..1 pad coordinates
+  // (x = chroma axis, y = lightness axis) and writes them into OKLCH state.
+  // Pointer drag and keyboard both go through this so behavior can't diverge.
+  const applyPosition = useCallback(
+    (x: number, y: number) => {
+      setColor({ c: clamp01(x) * CHROMA_MAX, l: 1 - clamp01(y) });
+    },
+    [setColor]
+  );
+
   const handlePointerMove = useCallback(
     (event: PointerEvent) => {
       if (!(isDragging.current && containerRef.current)) return;
@@ -107,9 +123,9 @@ const OklchArea = ({ className, ...props }: ColorPickerAreaProps) => {
       const rect = containerRef.current.getBoundingClientRect();
       const x = clamp01((event.clientX - rect.left) / rect.width);
       const y = clamp01((event.clientY - rect.top) / rect.height);
-      setColor({ c: x * CHROMA_MAX, l: 1 - y });
+      applyPosition(x, y);
     },
-    [setColor]
+    [applyPosition]
   );
 
   const handlePointerUp = useCallback(() => {
@@ -134,11 +150,64 @@ const OklchArea = ({ className, ...props }: ColorPickerAreaProps) => {
     [handlePointerMove, handlePointerUp]
   );
 
+  const handleKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLDivElement>) => {
+      // Current thumb position, mirrored from the same math the thumb effect
+      // uses (x = chroma / CHROMA_MAX, y = 1 - lightness).
+      let x = clamp01(chroma / CHROMA_MAX);
+      let y = clamp01(1 - lightness);
+      const step = e.shiftKey ? STEP_LARGE : STEP;
+      switch (e.key) {
+        case 'ArrowLeft':
+          x -= step;
+          break;
+        case 'ArrowRight':
+          x += step;
+          break;
+        case 'ArrowUp':
+          y -= step; // up = more lightness (y = 1 - L)
+          break;
+        case 'ArrowDown':
+          y += step;
+          break;
+        case 'PageUp':
+          y -= STEP_LARGE;
+          break;
+        case 'PageDown':
+          y += STEP_LARGE;
+          break;
+        case 'Home':
+          x = 0; // no chroma
+          break;
+        case 'End':
+          x = 1; // max chroma
+          break;
+        default:
+          return; // let other keys (Tab, etc.) pass through
+      }
+      e.preventDefault();
+      applyPosition(x, y);
+    },
+    [applyPosition, chroma, lightness]
+  );
+
+  const valueText =
+    `chroma ${Math.round((chroma / CHROMA_MAX) * 100)}%, ` +
+    `lightness ${Math.round(lightness * 100)}%`;
+
   return (
     <div
       className={cx(styles.selectionRoot, className)}
       onPointerDown={handlePointerDown}
+      onKeyDown={handleKeyDown}
       ref={containerRef}
+      role='slider'
+      tabIndex={0}
+      aria-label='Color area, chroma and lightness'
+      aria-valuetext={valueText}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={Math.round((chroma / CHROMA_MAX) * 100)}
       {...props}
     >
       <canvas
@@ -193,6 +262,22 @@ const HslArea = ({ className, ...props }: ColorPickerAreaProps) => {
     }
   }, [hsl.s, hsl.l]);
 
+  // Shared color-computation path. Takes normalized 0..1 pad coordinates
+  // (x = saturation axis, y = scaled-lightness axis) and round-trips through
+  // hslToOklch into OKLCH state. Pointer drag and keyboard both go through
+  // this so behavior can't diverge.
+  const applyPosition = useCallback(
+    (x: number, y: number) => {
+      const cx0 = clamp01(x);
+      const saturation = cx0 * 100;
+      const topLightness = cx0 < 0.01 ? 100 : 50 + 50 * (1 - cx0);
+      const nextL = topLightness * (1 - clamp01(y));
+      const next = hslToOklch(hsl.h, saturation, nextL);
+      setColor({ l: next.l, c: next.c, h: next.h });
+    },
+    [hsl.h, setColor]
+  );
+
   const handlePointerMove = useCallback(
     (event: PointerEvent) => {
       if (!(isDragging.current && containerRef.current)) return;
@@ -201,13 +286,9 @@ const HslArea = ({ className, ...props }: ColorPickerAreaProps) => {
       const rect = containerRef.current.getBoundingClientRect();
       const x = clamp01((event.clientX - rect.left) / rect.width);
       const y = clamp01((event.clientY - rect.top) / rect.height);
-      const saturation = x * 100;
-      const topLightness = x < 0.01 ? 100 : 50 + 50 * (1 - x);
-      const nextL = topLightness * (1 - y);
-      const next = hslToOklch(hsl.h, saturation, nextL);
-      setColor({ l: next.l, c: next.c, h: next.h });
+      applyPosition(x, y);
     },
-    [hsl.h, setColor]
+    [applyPosition]
   );
 
   const handlePointerUp = useCallback(() => {
@@ -232,11 +313,66 @@ const HslArea = ({ className, ...props }: ColorPickerAreaProps) => {
     [handlePointerMove, handlePointerUp]
   );
 
+  const handleKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLDivElement>) => {
+      // Current position mirrored from the same math the thumb effect uses.
+      let x = clamp01(hsl.s / 100);
+      const topLightness = x < 0.01 ? 100 : 50 + 50 * (1 - x);
+      let y = clamp01(1 - hsl.l / topLightness);
+      const step = e.shiftKey ? STEP_LARGE : STEP;
+      switch (e.key) {
+        case 'ArrowLeft':
+          x -= step;
+          break;
+        case 'ArrowRight':
+          x += step;
+          break;
+        case 'ArrowUp':
+          y -= step;
+          break;
+        case 'ArrowDown':
+          y += step;
+          break;
+        case 'PageUp':
+          y -= STEP_LARGE;
+          break;
+        case 'PageDown':
+          y += STEP_LARGE;
+          break;
+        case 'Home':
+          x = 0;
+          break;
+        case 'End':
+          x = 1;
+          break;
+        default:
+          return;
+      }
+      e.preventDefault();
+      applyPosition(x, y);
+    },
+    [applyPosition, hsl.s, hsl.l]
+  );
+
+  const topLightnessNow =
+    hsl.s / 100 < 0.01 ? 100 : 50 + 50 * (1 - hsl.s / 100);
+  const valueText =
+    `saturation ${Math.round(hsl.s)}%, ` +
+    `brightness ${Math.round((hsl.l / topLightnessNow) * 100)}%`;
+
   return (
     <div
       className={cx(styles.selectionRoot, className)}
       onPointerDown={handlePointerDown}
+      onKeyDown={handleKeyDown}
       ref={containerRef}
+      role='slider'
+      tabIndex={0}
+      aria-label='Color area, saturation and brightness'
+      aria-valuetext={valueText}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={Math.round(hsl.s)}
       style={{ background }}
       {...props}
     >

--- a/packages/raystack/components/color-picker/color-picker.module.css
+++ b/packages/raystack/components/color-picker/color-picker.module.css
@@ -123,6 +123,11 @@
   user-select: none;
 }
 
+.selectionRoot:focus-visible {
+  outline: var(--rs-focus-ring);
+  outline-offset: var(--rs-focus-ring-offset-inset);
+}
+
 .selectionCanvas {
   display: block;
   width: 100%;

--- a/packages/raystack/components/color-picker/color-picker.module.css
+++ b/packages/raystack/components/color-picker/color-picker.module.css
@@ -66,7 +66,7 @@
 }
 
 .sliderThumb:focus-visible {
-  outline: none;
+  outline: var(--rs-focus-ring);
 }
 
 .sliderThumb:disabled {
@@ -117,6 +117,10 @@
   aspect-ratio: 1 / 1;
   border-radius: var(--rs-radius-1);
   overflow: hidden;
+  /* thumb transform below resolves 100cqw/100cqh against this box */
+  container-type: size;
+  touch-action: none;
+  user-select: none;
 }
 
 .selectionCanvas {
@@ -127,6 +131,16 @@
 
 .selectionThumb {
   position: absolute;
+  left: 0;
+  top: 0;
   pointer-events: none;
-  transform: translate(-50%, -50%);
+  /* --thumb-x / --thumb-y are unitless 0..1 fractions set from JS.
+     First translate() positions within the container (cq units),
+     second translate() keeps the existing -50% self-centering. */
+  transform: translate(
+      calc(var(--thumb-x, 0) * 100cqw),
+      calc(var(--thumb-y, 0) * 100cqh)
+    )
+    translate(-50%, -50%);
+  transition: opacity var(--rs-duration-fast) var(--rs-ease-out);
 }

--- a/packages/raystack/components/combobox/combobox-input.tsx
+++ b/packages/raystack/components/combobox/combobox-input.tsx
@@ -4,7 +4,6 @@ import { Combobox as ComboboxPrimitive } from '@base-ui/react';
 import { ChevronDownIcon } from '@radix-ui/react-icons';
 import { type ComponentProps } from 'react';
 import { Input } from '../input';
-import styles from './combobox.module.css';
 import { useComboboxContext } from './combobox-root';
 
 export interface ComboboxInputProps
@@ -31,7 +30,7 @@ export const ComboboxInput = ({ ref, ...props }: ComboboxInputProps) => {
                 }))
               : undefined
           }
-          trailingIcon={<ChevronDownIcon className={styles.triggerIcon} />}
+          trailingIcon={<ChevronDownIcon />}
           {...props}
         />
       }

--- a/packages/raystack/components/combobox/combobox.module.css
+++ b/packages/raystack/components/combobox/combobox.module.css
@@ -10,7 +10,7 @@
   background-color: var(--rs-color-background-base-primary);
   border-radius: var(--rs-radius-2);
   box-shadow: var(--rs-shadow-soft);
-  border: 1px solid var(--rs-color-border-base-primary);
+  border: 0.5px solid var(--rs-color-border-base-primary);
   /* Todo: var does not exist for 320px */
   max-height: 320px;
   min-width: var(--anchor-width);

--- a/packages/raystack/components/combobox/combobox.module.css
+++ b/packages/raystack/components/combobox/combobox.module.css
@@ -15,6 +15,26 @@
   max-height: 320px;
   min-width: var(--anchor-width);
   overflow: auto;
+  transform-origin: var(--transform-origin);
+  transition: opacity var(--rs-duration-fast) var(--rs-ease-out);
+}
+
+.content[data-starting-style],
+.content[data-ending-style] {
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .content {
+    transition:
+      opacity var(--rs-duration-fast) var(--rs-ease-out),
+      transform var(--rs-duration-fast) var(--rs-ease-out);
+  }
+
+  .content[data-starting-style],
+  .content[data-ending-style] {
+    transform: scale(0.97);
+  }
 }
 
 .list {

--- a/packages/raystack/components/command/command-dialog.tsx
+++ b/packages/raystack/components/command/command-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
 import { cx } from 'class-variance-authority';
-import { forwardRef } from 'react';
+import { forwardRef, useRef } from 'react';
 import styles from './command.module.css';
 
 export const CommandDialog = (props: DialogPrimitive.Root.Props) => (
@@ -17,37 +17,49 @@ export const CommandDialogTrigger = forwardRef<
 CommandDialogTrigger.displayName = 'Command.DialogTrigger';
 
 export interface CommandDialogContentProps extends DialogPrimitive.Popup.Props {
-  overlay?: DialogPrimitive.Backdrop.Props & { blur?: boolean };
   width?: string | number;
 }
 
 export function CommandDialogContent({
   className,
   children,
-  overlay,
   width,
   style,
   ...props
 }: CommandDialogContentProps) {
-  const {
-    blur = false,
-    className: overlayClassName,
-    ...overlayProps
-  } = overlay ?? {};
+  const popupRef = useRef<HTMLDivElement>(null);
+  /* Remember what had focus before the palette opened. Base UI otherwise
+     always returns focus to the trigger on close, so the trigger shows a focus
+     ring even when the palette was opened by a keyboard shortcut (the trigger
+     was never focused). Restoring the real origin matches how command palettes
+     usually behave: focus goes back to the trigger only when you opened it by
+     clicking the trigger. */
+  const originRef = useRef<HTMLElement | null>(null);
+
   return (
     <DialogPrimitive.Portal>
-      <DialogPrimitive.Backdrop
-        {...overlayProps}
-        className={cx(
-          styles.overlay,
-          blur && styles.overlayBlur,
-          overlayClassName
-        )}
-      />
       <DialogPrimitive.Viewport className={styles.viewport}>
         <DialogPrimitive.Popup
+          ref={popupRef}
           className={cx(styles.dialogPopup, className)}
           style={{ width, ...style }}
+          initialFocus={openType => {
+            /* Runs before focus moves into the popup, so activeElement is
+               still the element focused before opening. */
+            originRef.current = document.activeElement as HTMLElement | null;
+            /* Keep Base UI's default: focus the popup on touch to avoid
+               popping the on-screen keyboard, otherwise the first tabbable. */
+            return openType === 'touch' ? popupRef.current : true;
+          }}
+          finalFocus={() => {
+            const origin = originRef.current;
+            /* Only restore to a real, still-connected element. Returning false
+               skips focus return (Base UI would otherwise fall back to the
+               trigger or the page's first tabbable). */
+            return origin && origin !== document.body && origin.isConnected
+              ? origin
+              : false;
+          }}
           {...props}
         >
           {children}

--- a/packages/raystack/components/command/command-dialog.tsx
+++ b/packages/raystack/components/command/command-dialog.tsx
@@ -39,8 +39,8 @@ export function CommandDialogContent({
       <DialogPrimitive.Backdrop
         {...overlayProps}
         className={cx(
-          styles.backdrop,
-          blur && styles.backdropBlur,
+          styles.overlay,
+          blur && styles.overlayBlur,
           overlayClassName
         )}
       />

--- a/packages/raystack/components/command/command-input.tsx
+++ b/packages/raystack/components/command/command-input.tsx
@@ -31,6 +31,7 @@ export const CommandInput = ({
         render={
           <Input
             containerRef={inputContainerRef}
+            classNames={{ container: styles.commandInputContainer }}
             leadingIcon={leadingIcon}
             variant='borderless'
             size={size}

--- a/packages/raystack/components/command/command.module.css
+++ b/packages/raystack/components/command/command.module.css
@@ -157,23 +157,15 @@
   background-color: var(--rs-color-border-base-primary);
 }
 
-.backdrop {
+.overlay {
   position: fixed;
   inset: 0;
   z-index: var(--rs-z-index-portal);
   background-color: var(--rs-color-overlay-black-a5);
-  transition:
-    opacity 200ms ease-out,
-    backdrop-filter 200ms ease-out;
 }
 
-.backdropBlur {
+.overlayBlur {
   backdrop-filter: var(--rs-blur-lg);
-}
-
-.backdrop[data-starting-style],
-.backdrop[data-ending-style] {
-  opacity: 0;
 }
 
 .viewport {
@@ -202,13 +194,12 @@
   overflow: hidden;
   outline: none;
   isolation: isolate;
-  transition:
-    opacity 200ms ease-out,
-    transform 200ms ease-out;
 }
 
-.dialogPopup[data-starting-style],
-.dialogPopup[data-ending-style] {
-  opacity: 0;
-  transform: scale(0.98);
+/* Reduced transparency: drop the blur, compensate with a heavier solid scrim */
+@media (prefers-reduced-transparency: reduce) {
+  .overlayBlur {
+    backdrop-filter: none;
+    background-color: var(--rs-color-overlay-black-a9);
+  }
 }

--- a/packages/raystack/components/command/command.module.css
+++ b/packages/raystack/components/command/command.module.css
@@ -14,11 +14,6 @@
   background-color: var(--rs-color-background-base-primary);
 }
 
-.inputWrapper > *:hover,
-.inputWrapper > *:focus-within {
-  background: var(--rs-color-background-base-primary);
-}
-
 .list {
   display: flex;
   flex-direction: column;

--- a/packages/raystack/components/command/command.module.css
+++ b/packages/raystack/components/command/command.module.css
@@ -14,6 +14,13 @@
   background-color: var(--rs-color-background-base-primary);
 }
 
+/* The search bar sits in its own dialog panel, so the borderless input's
+   keyboard focus ring is redundant here. The doubled class outranks the base
+   ring rule without needing !important. */
+.commandInputContainer.commandInputContainer:has(input:focus-visible) {
+  box-shadow: none;
+}
+
 .list {
   display: flex;
   flex-direction: column;
@@ -152,26 +159,12 @@
   background-color: var(--rs-color-border-base-primary);
 }
 
-.overlay {
-  position: fixed;
-  inset: 0;
-  z-index: var(--rs-z-index-portal);
-  background-color: var(--rs-color-overlay-black-a5);
-}
-
-.overlayBlur {
-  backdrop-filter: var(--rs-blur-lg);
-}
-
+/* No backdrop, so let clicks fall through the viewport to trigger dismissal;
+   the popup itself re-enables pointer events. */
 .viewport {
   position: fixed;
   inset: 0;
   z-index: var(--rs-z-index-portal);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: var(--rs-space-4);
   pointer-events: none;
 }
 
@@ -179,10 +172,17 @@
   pointer-events: auto;
   display: flex;
   flex-direction: column;
-  width: 100%;
-  max-width: 540px;
+  width: 540px;
+  max-width: 90vw;
   max-height: min(420px, 80vh);
   min-height: 0;
+  position: fixed;
+  top: 0;
+  left: 50%;
+  /* Match Dialog: sit 160px from the top on tall viewports, and fall back to
+     centered on short ones so the popup stays inside the viewport. The input
+     stays put while the list below changes height. */
+  transform: translate(-50%, min(160px, calc(50vh - 50%)));
   background-color: var(--rs-color-background-base-primary);
   border-radius: var(--rs-radius-2);
   box-shadow: var(--rs-shadow-floating);
@@ -191,10 +191,14 @@
   isolation: isolate;
 }
 
-/* Reduced transparency: drop the blur, compensate with a heavier solid scrim */
-@media (prefers-reduced-transparency: reduce) {
-  .overlayBlur {
-    backdrop-filter: none;
-    background-color: var(--rs-color-overlay-black-a9);
+/* Subtlest cue that still animates: a quick opacity-only fade, no movement. */
+@media (prefers-reduced-motion: no-preference) {
+  .dialogPopup {
+    transition: opacity var(--rs-duration-press) var(--rs-ease-out);
+  }
+
+  .dialogPopup[data-starting-style],
+  .dialogPopup[data-ending-style] {
+    opacity: 0;
   }
 }

--- a/packages/raystack/components/copy-button/copy-button.module.css
+++ b/packages/raystack/components/copy-button/copy-button.module.css
@@ -1,0 +1,57 @@
+/* Both icons are stacked in one grid cell and cross-fade on copy. */
+.iconSwap {
+  display: grid;
+  place-items: center;
+}
+
+.iconSwap > * {
+  grid-area: 1 / 1;
+  width: 100%;
+  height: 100%;
+  transition: opacity var(--rs-duration-fast) var(--rs-ease-out);
+}
+
+.checkIcon {
+  opacity: 0;
+}
+
+.iconSwap[data-copied] .copyIcon {
+  opacity: 0;
+}
+
+.iconSwap[data-copied] .checkIcon {
+  opacity: 1;
+}
+
+/* Under motion, the incoming icon grows in and the outgoing shrinks away. */
+@media (prefers-reduced-motion: no-preference) {
+  .iconSwap > * {
+    transition:
+      opacity var(--rs-duration-fast) var(--rs-ease-out),
+      transform var(--rs-duration-fast) var(--rs-ease-out);
+  }
+
+  .checkIcon {
+    transform: scale(0.8);
+  }
+
+  .iconSwap[data-copied] .copyIcon {
+    transform: scale(0.8);
+  }
+
+  .iconSwap[data-copied] .checkIcon {
+    transform: scale(1);
+  }
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/packages/raystack/components/copy-button/copy-button.tsx
+++ b/packages/raystack/components/copy-button/copy-button.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { CopyIcon } from '@radix-ui/react-icons';
-import { useState } from 'react';
+import { CheckIcon, CopyIcon } from '@radix-ui/react-icons';
+import { useEffect, useRef, useState } from 'react';
 import { useCopyToClipboard } from '~/hooks/useCopyToClipboard';
-import { CheckCircleFilledIcon } from '~/icons';
 import { IconButton, IconButtonProps } from '../icon-button/icon-button';
+import styles from './copy-button.module.css';
 
 export interface CopyButtonProps extends IconButtonProps {
   text: string;
@@ -19,28 +19,48 @@ export function CopyButton({
   ...props
 }: CopyButtonProps) {
   const { copy } = useCopyToClipboard();
-  const [isCopied, setIsCopied] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current !== null) clearTimeout(resetTimerRef.current);
+    };
+  }, []);
 
   async function onCopy() {
     const res = await copy(text);
-    if (res) {
-      setIsCopied(true);
-      if (resetIcon) {
-        setTimeout(() => {
-          setIsCopied(false);
-        }, resetTimeout);
-      }
+    if (!res) return;
+    setCopied(true);
+    if (resetIcon) {
+      if (resetTimerRef.current !== null) clearTimeout(resetTimerRef.current);
+      resetTimerRef.current = setTimeout(() => {
+        setCopied(false);
+        resetTimerRef.current = null;
+      }, resetTimeout);
     }
   }
 
   return (
-    <IconButton {...props} onClick={onCopy} data-test-id='copy-button'>
-      {isCopied ? (
-        <CheckCircleFilledIcon color='var(--rs-color-foreground-success-primary)' />
-      ) : (
-        <CopyIcon />
-      )}
-    </IconButton>
+    <>
+      <IconButton
+        aria-label='Copy'
+        {...props}
+        onClick={onCopy}
+        data-test-id='copy-button'
+      >
+        <span className={styles.iconSwap} data-copied={copied || undefined}>
+          <CopyIcon className={styles.copyIcon} />
+          <CheckIcon
+            className={styles.checkIcon}
+            color='var(--rs-color-foreground-success-primary)'
+          />
+        </span>
+      </IconButton>
+      <span className={styles['sr-only']} role='status' aria-live='polite'>
+        {copied ? 'Copied' : ''}
+      </span>
+    </>
   );
 }
 

--- a/packages/raystack/components/data-table/data-table.module.css
+++ b/packages/raystack/components/data-table/data-table.module.css
@@ -102,6 +102,8 @@
 .contentRoot table {
   border-collapse: separate;
   border-spacing: 0;
+  /* Align digits across rows/columns for numeric data. */
+  font-variant-numeric: tabular-nums;
 }
 
 .contentRoot thead {
@@ -118,6 +120,16 @@
 
 .clickable {
   cursor: pointer;
+}
+
+.row.clickable:active {
+  background: var(--rs-color-background-neutral-secondary);
+}
+
+.row[data-state="selected"],
+.row[data-state="selected"]:hover,
+.row[data-state="selected"].clickable:active {
+  background: var(--rs-color-background-accent-primary);
 }
 
 .head {
@@ -192,6 +204,13 @@
   box-sizing: border-box;
 }
 
+/* Let virtualized cells (tableStyles.cell paints an opaque background) show
+   the row's hover/selected/pressed color, like `.cell { background: inherit }`
+   already does for <td>s. `.virtualRow .virtualCell` outspecifies `.cell`. */
+.virtualRow .virtualCell {
+  background: inherit;
+}
+
 .virtualSectionHeader {
   position: absolute;
   width: 100%;
@@ -253,4 +272,25 @@
    * the panel (resolve their `max-width: 100%`) instead of overflowing it. */
   flex: 1;
   min-width: 0;
+}
+
+/* Scrolled-under edge for the virtualized sticky group anchor. The anchor is
+   permanently stuck and coincides with the first natural group header at
+   scroll 0, so "scrolled > 0" is exactly "content is underneath it".
+   (.stickySectionHeader is intentionally NOT gated: its many instances stick
+   at per-element offsets a scroll() timeline can't express — revisit with
+   @container scroll-state(stuck: top) when support matures.) */
+@supports (animation-timeline: scroll()) {
+  .stickyGroupAnchor {
+    box-shadow: 0 0.5px 0 0 transparent;
+    animation: anchor-edge linear both;
+    animation-timeline: scroll(nearest block);
+    animation-range: 0px 24px;
+  }
+}
+
+@keyframes anchor-edge {
+  to {
+    box-shadow: 0 0.5px 0 0 var(--rs-color-border-base-primary);
+  }
 }

--- a/packages/raystack/components/data-view/__tests__/data-view.test.tsx
+++ b/packages/raystack/components/data-view/__tests__/data-view.test.tsx
@@ -231,7 +231,7 @@ describe('DataView', () => {
       expect(onRowClick).toHaveBeenCalledWith(mockData[0]);
     });
 
-    it('exposes clickable rows as focusable buttons', () => {
+    it('exposes clickable rows as focusable rows', () => {
       render(
         <DataView
           data={mockData}
@@ -242,7 +242,9 @@ describe('DataView', () => {
           <DataView.List variant='table' columns={mockColumns} />
         </DataView>
       );
-      const row = screen.getByText('John Doe').closest('[role="button"]');
+      // Clickable rows keep role="row" (so cells stay associated) and become
+      // keyboard-focusable via tabIndex.
+      const row = screen.getByText('John Doe').closest('[role="row"]');
       expect(row).not.toBeNull();
       expect(row).toHaveAttribute('tabindex', '0');
       (row as HTMLElement).focus();
@@ -264,7 +266,7 @@ describe('DataView', () => {
       );
       const row = screen
         .getByText('John Doe')
-        .closest('[role="button"]') as HTMLElement;
+        .closest('[role="row"]') as HTMLElement;
       row.focus();
 
       await user.keyboard('{Enter}');

--- a/packages/raystack/components/data-view/__tests__/data-view.test.tsx
+++ b/packages/raystack/components/data-view/__tests__/data-view.test.tsx
@@ -230,6 +230,63 @@ describe('DataView', () => {
       await user.click(screen.getByText('John Doe'));
       expect(onRowClick).toHaveBeenCalledWith(mockData[0]);
     });
+
+    it('exposes clickable rows as focusable buttons', () => {
+      render(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          onRowClick={vi.fn()}
+        >
+          <DataView.List variant='table' columns={mockColumns} />
+        </DataView>
+      );
+      const row = screen.getByText('John Doe').closest('[role="button"]');
+      expect(row).not.toBeNull();
+      expect(row).toHaveAttribute('tabindex', '0');
+      (row as HTMLElement).focus();
+      expect(row).toHaveFocus();
+    });
+
+    it('activates the row with Enter and Space', async () => {
+      const user = userEvent.setup();
+      const onRowClick = vi.fn();
+      render(
+        <DataView
+          data={mockData}
+          fields={mockFields}
+          defaultSort={defaultSort}
+          onRowClick={onRowClick}
+        >
+          <DataView.List variant='table' columns={mockColumns} />
+        </DataView>
+      );
+      const row = screen
+        .getByText('John Doe')
+        .closest('[role="button"]') as HTMLElement;
+      row.focus();
+
+      await user.keyboard('{Enter}');
+      expect(onRowClick).toHaveBeenCalledWith(mockData[0]);
+
+      await user.keyboard(' ');
+      expect(onRowClick).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps rows inert without onRowClick', () => {
+      render(
+        <DataView data={mockData} fields={mockFields} defaultSort={defaultSort}>
+          <DataView.List variant='table' columns={mockColumns} />
+        </DataView>
+      );
+      const cell = screen.getByText('John Doe');
+      // The structural role stays; there is no button and no tab stop.
+      expect(cell.closest('[role="button"]')).toBeNull();
+      const row = cell.closest('[role="row"]');
+      expect(row).not.toBeNull();
+      expect(row).not.toHaveAttribute('tabindex');
+    });
   });
 
   describe('Zero / Empty State', () => {

--- a/packages/raystack/components/data-view/components/list.tsx
+++ b/packages/raystack/components/data-view/components/list.tsx
@@ -3,7 +3,14 @@
 import type { Header, Row } from '@tanstack/react-table';
 import { flexRender } from '@tanstack/react-table';
 import { cx } from 'class-variance-authority';
-import { CSSProperties, useCallback, useEffect, useMemo, useRef } from 'react';
+import {
+  CSSProperties,
+  KeyboardEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef
+} from 'react';
 
 import { Badge } from '../../badge';
 import { Skeleton } from '../../skeleton';
@@ -346,9 +353,21 @@ export function DataViewList<TData, TValue = unknown>({
     const composedStyle: CSSProperties = isVirtual
       ? { ...style, gridTemplateColumns }
       : (style ?? {});
+    const handleRowActivate = () => onRowClick?.(row.original);
+    const handleRowKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+      // Enter and Space both activate, matching a native button.
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault(); // Space would otherwise scroll the page.
+        handleRowActivate();
+      }
+    };
     return (
       <div
-        role={ariaRole === 'table' ? 'row' : 'listitem'}
+        // A clickable row is announced as a button; a plain row keeps its
+        // structural role and stays inert for the keyboard.
+        role={onRowClick ? 'button' : ariaRole === 'table' ? 'row' : 'listitem'}
+        tabIndex={onRowClick ? 0 : undefined}
+        onKeyDown={onRowClick ? handleRowKeyDown : undefined}
         key={key ?? row.id}
         ref={measure}
         data-index={dataIndex}
@@ -359,7 +378,7 @@ export function DataViewList<TData, TValue = unknown>({
           classNames.row
         )}
         style={composedStyle}
-        onClick={() => onRowClick?.(row.original)}
+        onClick={handleRowActivate}
       >
         {renderRowCells(row)}
       </div>

--- a/packages/raystack/components/data-view/components/list.tsx
+++ b/packages/raystack/components/data-view/components/list.tsx
@@ -355,6 +355,10 @@ export function DataViewList<TData, TValue = unknown>({
       : (style ?? {});
     const handleRowActivate = () => onRowClick?.(row.original);
     const handleRowKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+      // Only act on keys aimed at the row itself; ignore events bubbling up
+      // from interactive children (buttons, links) so they don't also
+      // trigger row activation.
+      if (event.target !== event.currentTarget) return;
       // Enter and Space both activate, matching a native button.
       if (event.key === 'Enter' || event.key === ' ') {
         event.preventDefault(); // Space would otherwise scroll the page.
@@ -363,9 +367,10 @@ export function DataViewList<TData, TValue = unknown>({
     };
     return (
       <div
-        // A clickable row is announced as a button; a plain row keeps its
-        // structural role and stays inert for the keyboard.
-        role={onRowClick ? 'button' : ariaRole === 'table' ? 'row' : 'listitem'}
+        // Keep the structural role (row/listitem) so cells stay associated with
+        // their row; a clickable row becomes keyboard-activatable via tabIndex +
+        // keydown. Swapping to role="button" would break that association.
+        role={ariaRole === 'table' ? 'row' : 'listitem'}
         tabIndex={onRowClick ? 0 : undefined}
         onKeyDown={onRowClick ? handleRowKeyDown : undefined}
         key={key ?? row.id}

--- a/packages/raystack/components/data-view/components/ordering.tsx
+++ b/packages/raystack/components/data-view/components/ordering.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { TextAlignBottomIcon, TextAlignTopIcon } from '@radix-ui/react-icons';
+import { TextAlignBottomIcon } from '@radix-ui/react-icons';
 
 import { Flex } from '../../flex';
 import { IconButton } from '../../icon-button';
@@ -68,13 +68,10 @@ export function Ordering({ columnList, onChange, value }: OrderingProps) {
           size={4}
           disabled={columnList.length === 0}
         >
-          {value.order === SortOrders?.ASC ? (
-            <TextAlignBottomIcon
-              className={styles['display-popover-sort-icon']}
-            />
-          ) : (
-            <TextAlignTopIcon className={styles['display-popover-sort-icon']} />
-          )}
+          <TextAlignBottomIcon
+            className={styles['display-popover-sort-icon']}
+            data-order={value.order}
+          />
         </IconButton>
       </Flex>
     </Flex>

--- a/packages/raystack/components/data-view/data-view.module.css
+++ b/packages/raystack/components/data-view/data-view.module.css
@@ -52,6 +52,20 @@
 .display-popover-sort-icon {
   height: var(--rs-space-6);
   width: var(--rs-space-6);
+  /* Flip around the icon's own visual centre, not the SVG viewBox origin,
+     so scaleY reads as a clean flip in place instead of a shift. */
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+.display-popover-sort-icon[data-order="desc"] {
+  transform: scaleY(-1);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .display-popover-sort-icon {
+    transition: transform var(--rs-duration-fast) var(--rs-ease-out);
+  }
 }
 
 .flex-1 {
@@ -205,6 +219,11 @@
   background: var(--rs-color-background-base-primary-hover);
 }
 
+.listRow.clickable:active,
+.listRowVirtual.clickable:active {
+  background: var(--rs-color-background-neutral-secondary);
+}
+
 .listRowDivider {
   border-bottom: 0.5px solid var(--rs-color-border-base-primary);
 }
@@ -325,4 +344,34 @@
   padding: var(--rs-space-9) 0;
   width: 100%;
   box-sizing: border-box;
+}
+
+/* Scrolled-under edges: header hairline and group-anchor hairline appear only
+   once content scrolls beneath them. See table.module.css for rationale. */
+@supports (animation-timeline: scroll()) {
+  .listHeader {
+    border-bottom-color: transparent;
+    animation: list-header-edge linear both;
+    animation-timeline: scroll(nearest block);
+    animation-range: 0px 24px;
+  }
+
+  .listGroupAnchor {
+    box-shadow: 0 0.5px 0 0 transparent;
+    animation: list-anchor-edge linear both;
+    animation-timeline: scroll(nearest block);
+    animation-range: 0px 24px;
+  }
+}
+
+@keyframes list-header-edge {
+  to {
+    border-bottom-color: var(--rs-color-border-base-primary);
+  }
+}
+
+@keyframes list-anchor-edge {
+  to {
+    box-shadow: 0 0.5px 0 0 var(--rs-color-border-base-primary);
+  }
 }

--- a/packages/raystack/components/data-view/data-view.module.css
+++ b/packages/raystack/components/data-view/data-view.module.css
@@ -224,6 +224,14 @@
   background: var(--rs-color-background-neutral-secondary);
 }
 
+/* Inset ring: .listRoot scrolls (overflow: auto), so an outward outline
+   would clip at the container edge. */
+.listRow.clickable:focus-visible,
+.listRowVirtual.clickable:focus-visible {
+  outline: var(--rs-focus-ring);
+  outline-offset: var(--rs-focus-ring-offset-inset);
+}
+
 .listRowDivider {
   border-bottom: 0.5px solid var(--rs-color-border-base-primary);
 }

--- a/packages/raystack/components/dialog/dialog.module.css
+++ b/packages/raystack/components/dialog/dialog.module.css
@@ -2,7 +2,7 @@
   background-color: var(--rs-color-overlay-black-a5);
   position: fixed;
   inset: 0;
-  transition: opacity 150ms cubic-bezier(0.45, 1.005, 0, 1.005);
+  transition: opacity var(--rs-duration-normal) var(--rs-ease-out);
   z-index: var(--rs-z-index-portal);
 }
 
@@ -24,7 +24,7 @@
   position: fixed;
   top: 0;
   left: 50%;
-  transition: opacity 150ms;
+  transition: opacity var(--rs-duration-normal) var(--rs-ease-out);
   /* translateY is the smaller of 160px (desired top offset) and
      calc(50vh - 50%) (the y-coord that vertically centers the dialog,
      where the inner 50% resolves to the element's own height). On tall
@@ -48,6 +48,11 @@
   position: absolute;
   border-radius: inherit;
   background-color: var(--rs-color-overlay-black-a1);
+}
+
+.dialogContent[data-starting-style],
+.dialogContent[data-ending-style] {
+  opacity: 0;
 }
 
 .dialogContent.showNestedAnimation[data-starting-style],
@@ -78,8 +83,8 @@
 @media (prefers-reduced-motion: no-preference) {
   .dialogContent {
     transition:
-      opacity 150ms,
-      transform 150ms ease;
+      opacity var(--rs-duration-normal) var(--rs-ease-out),
+      transform var(--rs-duration-normal) var(--rs-ease-out);
   }
 }
 
@@ -118,4 +123,12 @@
 
 .footer {
   padding: var(--rs-space-5) var(--rs-space-7);
+}
+
+/* Reduced transparency: drop the blur, compensate with a heavier solid scrim */
+@media (prefers-reduced-transparency: reduce) {
+  .overlayBlur {
+    backdrop-filter: none;
+    background-color: var(--rs-color-overlay-black-a9);
+  }
 }

--- a/packages/raystack/components/dialog/dialog.module.css
+++ b/packages/raystack/components/dialog/dialog.module.css
@@ -36,7 +36,7 @@
 .dialogContent.showNestedAnimation {
   transform: translate(-50%, min(160px, calc(50vh - 50%)))
     scale(calc(1 - 0.1 * var(--nested-dialogs, 0)));
-  translate: 0 calc(0px + 1.25rem * var(--nested-dialogs, 0));
+  translate: 0 calc(1.25rem * var(--nested-dialogs, 0));
 }
 
 .dialogContent:focus {
@@ -53,12 +53,6 @@
 .dialogContent[data-starting-style],
 .dialogContent[data-ending-style] {
   opacity: 0;
-}
-
-.dialogContent.showNestedAnimation[data-starting-style],
-.dialogContent.showNestedAnimation[data-ending-style] {
-  opacity: 0;
-  transform: translate(-50%, min(160px, calc(50vh - 50%))) scale(0.9);
 }
 
 .closeButton {
@@ -85,6 +79,11 @@
     transition:
       opacity var(--rs-duration-normal) var(--rs-ease-out),
       transform var(--rs-duration-normal) var(--rs-ease-out);
+  }
+
+  .dialogContent.showNestedAnimation[data-starting-style],
+  .dialogContent.showNestedAnimation[data-ending-style] {
+    transform: translate(-50%, min(160px, calc(50vh - 50%))) scale(0.9);
   }
 }
 

--- a/packages/raystack/components/drawer/drawer-content.tsx
+++ b/packages/raystack/components/drawer/drawer-content.tsx
@@ -4,6 +4,7 @@ import { Drawer as DrawerPrimitive } from '@base-ui/react/drawer';
 import { Cross1Icon } from '@radix-ui/react-icons';
 import { cva, cx, type VariantProps } from 'class-variance-authority';
 import { ReactNode } from 'react';
+import { IconButton } from '../icon-button';
 import styles from './drawer.module.css';
 
 const drawerPopup = cva(styles.drawerPopup, {
@@ -60,6 +61,7 @@ export function DrawerContent({
               <DrawerPrimitive.Close
                 className={styles.close}
                 aria-label={closeLabel}
+                render={<IconButton size={3} />}
               >
                 <Cross1Icon aria-hidden='true' />
               </DrawerPrimitive.Close>

--- a/packages/raystack/components/drawer/drawer.module.css
+++ b/packages/raystack/components/drawer/drawer.module.css
@@ -60,6 +60,7 @@
   overflow-y: auto;
   overscroll-behavior: contain;
   will-change: transform;
+  box-shadow: var(--rs-shadow-floating);
   transition: opacity var(--rs-duration-drawer) var(--rs-ease-drawer);
 }
 
@@ -138,33 +139,11 @@
   height: 100%;
 }
 
+/* Positioning only — IconButton supplies the chrome, states and focus ring. */
 .close {
-  all: unset;
   position: absolute;
   top: var(--rs-space-3);
   right: var(--rs-space-3);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--rs-radius-2);
-  color: var(--rs-color-foreground-base-secondary);
-  padding: var(--rs-space-2);
-  cursor: pointer;
-}
-
-.close:hover {
-  background-color: var(--rs-color-background-base-primary-hover);
-  color: var(--rs-color-foreground-base-primary);
-}
-
-.close:active {
-  background-color: var(--rs-color-background-neutral-secondary);
-  color: var(--rs-color-foreground-base-primary);
-}
-
-.close:focus-visible {
-  outline: 2px solid var(--rs-color-border-base-focus);
-  outline-offset: -1px;
 }
 
 .header {

--- a/packages/raystack/components/drawer/drawer.module.css
+++ b/packages/raystack/components/drawer/drawer.module.css
@@ -5,7 +5,7 @@
   z-index: var(--rs-z-index-portal);
   background-color: var(--rs-color-overlay-black-a5);
   opacity: calc(1 - var(--drawer-swipe-progress, 0));
-  transition: opacity 450ms cubic-bezier(0.32, 0.72, 0, 1);
+  transition: opacity var(--rs-duration-drawer) var(--rs-ease-drawer);
 }
 
 .backdrop[data-starting-style],
@@ -18,7 +18,10 @@
 }
 
 .backdrop[data-ending-style] {
-  transition-duration: calc(var(--drawer-swipe-strength, 1) * 400ms);
+  transition-duration: calc(
+    var(--drawer-swipe-strength, 1) *
+    var(--rs-duration-drawer)
+  );
 }
 
 .viewport {
@@ -59,14 +62,21 @@
   overscroll-behavior: contain;
   touch-action: auto;
   will-change: transform;
+  transition: opacity var(--rs-duration-drawer) var(--rs-ease-drawer);
 }
 
 .drawerPopup:focus {
   outline: none;
 }
 
+.drawerPopup[data-starting-style],
+.drawerPopup[data-ending-style] {
+  opacity: 0;
+}
+
 .drawerPopup[data-swiping] {
   user-select: none;
+  transition: none;
 }
 
 /* Right side drawer */
@@ -76,13 +86,11 @@
   transform: translateX(var(--drawer-swipe-movement-x));
 }
 
-.drawerPopup-right[data-starting-style],
 .drawerPopup-right[data-ending-style] {
-  transform: translateX(100%);
-}
-
-.drawerPopup-right[data-ending-style] {
-  transition-duration: calc(var(--drawer-swipe-strength, 1) * 400ms);
+  transition-duration: calc(
+    var(--drawer-swipe-strength, 1) *
+    var(--rs-duration-drawer)
+  );
 }
 
 /* Left side drawer */
@@ -92,13 +100,11 @@
   transform: translateX(var(--drawer-swipe-movement-x));
 }
 
-.drawerPopup-left[data-starting-style],
 .drawerPopup-left[data-ending-style] {
-  transform: translateX(-100%);
-}
-
-.drawerPopup-left[data-ending-style] {
-  transition-duration: calc(var(--drawer-swipe-strength, 1) * 400ms);
+  transition-duration: calc(
+    var(--drawer-swipe-strength, 1) *
+    var(--rs-duration-drawer)
+  );
 }
 
 /* Top side drawer */
@@ -108,13 +114,11 @@
   transform: translateY(var(--drawer-swipe-movement-y));
 }
 
-.drawerPopup-top[data-starting-style],
 .drawerPopup-top[data-ending-style] {
-  transform: translateY(-100%);
-}
-
-.drawerPopup-top[data-ending-style] {
-  transition-duration: calc(var(--drawer-swipe-strength, 1) * 400ms);
+  transition-duration: calc(
+    var(--drawer-swipe-strength, 1) *
+    var(--rs-duration-drawer)
+  );
 }
 
 /* Bottom side drawer */
@@ -124,13 +128,11 @@
   transform: translateY(var(--drawer-swipe-movement-y));
 }
 
-.drawerPopup-bottom[data-starting-style],
 .drawerPopup-bottom[data-ending-style] {
-  transform: translateY(100%);
-}
-
-.drawerPopup-bottom[data-ending-style] {
-  transition-duration: calc(var(--drawer-swipe-strength, 1) * 400ms);
+  transition-duration: calc(
+    var(--drawer-swipe-strength, 1) *
+    var(--rs-duration-drawer)
+  );
 }
 
 .content {
@@ -154,6 +156,11 @@
 
 .close:hover {
   background-color: var(--rs-color-background-base-primary-hover);
+  color: var(--rs-color-foreground-base-primary);
+}
+
+.close:active {
+  background-color: var(--rs-color-background-neutral-secondary);
   color: var(--rs-color-foreground-base-primary);
 }
 
@@ -202,6 +209,33 @@
   .drawerPopup-left,
   .drawerPopup-top,
   .drawerPopup-bottom {
-    transition: transform 450ms cubic-bezier(0.32, 0.72, 0, 1);
+    transition: transform var(--rs-duration-drawer) var(--rs-ease-drawer);
+  }
+
+  /* Normal motion slides an opaque panel; the base opacity fade is the
+     reduced-motion fallback only. */
+  .drawerPopup[data-starting-style],
+  .drawerPopup[data-ending-style] {
+    opacity: 1;
+  }
+
+  .drawerPopup-right[data-starting-style],
+  .drawerPopup-right[data-ending-style] {
+    transform: translateX(100%);
+  }
+
+  .drawerPopup-left[data-starting-style],
+  .drawerPopup-left[data-ending-style] {
+    transform: translateX(-100%);
+  }
+
+  .drawerPopup-top[data-starting-style],
+  .drawerPopup-top[data-ending-style] {
+    transform: translateY(-100%);
+  }
+
+  .drawerPopup-bottom[data-starting-style],
+  .drawerPopup-bottom[data-ending-style] {
+    transform: translateY(100%);
   }
 }

--- a/packages/raystack/components/drawer/drawer.module.css
+++ b/packages/raystack/components/drawer/drawer.module.css
@@ -1,7 +1,6 @@
 .backdrop {
   position: fixed;
   inset: 0;
-  min-height: 100dvh;
   z-index: var(--rs-z-index-portal);
   background-color: var(--rs-color-overlay-black-a5);
   opacity: calc(1 - var(--drawer-swipe-progress, 0));
@@ -60,7 +59,6 @@
   color: var(--rs-color-foreground-base-primary);
   overflow-y: auto;
   overscroll-behavior: contain;
-  touch-action: auto;
   will-change: transform;
   transition: opacity var(--rs-duration-drawer) var(--rs-ease-drawer);
 }

--- a/packages/raystack/components/empty-state/empty-state.module.css
+++ b/packages/raystack/components/empty-state/empty-state.module.css
@@ -97,3 +97,28 @@
   height: 100%;
   padding: var(--rs-space-9) var(--rs-space-5);
 }
+
+@keyframes empty-state-enter {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes empty-state-enter-rise {
+  from {
+    opacity: 0;
+    translate: 0 var(--rs-space-2);
+  }
+}
+
+.emptyState,
+.emptyStateContent {
+  animation: empty-state-enter var(--rs-duration-moderate) var(--rs-ease-out);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .emptyState,
+  .emptyStateContent {
+    animation-name: empty-state-enter-rise;
+  }
+}

--- a/packages/raystack/components/empty-state/empty-state.module.css
+++ b/packages/raystack/components/empty-state/empty-state.module.css
@@ -24,7 +24,6 @@
 }
 
 .icon svg {
-  border-color: currentColor;
   height: 100%;
   width: 100%;
 }
@@ -86,9 +85,6 @@
 }
 
 .iconLarge svg {
-  height: 100%;
-  width: 100%;
-  border-color: currentColor;
   padding: var(--rs-space-4);
 }
 
@@ -98,12 +94,6 @@
   padding: var(--rs-space-9) var(--rs-space-5);
 }
 
-@keyframes empty-state-enter {
-  from {
-    opacity: 0;
-  }
-}
-
 @keyframes empty-state-enter-rise {
   from {
     opacity: 0;
@@ -111,14 +101,9 @@
   }
 }
 
-.emptyState,
-.emptyStateContent {
-  animation: empty-state-enter var(--rs-duration-moderate) var(--rs-ease-out);
-}
-
 @media (prefers-reduced-motion: no-preference) {
   .emptyState,
   .emptyStateContent {
-    animation-name: empty-state-enter-rise;
+    animation: empty-state-enter-rise var(--rs-duration-moderate) var(--rs-ease-out);
   }
 }

--- a/packages/raystack/components/empty-state/empty-state.module.css
+++ b/packages/raystack/components/empty-state/empty-state.module.css
@@ -49,7 +49,7 @@
   font-weight: var(--rs-font-weight-medium);
   line-height: var(--rs-line-height-large);
   letter-spacing: var(--rs-letter-spacing-large);
-  text-wrap: wrap;
+  text-wrap: balance;
   max-width: 360px;
 }
 
@@ -60,7 +60,7 @@
   font-weight: var(--rs-font-weight-regular);
   line-height: var(--rs-line-height-regular);
   letter-spacing: var(--rs-letter-spacing-regular);
-  text-wrap: wrap;
+  text-wrap: pretty;
   max-width: 360px;
 }
 

--- a/packages/raystack/components/field/__tests__/field.test.tsx
+++ b/packages/raystack/components/field/__tests__/field.test.tsx
@@ -72,13 +72,13 @@ describe('Field', () => {
       expect(screen.getByText('Enter a valid email')).toBeInTheDocument();
     });
 
-    it('does not render description when error is present', () => {
+    it('keeps description rendered alongside error', () => {
       render(
         <Field description='Enter email' error='Invalid email'>
           content
         </Field>
       );
-      expect(screen.queryByText('Enter email')).not.toBeInTheDocument();
+      expect(screen.getByText('Enter email')).toBeInTheDocument();
       expect(screen.getByText('Invalid email')).toBeInTheDocument();
     });
   });

--- a/packages/raystack/components/field/__tests__/field.test.tsx
+++ b/packages/raystack/components/field/__tests__/field.test.tsx
@@ -72,13 +72,15 @@ describe('Field', () => {
       expect(screen.getByText('Enter a valid email')).toBeInTheDocument();
     });
 
-    it('keeps description rendered alongside error', () => {
+    it('hides the description while an error is showing', () => {
       render(
         <Field description='Enter email' error='Invalid email'>
           content
         </Field>
       );
-      expect(screen.getByText('Enter email')).toBeInTheDocument();
+      // The description is unmounted when an error is present so it does not
+      // leak into the input's aria-describedby alongside the error.
+      expect(screen.queryByText('Enter email')).not.toBeInTheDocument();
       expect(screen.getByText('Invalid email')).toBeInTheDocument();
     });
   });

--- a/packages/raystack/components/field/field-root.tsx
+++ b/packages/raystack/components/field/field-root.tsx
@@ -48,11 +48,8 @@ export function FieldRoot({
         <div className={styles.control}>{children}</div>
         {(description || error) && (
           <div className={styles.helperSlot}>
-            {description && (
-              <FieldPrimitive.Description
-                className={styles.description}
-                data-hidden={error ? '' : undefined}
-              >
+            {description && !error && (
+              <FieldPrimitive.Description className={styles.description}>
                 {description}
               </FieldPrimitive.Description>
             )}

--- a/packages/raystack/components/field/field-root.tsx
+++ b/packages/raystack/components/field/field-root.tsx
@@ -46,15 +46,22 @@ export function FieldRoot({
       >
         {label && <FieldLabel required={required}>{label}</FieldLabel>}
         <div className={styles.control}>{children}</div>
-        {error && (
-          <FieldPrimitive.Error className={styles.error} match>
-            {error}
-          </FieldPrimitive.Error>
-        )}
-        {!error && description && (
-          <FieldPrimitive.Description className={styles.description}>
-            {description}
-          </FieldPrimitive.Description>
+        {(description || error) && (
+          <div className={styles.helperSlot}>
+            {description && (
+              <FieldPrimitive.Description
+                className={styles.description}
+                data-hidden={error ? '' : undefined}
+              >
+                {description}
+              </FieldPrimitive.Description>
+            )}
+            {error && (
+              <FieldPrimitive.Error className={styles.error} match>
+                {error}
+              </FieldPrimitive.Error>
+            )}
+          </div>
         )}
       </FieldPrimitive.Root>
     </FieldContext.Provider>

--- a/packages/raystack/components/field/field.module.css
+++ b/packages/raystack/components/field/field.module.css
@@ -28,11 +28,41 @@
   margin: 0;
 }
 
+/* Description and error share one slot, stacked in the same grid cell. When an
+   error appears it crossfades in over the description (which fades out), so the
+   hint is replaced smoothly instead of popping. Reduced motion swaps instantly. */
+.helperSlot {
+  display: grid;
+}
+
+.helperSlot > * {
+  grid-area: 1 / 1;
+}
+
+.description[data-hidden] {
+  opacity: 0;
+  visibility: hidden;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .helperSlot > * {
+    transition:
+      opacity var(--rs-duration-fast) var(--rs-ease-out),
+      visibility var(--rs-duration-fast) var(--rs-ease-out);
+  }
+
+  @starting-style {
+    .helperSlot .error {
+      opacity: 0;
+    }
+  }
+}
+
 .input {
   width: 100%;
   padding: 0 var(--rs-space-3);
   border-radius: var(--rs-radius-2);
-  border: 1px solid var(--rs-color-border-base-tertiary);
+  border: 0.5px solid var(--rs-color-border-base-tertiary);
   background: var(--rs-color-background-base-primary);
   font-weight: var(--rs-font-weight-regular);
   font-size: var(--rs-font-size-small);
@@ -40,13 +70,8 @@
   letter-spacing: var(--rs-letter-spacing-small);
   outline: none;
   box-sizing: border-box;
-  transition: all 0.2s ease;
+  transition: var(--rs-transition-interactive);
   height: var(--rs-space-9);
-}
-
-.input:hover {
-  border-color: var(--rs-color-border-base-focus);
-  background: var(--rs-color-background-base-primary-hover);
 }
 
 .input:focus {
@@ -55,7 +80,11 @@
 }
 
 .input[data-invalid] {
-  border-color: var(--rs-color-border-danger-primary);
+  border-color: var(--rs-color-border-danger-emphasis);
+}
+
+.input[data-invalid]:focus {
+  border-color: var(--rs-color-border-danger-emphasis-hover);
 }
 
 .input[data-disabled] {

--- a/packages/raystack/components/field/field.module.css
+++ b/packages/raystack/components/field/field.module.css
@@ -39,11 +39,6 @@
   grid-area: 1 / 1;
 }
 
-.description[data-hidden] {
-  opacity: 0;
-  visibility: hidden;
-}
-
 @media (prefers-reduced-motion: no-preference) {
   .helperSlot > * {
     transition:

--- a/packages/raystack/components/field/field.module.css
+++ b/packages/raystack/components/field/field.module.css
@@ -76,7 +76,6 @@
 
 .input:focus {
   border-color: var(--rs-color-border-accent-emphasis);
-  background-color: var(--rs-color-background-base-primary);
 }
 
 .input[data-invalid] {

--- a/packages/raystack/components/filter-chip/filter-chip.module.css
+++ b/packages/raystack/components/filter-chip/filter-chip.module.css
@@ -226,6 +226,14 @@ button.selectValue:hover {
   display: none;
 }
 
+/* The DatePicker reserves an (invisible) error line below its input so
+   appearing errors don't shift layout. Inside the 24px chip row that
+   reserved line inflates the wrapper and pushes the input off-center;
+   the chip signals date errors with the danger border below instead. */
+.dateFieldWrapper [class*="datePickerError"] {
+  display: none;
+}
+
 .dateFieldWrapper [class*="input-error-wrapper"] {
   border: 1px solid var(--rs-color-border-danger-primary);
 }

--- a/packages/raystack/components/filter-chip/filter-chip.module.css
+++ b/packages/raystack/components/filter-chip/filter-chip.module.css
@@ -93,10 +93,21 @@
   background: var(--rs-color-background-base-primary-hover);
 }
 
+/* Mirrors the chip dismiss button so the two siblings feel identical. */
+.removeIconContainer:active {
+  transform: scale(var(--rs-scale-pressed-strong));
+}
+
 /* Remove button sits inside the clipped chip: keep the ring inside. */
 .removeIconContainer:focus-visible {
   outline: var(--rs-focus-ring);
   outline-offset: var(--rs-focus-ring-offset-inset);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .removeIconContainer {
+    transition: transform var(--rs-duration-press) var(--rs-ease-out);
+  }
 }
 
 .removeIcon {

--- a/packages/raystack/components/filter-chip/filter-chip.module.css
+++ b/packages/raystack/components/filter-chip/filter-chip.module.css
@@ -93,10 +93,16 @@
   background: var(--rs-color-background-base-primary-hover);
 }
 
+/* Remove button sits inside the clipped chip: keep the ring inside. */
+.removeIconContainer:focus-visible {
+  outline: var(--rs-focus-ring);
+  outline-offset: var(--rs-focus-ring-offset-inset);
+}
+
 .removeIcon {
   cursor: pointer;
   color: var(--rs-color-foreground-base-primary);
-  transition: color 0.2s ease-in-out;
+  transition: color var(--rs-duration-normal) var(--rs-ease-out);
   width: var(--rs-space-4);
   height: var(--rs-space-4);
 }

--- a/packages/raystack/components/floating-actions/floating-actions.module.css
+++ b/packages/raystack/components/floating-actions/floating-actions.module.css
@@ -8,6 +8,31 @@
   background: var(--rs-color-background-base-primary);
   border-radius: var(--rs-radius-2);
   box-shadow: var(--rs-shadow-lifted);
+  transition: opacity var(--rs-duration-normal) var(--rs-ease-out);
+}
+
+@starting-style {
+  .root {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .root {
+    transition:
+      opacity var(--rs-duration-normal) var(--rs-ease-out),
+      transform var(--rs-duration-normal) var(--rs-ease-out);
+  }
+
+  @starting-style {
+    .root[data-variant="floating"][data-side="bottom"] {
+      transform: translateY(var(--rs-space-3));
+    }
+
+    .root[data-variant="floating"][data-side="top"] {
+      transform: translateY(calc(-1 * var(--rs-space-3)));
+    }
+  }
 }
 
 /* ===== Floating variant ===== */
@@ -31,8 +56,9 @@
 }
 
 .root[data-variant="floating"][data-align="center"] {
-  left: 50%;
-  transform: translateX(-50%);
+  left: 0;
+  right: 0;
+  margin-inline: auto;
 }
 
 .root[data-variant="floating"][data-align="end"] {

--- a/packages/raystack/components/headline/headline.module.css
+++ b/packages/raystack/components/headline/headline.module.css
@@ -5,7 +5,6 @@
   font-family: var(--rs-font-title);
   font-weight: var(--rs-font-weight-regular);
   color: var(--rs-color-foreground-base-primary);
-  width: 100%;
 }
 
 .headline-t1 {

--- a/packages/raystack/components/headline/headline.module.css
+++ b/packages/raystack/components/headline/headline.module.css
@@ -29,7 +29,7 @@
 }
 
 .headline-align-left {
-  text-align: left;
+  text-align: start;
 }
 
 .headline-align-center {
@@ -37,7 +37,7 @@
 }
 
 .headline-align-right {
-  text-align: right;
+  text-align: end;
 }
 
 .headline-truncate {

--- a/packages/raystack/components/icon-button/icon-button.module.css
+++ b/packages/raystack/components/icon-button/icon-button.module.css
@@ -8,7 +8,6 @@
   border: none;
   color: var(--rs-color-foreground-base-secondary);
   cursor: pointer;
-  transition: var(--rs-transition-interactive);
   padding: var(--rs-space-1);
 }
 
@@ -20,7 +19,19 @@
 .iconButton:active:not(:disabled) {
   background-color: var(--rs-color-background-neutral-secondary);
   color: var(--rs-color-foreground-base-primary);
-  transition: var(--rs-transition-pressed);
+  transform: scale(var(--rs-scale-pressed));
+}
+
+/* The scale applies unconditionally (an instant state change); only the
+   eased tween is motion, so only the transitions are gated. Mirrors button. */
+@media (prefers-reduced-motion: no-preference) {
+  .iconButton {
+    transition: var(--rs-transition-interactive);
+  }
+
+  .iconButton:active {
+    transition: var(--rs-transition-pressed);
+  }
 }
 
 .iconButton:disabled {

--- a/packages/raystack/components/icon-button/icon-button.module.css
+++ b/packages/raystack/components/icon-button/icon-button.module.css
@@ -12,15 +12,24 @@
   padding: var(--rs-space-1);
 }
 
-.iconButton:hover:not(:disabled),
-.iconButton:active:not(:disabled) {
+.iconButton:hover:not(:disabled) {
   background-color: var(--rs-color-background-base-primary-hover);
   color: var(--rs-color-foreground-base-primary);
+}
+
+.iconButton:active:not(:disabled) {
+  background-color: var(--rs-color-background-neutral-secondary);
+  color: var(--rs-color-foreground-base-primary);
+  transition: var(--rs-transition-pressed);
 }
 
 .iconButton:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.iconButton:focus-visible {
+  outline: var(--rs-focus-ring);
 }
 
 .iconButton-size-1 {

--- a/packages/raystack/components/image/__tests__/image.test.tsx
+++ b/packages/raystack/components/image/__tests__/image.test.tsx
@@ -124,6 +124,18 @@ describe('Image', () => {
       fireEvent.error(img);
       expect(img.src).toContain('/fallback.jpg');
     });
+
+    it('assigns the fallback src exactly once, even if the fallback also errors', () => {
+      render(<Image src='/invalid.jpg' alt='Test' fallback='/fallback.jpg' />);
+      const img = screen.getByRole('img') as HTMLImageElement;
+
+      fireEvent.error(img);
+      expect(img.src).toContain('/fallback.jpg');
+
+      // The fallback itself fails to load — must not re-assign it again.
+      fireEvent.error(img);
+      expect(img.src).toContain('/fallback.jpg');
+    });
   });
 
   describe('Loading Attributes', () => {

--- a/packages/raystack/components/image/image.module.css
+++ b/packages/raystack/components/image/image.module.css
@@ -31,3 +31,19 @@
 .image-radius-full {
   border-radius: var(--rs-radius-full);
 }
+
+/* Load fade: hidden only after JS confirms an in-flight load, so SSR/no-JS
+   images are never invisible. Cached images skip this entirely. */
+.image-loading {
+  opacity: 0;
+}
+
+.image-loaded {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .image-loaded {
+    transition: opacity var(--rs-duration-fast) var(--rs-ease-out);
+  }
+}

--- a/packages/raystack/components/image/image.module.css
+++ b/packages/raystack/components/image/image.module.css
@@ -2,6 +2,10 @@
   display: block;
   max-width: 100%;
   height: auto;
+  /* Hairline media edge so pale images keep a shape on light surfaces.
+     Outline, not inset shadow — the decoded image paints over a shadow. */
+  outline: 0.5px solid var(--rs-color-overlay-base-a2);
+  outline-offset: -0.5px;
 }
 
 .image-contain {

--- a/packages/raystack/components/image/image.tsx
+++ b/packages/raystack/components/image/image.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { cva, type VariantProps } from 'class-variance-authority';
-import { ComponentProps, SyntheticEvent } from 'react';
+import { cva, cx, type VariantProps } from 'class-variance-authority';
+import { ComponentProps, SyntheticEvent, useRef, useState } from 'react';
+import { useIsomorphicLayoutEffect } from '~/hooks';
 
 import styles from './image.module.css';
 
@@ -36,6 +37,8 @@ export function Image({
   radius,
   fallback,
   onError,
+  onLoad,
+  src,
   width,
   height,
   style,
@@ -43,9 +46,33 @@ export function Image({
   decoding = 'async',
   ...props
 }: ImageProps) {
+  const imgRef = useRef<HTMLImageElement>(null);
+  const hasFallenBackRef = useRef(false);
+  const [loadState, setLoadState] = useState<'static' | 'loading' | 'loaded'>(
+    'static'
+  );
+
+  useIsomorphicLayoutEffect(() => {
+    hasFallenBackRef.current = false;
+    const node = imgRef.current;
+    // Already-decoded (cached/SSR-painted) images stay visible — no fade.
+    setLoadState(node && !node.complete ? 'loading' : 'static');
+  }, [src]);
+
+  const handleLoad = (event: SyntheticEvent<HTMLImageElement, Event>) => {
+    setLoadState(prev => (prev === 'loading' ? 'loaded' : prev));
+    onLoad?.(event);
+  };
+
   const handleError = (event: SyntheticEvent<HTMLImageElement, Event>) => {
-    if (fallback) {
+    if (fallback && !hasFallenBackRef.current) {
+      // One-shot: if the fallback itself errors, never re-assign it.
+      hasFallenBackRef.current = true;
       event.currentTarget.src = fallback;
+    } else {
+      // No fallback (or the fallback failed): show the alt/broken rendering
+      // instead of holding the img invisible.
+      setLoadState('static');
     }
     onError?.(event);
   };
@@ -58,9 +85,20 @@ export function Image({
 
   return (
     <img
+      ref={imgRef}
       alt={alt}
-      className={image({ fit, radius, className })}
+      src={src}
+      className={image({
+        fit,
+        radius,
+        className: cx(
+          loadState === 'loading' && styles['image-loading'],
+          loadState === 'loaded' && styles['image-loaded'],
+          className
+        )
+      })}
       onError={handleError}
+      onLoad={handleLoad}
       style={imageStyle}
       loading={loading}
       decoding={decoding}

--- a/packages/raystack/components/input/input.module.css
+++ b/packages/raystack/components/input/input.module.css
@@ -62,6 +62,7 @@
   margin: 0;
   border: none;
   background: transparent;
+  color: var(--rs-color-foreground-base-primary);
   font-weight: var(--rs-font-weight-regular);
   font-size: var(--rs-font-size-small);
   line-height: var(--rs-line-height-t2);
@@ -69,6 +70,14 @@
   outline: none;
   box-sizing: border-box;
   border-radius: 0;
+}
+
+.input-field::placeholder {
+  color: var(--rs-color-foreground-base-tertiary);
+  font-size: var(--rs-font-size-small);
+  font-weight: var(--rs-font-weight-regular);
+  line-height: var(--rs-line-height-t2);
+  letter-spacing: var(--rs-letter-spacing-small);
 }
 
 .input-field:focus {

--- a/packages/raystack/components/input/input.module.css
+++ b/packages/raystack/components/input/input.module.css
@@ -13,11 +13,6 @@
   overflow: hidden;
 }
 
-.input-wrapper:hover {
-  border-color: var(--rs-color-border-base-focus);
-  background: var(--rs-color-background-base-primary-hover);
-}
-
 .input-wrapper:focus-within,
 .input-wrapper:has(.input-field[data-active="true"]) {
   border-color: var(--rs-color-border-accent-emphasis);
@@ -29,7 +24,6 @@
   border-color: var(--rs-color-border-danger-emphasis);
 }
 
-.input-wrapper:has(.input-field[data-invalid]):hover,
 .input-wrapper:has(.input-field[data-invalid]):focus-within {
   border-color: var(--rs-color-border-danger-emphasis-hover);
 }
@@ -37,11 +31,6 @@
 .input-wrapper[data-disabled] {
   opacity: 0.5;
   cursor: not-allowed;
-}
-
-.input-wrapper[data-disabled]:hover {
-  border-color: var(--rs-color-border-base-tertiary);
-  background: var(--rs-color-background-base-primary);
 }
 
 .leading-icon {
@@ -82,10 +71,6 @@
   border-radius: 0;
 }
 
-.input-field:hover {
-  border-color: var(--rs-color-border-base-focus);
-}
-
 .input-field:focus {
   border-color: var(--rs-color-border-accent-emphasis);
 }
@@ -106,10 +91,6 @@
 .has-chips {
   background: var(--rs-color-background-base-primary);
   transition: var(--rs-transition-interactive);
-}
-
-.has-chips:hover {
-  border-color: var(--rs-color-border-base-focus);
 }
 
 .has-chips:focus-within {
@@ -226,11 +207,12 @@
   border-color: transparent;
 }
 
-.variant-borderless:hover {
-  border-color: transparent;
-}
-
 .variant-borderless:focus-within {
   border-color: transparent;
   outline: none;
+}
+
+/* Keyboard focus must still be visible on the chromeless variant. */
+.variant-borderless:has(.input-field:focus-visible) {
+  box-shadow: var(--rs-focus-ring-shadow);
 }

--- a/packages/raystack/components/link/link.module.css
+++ b/packages/raystack/components/link/link.module.css
@@ -1,9 +1,39 @@
 .link {
   cursor: pointer;
   margin: 0;
-  transition: opacity 0.2s ease;
+  text-decoration-line: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.2em;
+  text-decoration-color: transparent;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .link {
+    transition:
+      text-decoration-color var(--rs-duration-fast) var(--rs-ease-out),
+      opacity var(--rs-duration-fast) var(--rs-ease-out);
+  }
+
+  /* Press dims at the snappy press tier; releasing eases back at the base
+     (fast) tier above — quick press, gentle release. */
+  .link:active {
+    transition: opacity var(--rs-duration-press) var(--rs-ease-out);
+  }
 }
 
 .link:hover {
-  opacity: 0.8;
+  text-decoration-color: currentColor;
+}
+
+.link:active {
+  opacity: 0.7;
+}
+
+.link:focus {
+  outline: none;
+}
+
+.link:focus-visible {
+  outline: var(--rs-focus-ring);
+  border-radius: var(--rs-radius-1);
 }

--- a/packages/raystack/components/menu/menu.module.css
+++ b/packages/raystack/components/menu/menu.module.css
@@ -17,7 +17,28 @@
   border: 0.5px solid var(--rs-color-border-base-primary);
   color: var(--rs-color-foreground-base-primary);
   min-width: var(--anchor-width);
+  transform-origin: var(--transform-origin);
+  transition: opacity var(--rs-duration-fast) var(--rs-ease-out);
 }
+
+.content[data-starting-style],
+.content[data-ending-style] {
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .content {
+    transition:
+      opacity var(--rs-duration-fast) var(--rs-ease-out),
+      transform var(--rs-duration-fast) var(--rs-ease-out);
+  }
+
+  .content[data-starting-style],
+  .content[data-ending-style] {
+    transform: scale(0.97);
+  }
+}
+
 .content:focus,
 .content:focus-visible {
   outline: none;

--- a/packages/raystack/components/menu/menu.module.css
+++ b/packages/raystack/components/menu/menu.module.css
@@ -12,7 +12,7 @@
   padding: var(--rs-space-2);
   background-color: var(--rs-color-background-base-primary);
   border-radius: var(--rs-radius-2);
-  box-shadow: var(--rs-shadow-lifted);
+  box-shadow: var(--rs-shadow-soft);
   border: 0.5px solid var(--rs-color-border-base-primary);
   color: var(--rs-color-foreground-base-primary);
   min-width: var(--anchor-width);

--- a/packages/raystack/components/menu/menu.module.css
+++ b/packages/raystack/components/menu/menu.module.css
@@ -8,7 +8,6 @@
   line-height: var(--rs-line-height-small);
   letter-spacing: var(--rs-letter-spacing-small);
   box-sizing: border-box;
-  min-width: var(--rs-space-15);
 
   padding: var(--rs-space-2);
   background-color: var(--rs-color-background-base-primary);
@@ -95,19 +94,6 @@
   justify-content: center;
   padding: var(--rs-space-4);
   text-align: center;
-}
-
-.leadingIcon {
-  display: flex;
-  align-items: center;
-  color: var(--rs-color-foreground-base-secondary);
-}
-
-.trailingIcon {
-  display: flex;
-  align-items: center;
-  color: var(--rs-color-foreground-base-secondary);
-  margin-left: auto;
 }
 
 .menuBarTrigger[data-pressed] {

--- a/packages/raystack/components/meter/meter-track.tsx
+++ b/packages/raystack/components/meter/meter-track.tsx
@@ -35,7 +35,10 @@ export function MeterTrack({
 
   return (
     <MeterPrimitive.Track className={cx(styles.track, className)} {...props}>
-      <MeterPrimitive.Indicator className={styles.indicator} />
+      <MeterPrimitive.Indicator
+        className={styles.indicator}
+        style={{ width: '100%' }}
+      />
       {children}
     </MeterPrimitive.Track>
   );

--- a/packages/raystack/components/meter/meter.module.css
+++ b/packages/raystack/components/meter/meter.module.css
@@ -5,12 +5,6 @@
   width: 100%;
 }
 
-.header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
 .label {
   font-family: var(--rs-font-body);
   font-size: var(--rs-font-size-mini);

--- a/packages/raystack/components/meter/meter.module.css
+++ b/packages/raystack/components/meter/meter.module.css
@@ -42,6 +42,8 @@
 .indicator {
   height: 100%;
   background-color: var(--rs-color-background-accent-emphasis);
+  transform: scaleX(calc(var(--rs-meter-percentage, 0) / 100));
+  transform-origin: left;
 }
 
 /* Circular variant — viewBox is 72×72, SVG scales to container size */
@@ -53,7 +55,10 @@
 
 .circularSvg {
   --rs-meter-track-size: var(--rs-space-2);
-  --rs-meter-radius: calc((var(--rs-space-14) - var(--rs-meter-track-size) * 2) / 2);
+  --rs-meter-radius: calc(
+    (var(--rs-space-14) - var(--rs-meter-track-size) * 2) /
+    2
+  );
   --rs-meter-circumference: calc(2 * 3.14159265 * var(--rs-meter-radius));
   width: var(--rs-space-14);
   height: var(--rs-space-14);
@@ -86,11 +91,11 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .indicator {
-    transition: width 500ms;
+    transition: transform var(--rs-duration-moderate) linear;
   }
 
   .circularIndicatorCircle {
-    transition: stroke-dashoffset 500ms;
+    transition: stroke-dashoffset var(--rs-duration-moderate) linear;
   }
 }
 

--- a/packages/raystack/components/navbar/navbar.module.css
+++ b/packages/raystack/components/navbar/navbar.module.css
@@ -11,7 +11,7 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .root {
-    transition: transform 0.2s ease-in-out;
+    transition: transform var(--rs-duration-normal) var(--rs-ease-in-out);
   }
 }
 
@@ -46,4 +46,19 @@
 .end {
   grid-column: 3;
   justify-self: end;
+}
+
+/* Reduced motion: hide-on-scroll degrades to a quick fade instead of a slide */
+@media (prefers-reduced-motion: reduce) {
+  .root {
+    transition:
+      opacity var(--rs-duration-fast) var(--rs-ease-out),
+      visibility var(--rs-duration-fast) var(--rs-ease-out);
+  }
+
+  .root[data-hidden="true"] {
+    transform: none;
+    opacity: 0;
+    visibility: hidden;
+  }
 }

--- a/packages/raystack/components/number-field/number-field.module.css
+++ b/packages/raystack/components/number-field/number-field.module.css
@@ -19,10 +19,11 @@
   height: var(--rs-space-7);
   flex-shrink: 0;
   background: var(--rs-color-background-base-secondary);
-  border: 0.5px solid var(--rs-color-border-base-primary);
+  border: 0.5px solid var(--rs-color-border-base-tertiary);
   color: var(--rs-color-foreground-base-primary);
   cursor: pointer;
   padding: 0;
+  transition: var(--rs-transition-interactive);
 }
 
 .decrement {
@@ -38,6 +39,18 @@
   background: var(--rs-color-background-base-primary-hover);
 }
 
+/* Steppers sit inside the field border: keep the ring inside. */
+.decrement:focus-visible,
+.increment:focus-visible {
+  outline: var(--rs-focus-ring);
+  outline-offset: var(--rs-focus-ring-offset-inset);
+}
+
+.decrement:active:not([data-disabled]),
+.increment:active:not([data-disabled]) {
+  background: var(--rs-color-background-neutral-secondary);
+}
+
 .decrement[data-disabled],
 .increment[data-disabled] {
   pointer-events: none;
@@ -50,7 +63,7 @@
   min-width: 0;
   flex: 1 0 0;
   background: var(--rs-color-background-base-primary);
-  border: 0.5px solid var(--rs-color-border-base-primary);
+  border: 0.5px solid var(--rs-color-border-base-tertiary);
   font-family: var(--rs-font-body);
   font-size: var(--rs-font-size-small);
   font-weight: var(--rs-font-weight-regular);
@@ -59,8 +72,22 @@
   color: var(--rs-color-foreground-base-primary);
   text-align: center;
   font-variant-numeric: tabular-nums;
+  transition: var(--rs-transition-interactive);
   outline: none;
   padding: 0 var(--rs-space-2);
+}
+
+.input:focus {
+  border-color: var(--rs-color-border-accent-emphasis);
+  background-color: var(--rs-color-background-base-primary);
+}
+
+.input[data-invalid] {
+  border-color: var(--rs-color-border-danger-emphasis);
+}
+
+.input[data-invalid]:focus {
+  border-color: var(--rs-color-border-danger-emphasis-hover);
 }
 
 .input[data-disabled] {

--- a/packages/raystack/components/number-field/number-field.module.css
+++ b/packages/raystack/components/number-field/number-field.module.css
@@ -39,11 +39,12 @@
   background: var(--rs-color-background-base-primary-hover);
 }
 
-/* Steppers sit inside the field border: keep the ring inside. */
+/* Steppers have their own border: hug it with the ring so they don't read as
+   two separate lines. */
 .decrement:focus-visible,
 .increment:focus-visible {
   outline: var(--rs-focus-ring);
-  outline-offset: var(--rs-focus-ring-offset-inset);
+  outline-offset: var(--rs-focus-ring-offset-inset-border);
 }
 
 .decrement:active:not([data-disabled]),

--- a/packages/raystack/components/otp-field/__tests__/otp-field.test.tsx
+++ b/packages/raystack/components/otp-field/__tests__/otp-field.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
+import { Field } from '../../field';
 import { OTPField } from '../otp-field';
 import styles from '../otp-field.module.css';
 
@@ -142,6 +143,17 @@ describe('OTPField', () => {
       await user.keyboard('a');
 
       expect(first).toHaveValue('a');
+    });
+
+    it('marks the root data-invalid inside an errored Field (drives the shake)', () => {
+      render(
+        <Field label='Code' error='Incorrect code'>
+          <BasicOTPField length={4} data-testid='root' />
+        </Field>
+      );
+
+      expect(screen.getByTestId('root')).toHaveAttribute('data-invalid');
+      expect(screen.getByTestId('slot-0')).toHaveAttribute('data-invalid');
     });
 
     it('accepts both letters and digits when alphanumeric', async () => {

--- a/packages/raystack/components/otp-field/otp-field.module.css
+++ b/packages/raystack/components/otp-field/otp-field.module.css
@@ -38,25 +38,21 @@
   color: var(--rs-color-foreground-base-tertiary);
 }
 
-.otp-field-input:hover:not(:focus):not(:disabled):not([data-disabled]):not(
-    [data-readonly]
-  ):not([data-invalid]) {
-  border-color: var(--rs-color-border-base-focus);
-}
-
 .otp-field-input:focus:not([data-readonly]):not([data-invalid]) {
   border-color: var(--rs-color-border-accent-emphasis);
+  box-shadow: var(--rs-focus-ring-shadow);
 }
 
 .otp-field-input[data-invalid] {
   border-color: var(--rs-color-border-danger-emphasis);
 }
 
-.otp-field-input[data-invalid]:hover:not(:disabled):not([data-disabled]):not(
-    [data-readonly]
-  ),
 .otp-field-input[data-invalid]:focus:not([data-readonly]) {
   border-color: var(--rs-color-border-danger-emphasis-hover);
+}
+
+.otp-field-input[data-invalid]:focus:not([data-readonly]) {
+  box-shadow: 0 0 0 1.5px var(--rs-color-border-danger-primary);
 }
 
 .otp-field-input[data-disabled],
@@ -64,12 +60,6 @@
   opacity: 0.5;
   cursor: not-allowed;
   color: var(--rs-color-foreground-base-tertiary);
-}
-
-.otp-field-input[data-disabled]:hover,
-.otp-field-input:disabled:hover {
-  border-color: var(--rs-color-border-base-tertiary);
-  background: var(--rs-color-background-base-primary);
 }
 
 .otp-field-input[data-readonly] {

--- a/packages/raystack/components/otp-field/otp-field.module.css
+++ b/packages/raystack/components/otp-field/otp-field.module.css
@@ -4,6 +4,33 @@
   gap: var(--rs-space-3);
 }
 
+/* Failed validation shakes the row once; the red borders remain the durable
+   signal, so reduced-motion users lose nothing. */
+@media (prefers-reduced-motion: no-preference) {
+  .otp-field[data-invalid] {
+    animation: otp-field-shake var(--rs-duration-slow) var(--rs-ease-out);
+  }
+}
+
+@keyframes otp-field-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-4px);
+  }
+  40% {
+    transform: translateX(4px);
+  }
+  60% {
+    transform: translateX(-3px);
+  }
+  80% {
+    transform: translateX(3px);
+  }
+}
+
 .otp-field-input {
   width: var(--rs-space-7);
   height: var(--rs-space-9);

--- a/packages/raystack/components/popover/popover.module.css
+++ b/packages/raystack/components/popover/popover.module.css
@@ -14,7 +14,7 @@
   background-color: var(--rs-color-background-base-primary);
   border-radius: var(--rs-radius-2);
   box-shadow: var(--rs-shadow-soft);
-  border: 1px solid var(--rs-color-border-base-primary);
+  border: 0.5px solid var(--rs-color-border-base-primary);
   color: var(--rs-color-foreground-base-primary);
   transform-origin: var(--transform-origin);
   transition: opacity var(--rs-duration-normal) var(--rs-ease-out);

--- a/packages/raystack/components/popover/popover.module.css
+++ b/packages/raystack/components/popover/popover.module.css
@@ -16,21 +16,24 @@
   box-shadow: var(--rs-shadow-soft);
   border: 1px solid var(--rs-color-border-base-primary);
   color: var(--rs-color-foreground-base-primary);
+  transform-origin: var(--transform-origin);
+  transition: opacity var(--rs-duration-normal) var(--rs-ease-out);
 }
 
-@keyframes slideUpAndFade {
-  from {
-    opacity: 0;
-    transform: translateY(var(--rs-space-1));
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+.popover[data-starting-style],
+.popover[data-ending-style] {
+  opacity: 0;
 }
 
 @media (prefers-reduced-motion: no-preference) {
   .popover {
-    animation: slideUpAndFade 400ms cubic-bezier(0.16, 1, 0.3, 1);
+    transition:
+      opacity var(--rs-duration-normal) var(--rs-ease-out),
+      transform var(--rs-duration-normal) var(--rs-ease-out);
+  }
+
+  .popover[data-starting-style],
+  .popover[data-ending-style] {
+    transform: scale(0.97);
   }
 }

--- a/packages/raystack/components/preview-card/preview-card.module.css
+++ b/packages/raystack/components/preview-card/preview-card.module.css
@@ -1,3 +1,7 @@
+/* Default mode (no PreviewCard.Viewport): Base UI positions the positioner
+   via transform (floating-ui). Don't transition that transform, or the card
+   eases toward every reposition and swims behind its anchor. The popup owns
+   the entrance (scale below); the positioner only fades — like popover/menu/tooltip. */
 .positioner {
   --easing: var(--rs-ease-out);
   --animation-duration: var(--rs-duration-moderate);
@@ -29,7 +33,6 @@
 .popup[data-starting-style],
 .popup[data-ending-style] {
   opacity: 0;
-  transform: scale(0.9);
 }
 
 .arrow svg {
@@ -80,41 +83,34 @@
 
 .viewport[data-activation-direction~="left"]
   [data-current][data-starting-style] {
-  translate: -30% 0;
   opacity: 0;
 }
 
 .viewport[data-activation-direction~="right"]
   [data-current][data-starting-style] {
-  translate: 30% 0;
   opacity: 0;
 }
 
 .viewport[data-activation-direction~="left"]
   [data-previous][data-ending-style] {
-  translate: 30% 0;
   opacity: 0;
 }
 
 .viewport[data-activation-direction~="right"]
   [data-previous][data-ending-style] {
-  translate: -30% 0;
   opacity: 0;
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  /* Default mode (no PreviewCard.Viewport): Base UI positions the positioner
-     via transform (floating-ui). Don't transition that transform, or the card
-     eases toward every reposition and swims behind its anchor. The popup owns
-     the entrance (scale below); the positioner only fades — like popover/menu/tooltip. */
-  .positioner {
-    transition: opacity var(--animation-duration) var(--easing);
-  }
-
   .popup {
     transition:
       opacity var(--animation-duration) var(--easing),
       transform var(--animation-duration) var(--easing);
+  }
+
+  .popup[data-starting-style],
+  .popup[data-ending-style] {
+    transform: scale(0.9);
   }
 
   /* Viewport-morph mode: Base UI switches to inset positioning
@@ -143,5 +139,25 @@
     transition:
       translate var(--animation-duration) var(--easing),
       opacity calc(var(--animation-duration) / 2) var(--easing);
+  }
+
+  .viewport[data-activation-direction~="left"]
+    [data-current][data-starting-style] {
+    translate: -30% 0;
+  }
+
+  .viewport[data-activation-direction~="right"]
+    [data-current][data-starting-style] {
+    translate: 30% 0;
+  }
+
+  .viewport[data-activation-direction~="left"]
+    [data-previous][data-ending-style] {
+    translate: 30% 0;
+  }
+
+  .viewport[data-activation-direction~="right"]
+    [data-previous][data-ending-style] {
+    translate: -30% 0;
   }
 }

--- a/packages/raystack/components/preview-card/preview-card.module.css
+++ b/packages/raystack/components/preview-card/preview-card.module.css
@@ -20,7 +20,7 @@
   background-color: var(--rs-color-background-base-primary);
   border-radius: var(--rs-radius-2);
   border: 0.5px solid var(--rs-color-border-base-primary);
-  box-shadow: var(--rs-shadow-lifted);
+  box-shadow: var(--rs-shadow-soft);
   color: var(--rs-color-foreground-base-primary);
   transform-origin: var(--transform-origin);
 

--- a/packages/raystack/components/preview-card/preview-card.module.css
+++ b/packages/raystack/components/preview-card/preview-card.module.css
@@ -1,6 +1,6 @@
 .positioner {
-  --easing: cubic-bezier(0.22, 1, 0.36, 1);
-  --animation-duration: 0.35s;
+  --easing: var(--rs-ease-out);
+  --animation-duration: var(--rs-duration-moderate);
 
   z-index: var(--rs-z-index-portal);
   height: var(--positioner-height);
@@ -103,17 +103,34 @@
 }
 
 @media (prefers-reduced-motion: no-preference) {
+  /* Default mode (no PreviewCard.Viewport): Base UI positions the positioner
+     via transform (floating-ui). Don't transition that transform, or the card
+     eases toward every reposition and swims behind its anchor. The popup owns
+     the entrance (scale below); the positioner only fades — like popover/menu/tooltip. */
   .positioner {
+    transition: opacity var(--animation-duration) var(--easing);
+  }
+
+  .popup {
+    transition:
+      opacity var(--animation-duration) var(--easing),
+      transform var(--animation-duration) var(--easing);
+  }
+
+  /* Viewport-morph mode: Base UI switches to inset positioning
+     (adaptiveOrigin) and drives --popup-width/--popup-height, so animating
+     inset + width/height IS the morph. Layout cost is confined to this popup
+     subtree for the duration of the morph. */
+  .positioner:has(.viewport) {
     transition:
       top var(--animation-duration) var(--easing),
       left var(--animation-duration) var(--easing),
       right var(--animation-duration) var(--easing),
       bottom var(--animation-duration) var(--easing),
-      transform var(--animation-duration) var(--easing),
       opacity var(--animation-duration) var(--easing);
   }
 
-  .popup {
+  .popup:has(.viewport) {
     transition:
       width var(--animation-duration) var(--easing),
       height var(--animation-duration) var(--easing),

--- a/packages/raystack/components/progress/progress-track.tsx
+++ b/packages/raystack/components/progress/progress-track.tsx
@@ -35,7 +35,10 @@ export function ProgressTrack({
 
   return (
     <ProgressPrimitive.Track className={cx(styles.track, className)} {...props}>
-      <ProgressPrimitive.Indicator className={styles.indicator} />
+      <ProgressPrimitive.Indicator
+        className={styles.indicator}
+        style={{ width: '100%' }}
+      />
       {children}
     </ProgressPrimitive.Track>
   );

--- a/packages/raystack/components/progress/progress.module.css
+++ b/packages/raystack/components/progress/progress.module.css
@@ -5,12 +5,6 @@
   width: 100%;
 }
 
-.header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
 .label {
   font-family: var(--rs-font-body);
   font-size: var(--rs-font-size-mini);

--- a/packages/raystack/components/progress/progress.module.css
+++ b/packages/raystack/components/progress/progress.module.css
@@ -42,6 +42,8 @@
 .indicator {
   height: 100%;
   background-color: var(--rs-color-background-accent-emphasis);
+  transform: scaleX(calc(var(--rs-progress-percentage, 0) / 100));
+  transform-origin: left;
 }
 
 /* Circular variant — viewBox is 72×72, SVG scales to container size */
@@ -53,7 +55,10 @@
 
 .circularSvg {
   --rs-progress-track-size: var(--rs-space-2);
-  --rs-progress-radius: calc((var(--rs-space-14) - var(--rs-progress-track-size) * 2) / 2);
+  --rs-progress-radius: calc(
+    (var(--rs-space-14) - var(--rs-progress-track-size) * 2) /
+    2
+  );
   --rs-progress-circumference: calc(2 * 3.14159265 * var(--rs-progress-radius));
   width: var(--rs-space-14);
   height: var(--rs-space-14);
@@ -86,11 +91,11 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .indicator {
-    transition: width 500ms;
+    transition: transform var(--rs-duration-moderate) linear;
   }
 
   .circularIndicatorCircle {
-    transition: stroke-dashoffset 500ms;
+    transition: stroke-dashoffset var(--rs-duration-moderate) linear;
   }
 }
 
@@ -102,4 +107,51 @@
   font-weight: var(--rs-font-weight-medium);
   text-align: center;
   white-space: nowrap;
+}
+
+/* Indeterminate (value={null}). Static fallback: dimmed centered bar / partial arc. */
+.indicator[data-indeterminate] {
+  transform: scaleX(0.4);
+  transform-origin: center;
+  opacity: 0.6;
+}
+
+.circularSvg[data-indeterminate] .circularIndicatorCircle {
+  stroke-dashoffset: calc(var(--rs-progress-circumference) * 0.75);
+  opacity: 0.6;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .indicator[data-indeterminate] {
+    opacity: 1;
+    transform-origin: left;
+    transition: none;
+    animation: progress-indeterminate-sweep 1.2s var(--rs-ease-in-out) infinite;
+  }
+
+  .circularSvg[data-indeterminate] {
+    animation: progress-indeterminate-rotate 1.2s linear infinite;
+  }
+
+  .circularSvg[data-indeterminate] .circularIndicatorCircle {
+    opacity: 1;
+  }
+}
+
+@keyframes progress-indeterminate-sweep {
+  from {
+    transform: translateX(-45%) scaleX(0.4);
+  }
+  to {
+    transform: translateX(105%) scaleX(0.4);
+  }
+}
+
+@keyframes progress-indeterminate-rotate {
+  from {
+    transform: rotate(-90deg);
+  }
+  to {
+    transform: rotate(270deg);
+  }
 }

--- a/packages/raystack/components/radio/radio.module.css
+++ b/packages/raystack/components/radio/radio.module.css
@@ -141,7 +141,3 @@
   width: var(--rs-radius-3);
   height: var(--rs-radius-3);
 }
-
-.radioitem[data-disabled] .indicator::after {
-  background: var(--rs-color-foreground-base-emphasis);
-}

--- a/packages/raystack/components/radio/radio.module.css
+++ b/packages/raystack/components/radio/radio.module.css
@@ -20,6 +20,9 @@
   justify-content: center;
   cursor: pointer;
   box-sizing: border-box;
+  transition:
+    background-color var(--rs-duration-fast) var(--rs-ease-out),
+    border-color var(--rs-duration-fast) var(--rs-ease-out);
 }
 
 /* Group-level size — low specificity via :where() so item-level size wins */
@@ -42,6 +45,28 @@
 .radioitem:hover {
   border-color: var(--rs-color-border-base-tertiary-hover);
   background: var(--rs-color-background-base-primary-hover);
+}
+
+.radioitem:focus-visible {
+  outline: var(--rs-focus-ring);
+}
+
+/* Checked = accent fill: offset the ring so it clears it. */
+.radioitem[data-checked]:focus-visible {
+  outline-offset: var(--rs-focus-ring-offset-accent);
+}
+
+.radioitem:active:not([data-disabled]) {
+  transform: scale(var(--rs-scale-pressed-strong));
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .radioitem {
+    transition:
+      background-color var(--rs-duration-fast) var(--rs-ease-out),
+      border-color var(--rs-duration-fast) var(--rs-ease-out),
+      transform var(--rs-duration-press) var(--rs-ease-out);
+  }
 }
 
 .radioitem[data-checked] {
@@ -74,6 +99,26 @@
   width: 100%;
   height: 100%;
   position: relative;
+  transition: opacity var(--rs-duration-fast) var(--rs-ease-out);
+}
+
+.indicator[data-starting-style],
+.indicator[data-ending-style],
+.indicator[data-unchecked] {
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .indicator {
+    transition:
+      opacity var(--rs-duration-fast) var(--rs-ease-out),
+      transform var(--rs-duration-fast) var(--rs-ease-out);
+  }
+
+  .indicator[data-starting-style],
+  .indicator[data-ending-style] {
+    transform: scale(0.8);
+  }
 }
 
 .indicator::after {

--- a/packages/raystack/components/radio/radio.tsx
+++ b/packages/raystack/components/radio/radio.tsx
@@ -69,7 +69,7 @@ function RadioItem({ className, size, ...props }: RadioItemProps) {
       {...props}
       className={radioVariants({ size, className })}
     >
-      <RadioPrimitive.Indicator className={styles.indicator} />
+      <RadioPrimitive.Indicator className={styles.indicator} keepMounted />
     </RadioPrimitive.Root>
   );
 }

--- a/packages/raystack/components/scroll-area/scroll-area.module.css
+++ b/packages/raystack/components/scroll-area/scroll-area.module.css
@@ -1,6 +1,8 @@
 :root {
-  --rs-scrollbar-size-default: var(--rs-space-2);
-  --rs-scrollbar-size-hover: 6px;
+  --rs-scrollbar-size: 6px; /* track + hit area, and the expanded thumb */
+  --rs-scrollbar-thumb-rest: var(
+    --rs-space-2
+  ); /* 4px — visible thumb at rest */
 }
 
 .root {
@@ -25,42 +27,83 @@
   background: transparent;
   pointer-events: auto;
   position: relative;
-  transition: opacity 150ms ease-out;
+  transition: opacity var(--rs-duration-fast) var(--rs-ease-out);
 }
 
+/* Constant track = constant hit area; the track is transparent so hover never
+   changes layout (no content reflow). The visible bar is the thumb's ::before,
+   which is thinner at rest and grows to fill the track on hover. */
 .scrollbar[data-orientation="vertical"] {
-  width: var(--rs-scrollbar-size-default);
-}
-
-.scrollbar[data-orientation="vertical"]:hover {
-  width: var(--rs-scrollbar-size-hover);
+  width: var(--rs-scrollbar-size);
 }
 
 .scrollbar[data-orientation="horizontal"] {
   flex-direction: column;
-  height: var(--rs-scrollbar-size-default);
-}
-
-.scrollbar[data-orientation="horizontal"]:hover {
-  height: var(--rs-scrollbar-size-hover);
+  height: var(--rs-scrollbar-size);
 }
 
 .thumb {
   flex: 1;
-  background: var(--rs-color-overlay-base-a5);
-  border-radius: var(--rs-radius-2);
-  transition: opacity 150ms ease-out;
-  opacity: 1;
+  position: relative;
   pointer-events: auto;
   touch-action: none;
+  opacity: 1;
+}
+
+/* The drawn bar. The thumb stays the full-size hit area; this pseudo is what
+   you see. It's a pseudo because Base UI writes an inline transform on the
+   thumb to position it — so the thumb's own transform can't be used to size it,
+   and animating the thumb's transform would make it lag while scrolling. */
+.thumb::before {
+  content: "";
+  position: absolute;
+  background: var(--rs-color-overlay-base-a5);
+  border-radius: var(--rs-radius-2);
+  transition: background-color var(--rs-duration-fast) var(--rs-ease-out);
+}
+
+/* Vertical: bar hugs the outer (right) edge and grows inward. */
+.scrollbar[data-orientation="vertical"] .thumb::before {
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: var(--rs-scrollbar-thumb-rest);
+}
+
+.scrollbar[data-orientation="vertical"]:hover .thumb::before,
+.scrollbar[data-orientation="vertical"]:active .thumb::before {
+  width: var(--rs-scrollbar-size);
+}
+
+/* Horizontal: bar hugs the bottom edge and grows upward. */
+.scrollbar[data-orientation="horizontal"] .thumb::before {
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: var(--rs-scrollbar-thumb-rest);
+}
+
+.scrollbar[data-orientation="horizontal"]:hover .thumb::before,
+.scrollbar[data-orientation="horizontal"]:active .thumb::before {
+  height: var(--rs-scrollbar-size);
+}
+
+/* Deepen the bar one overlay step per state. Base UI exposes no data-pressed;
+   pointer capture holds :active for the whole drag. */
+.scrollbar:hover .thumb::before {
+  background: var(--rs-color-overlay-base-a6);
+}
+
+.scrollbar:active .thumb::before {
+  background: var(--rs-color-overlay-base-a7);
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  .scrollbar {
+  .thumb::before {
     transition:
-      width 150ms ease-out,
-      height 150ms ease-out,
-      opacity 150ms ease-out;
+      background-color var(--rs-duration-fast) var(--rs-ease-out),
+      width var(--rs-duration-fast) var(--rs-ease-out),
+      height var(--rs-duration-fast) var(--rs-ease-out);
   }
 }
 

--- a/packages/raystack/components/search/search.module.css
+++ b/packages/raystack/components/search/search.module.css
@@ -11,10 +11,23 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  opacity: 1;
+  visibility: visible;
 }
 
+@media (prefers-reduced-motion: no-preference) {
+  .clearButtonWrapper {
+    transition:
+      opacity var(--rs-duration-fast) var(--rs-ease-out),
+      visibility var(--rs-duration-fast) var(--rs-ease-out);
+  }
+}
+
+/* visibility rides the transition so the button stays hittable only while
+   fading, then drops out of hit-testing, tab order and the a11y tree. */
 .container:has(input:placeholder-shown) .clearButtonWrapper {
-  display: none;
+  opacity: 0;
+  visibility: hidden;
 }
 
 .clearButton {

--- a/packages/raystack/components/select/__tests__/select.test.tsx
+++ b/packages/raystack/components/select/__tests__/select.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { Select } from '../select';
@@ -167,6 +167,36 @@ describe('Select', () => {
       await user.click(options[1]);
       await flushMicrotasks();
       expect(handleValueChange).toHaveBeenCalledWith([]);
+    });
+
+    it('renders a checkbox indicator that reflects selection state', async () => {
+      const user = userEvent.setup();
+      render(<BasicSelect multiple />);
+      await openSelect(user);
+
+      const options = screen.getAllByRole('option');
+      // One checkbox per item (the hidden native input is aria-hidden).
+      expect(within(options[1]).getAllByRole('checkbox')).toHaveLength(1);
+
+      const checkbox = within(options[1]).getByRole('checkbox');
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+
+      await user.click(options[1]);
+      await flushMicrotasks();
+      expect(
+        within(screen.getAllByRole('option')[1]).getByRole('checkbox')
+      ).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('fires onValueChange exactly once per click on an option', async () => {
+      const handleValueChange = vi.fn();
+      render(<BasicSelect multiple onValueChange={handleValueChange} />);
+      const user = userEvent.setup();
+      await openSelect(user);
+
+      await user.click(screen.getAllByRole('option')[1]);
+      await flushMicrotasks();
+      expect(handleValueChange).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/raystack/components/select/select-item.tsx
+++ b/packages/raystack/components/select/select-item.tsx
@@ -6,11 +6,27 @@ import {
 } from '@base-ui/react';
 import { cx } from 'class-variance-authority';
 import { ReactNode, useLayoutEffect } from 'react';
-import { Checkbox } from '../checkbox';
 import { getMatch } from '../menu/utils';
 import { Text } from '../text';
 import styles from './select.module.css';
 import { useSelectContext } from './select-root';
+
+const CheckMarkIcon = () => (
+  <svg
+    xmlns='http://www.w3.org/2000/svg'
+    width='16'
+    height='16'
+    viewBox='0 0 16 16'
+    fill='none'
+  >
+    <path
+      fillRule='evenodd'
+      clipRule='evenodd'
+      d='M11.9005 4.9671C12.0894 4.6782 12.0083 4.29086 11.7194 4.10197C11.4305 3.91307 11.0432 3.99414 10.8543 4.28304L7.15577 9.93961L5.04542 8.02112C4.79001 7.78893 4.39473 7.80775 4.16254 8.06316C3.93035 8.31857 3.94917 8.71385 4.20458 8.94605L6.85731 11.3576C6.99274 11.4807 7.17532 11.5383 7.35686 11.5151C7.53841 11.492 7.70068 11.3904 7.80084 11.2372L11.9005 4.9671Z'
+      fill='currentColor'
+    />
+  </svg>
+);
 
 export interface SelectItemProps extends SelectPrimitive.Item.Props {
   leadingIcon?: ReactNode;
@@ -76,7 +92,15 @@ export function SelectItem({
       {...props}
       render={(renderProps, state) => (
         <div {...renderProps}>
-          {multiple && <Checkbox checked={state.selected} />}
+          {multiple && (
+            <span
+              className={styles.checkIndicator}
+              data-checked={state.selected || undefined}
+              aria-hidden='true'
+            >
+              {state.selected && <CheckMarkIcon />}
+            </span>
+          )}
           {element}
         </div>
       )}

--- a/packages/raystack/components/select/select-item.tsx
+++ b/packages/raystack/components/select/select-item.tsx
@@ -6,27 +6,11 @@ import {
 } from '@base-ui/react';
 import { cx } from 'class-variance-authority';
 import { ReactNode, useLayoutEffect } from 'react';
+import { Checkbox } from '../checkbox';
 import { getMatch } from '../menu/utils';
 import { Text } from '../text';
 import styles from './select.module.css';
 import { useSelectContext } from './select-root';
-
-const CheckMarkIcon = () => (
-  <svg
-    xmlns='http://www.w3.org/2000/svg'
-    width='16'
-    height='16'
-    viewBox='0 0 16 16'
-    fill='none'
-  >
-    <path
-      fillRule='evenodd'
-      clipRule='evenodd'
-      d='M11.9005 4.9671C12.0894 4.6782 12.0083 4.29086 11.7194 4.10197C11.4305 3.91307 11.0432 3.99414 10.8543 4.28304L7.15577 9.93961L5.04542 8.02112C4.79001 7.78893 4.39473 7.80775 4.16254 8.06316C3.93035 8.31857 3.94917 8.71385 4.20458 8.94605L6.85731 11.3576C6.99274 11.4807 7.17532 11.5383 7.35686 11.5151C7.53841 11.492 7.70068 11.3904 7.80084 11.2372L11.9005 4.9671Z'
-      fill='currentColor'
-    />
-  </svg>
-);
 
 export interface SelectItemProps extends SelectPrimitive.Item.Props {
   leadingIcon?: ReactNode;
@@ -92,15 +76,7 @@ export function SelectItem({
       {...props}
       render={(renderProps, state) => (
         <div {...renderProps}>
-          {multiple && (
-            <span
-              className={styles.checkIndicator}
-              data-checked={state.selected || undefined}
-              aria-hidden='true'
-            >
-              {state.selected && <CheckMarkIcon />}
-            </span>
-          )}
+          {multiple && <Checkbox checked={state.selected} />}
           {element}
         </div>
       )}

--- a/packages/raystack/components/select/select-trigger.tsx
+++ b/packages/raystack/components/select/select-trigger.tsx
@@ -4,7 +4,7 @@ import {
   Combobox as ComboboxPrimitive,
   Select as SelectPrimitive
 } from '@base-ui/react';
-import { CaretSortIcon } from '@radix-ui/react-icons';
+import { ChevronDownIcon } from '@radix-ui/react-icons';
 import { cva, VariantProps } from 'class-variance-authority';
 import { ComponentProps, SVGAttributes } from 'react';
 import { Flex } from '../flex';
@@ -67,7 +67,7 @@ export function SelectTrigger({
       <Flex className={styles.triggerContent} align='center' gap={2}>
         {children}
       </Flex>
-      <CaretSortIcon
+      <ChevronDownIcon
         className={styles.triggerIcon}
         aria-hidden='true'
         {...iconProps}

--- a/packages/raystack/components/select/select-trigger.tsx
+++ b/packages/raystack/components/select/select-trigger.tsx
@@ -4,7 +4,7 @@ import {
   Combobox as ComboboxPrimitive,
   Select as SelectPrimitive
 } from '@base-ui/react';
-import { ChevronDownIcon } from '@radix-ui/react-icons';
+import { CaretSortIcon } from '@radix-ui/react-icons';
 import { cva, VariantProps } from 'class-variance-authority';
 import { ComponentProps, SVGAttributes } from 'react';
 import { Flex } from '../flex';
@@ -67,7 +67,7 @@ export function SelectTrigger({
       <Flex className={styles.triggerContent} align='center' gap={2}>
         {children}
       </Flex>
-      <ChevronDownIcon
+      <CaretSortIcon
         className={styles.triggerIcon}
         aria-hidden='true'
         {...iconProps}

--- a/packages/raystack/components/select/select.module.css
+++ b/packages/raystack/components/select/select.module.css
@@ -61,30 +61,6 @@
   pointer-events: none;
 }
 
-.checkIndicator {
-  box-sizing: border-box;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  width: var(--rs-space-5);
-  height: var(--rs-space-5);
-  border-radius: var(--rs-radius-1);
-  background: var(--rs-color-background-base-primary);
-  border: 1px solid var(--rs-color-border-base-secondary);
-  color: var(--rs-color-foreground-accent-emphasis);
-}
-
-.checkIndicator[data-checked] {
-  background: var(--rs-color-background-accent-emphasis);
-  border: none;
-}
-
-.checkIndicator svg {
-  width: 100%;
-  height: 100%;
-}
-
 .label {
   padding: var(--rs-space-2) var(--rs-space-3);
   font-weight: var(--rs-font-weight-medium);

--- a/packages/raystack/components/select/select.module.css
+++ b/packages/raystack/components/select/select.module.css
@@ -56,10 +56,6 @@
   background: var(--rs-color-background-base-primary-hover);
 }
 
-/* .content:not([data-multiselectable="true"]) .menuitem[data-selected] {
-  background: var(--rs-color-background-neutral-secondary);
-} */
-
 .menuitem[data-disabled] {
   opacity: 0.5;
   pointer-events: none;
@@ -210,19 +206,6 @@
   color: var(--rs-color-foreground-base-secondary);
 }
 
-.content[data-variant="text"] {
-  margin-top: var(--rs-space-2);
-  padding: var(--rs-space-1);
-  border: 0.5px solid var(--rs-color-border-base-primary);
-  box-shadow: var(--rs-shadow-soft);
-}
-
-.content[data-variant="text"] .menuitem {
-  padding: var(--rs-space-1) var(--rs-space-2);
-  min-height: var(--rs-space-7) !important;
-  font-size: var(--rs-font-size-small);
-}
-
 .triggerContent {
   flex: 1;
   overflow: hidden;
@@ -272,11 +255,6 @@
 
 .placeholder,
 [data-placeholder] {
-  color: var(--rs-color-foreground-base-tertiary);
-}
-
-.placeholder:hover,
-[data-placeholder]:hover {
   color: var(--rs-color-foreground-base-tertiary);
 }
 

--- a/packages/raystack/components/select/select.module.css
+++ b/packages/raystack/components/select/select.module.css
@@ -1,6 +1,5 @@
 .positioner {
   z-index: var(--rs-z-index-portal);
-  background-color: var(--rs-color-background-base-primary);
 }
 
 .content {
@@ -14,10 +13,29 @@
   box-shadow: var(--rs-shadow-soft);
   border: 0.5px solid var(--rs-color-border-base-primary);
   min-width: var(--anchor-width);
-  transition: var(--rs-transition-interactive);
+  transform-origin: var(--transform-origin);
+  transition: opacity var(--rs-duration-fast) var(--rs-ease-out);
   max-height: 320px;
   position: relative;
   overflow: auto;
+}
+
+.content[data-starting-style],
+.content[data-ending-style] {
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .content {
+    transition:
+      opacity var(--rs-duration-fast) var(--rs-ease-out),
+      transform var(--rs-duration-fast) var(--rs-ease-out);
+  }
+
+  .content[data-starting-style],
+  .content[data-ending-style] {
+    transform: scale(0.97);
+  }
 }
 
 .menuitem {
@@ -45,6 +63,30 @@
 .menuitem[data-disabled] {
   opacity: 0.5;
   pointer-events: none;
+}
+
+.checkIndicator {
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: var(--rs-space-5);
+  height: var(--rs-space-5);
+  border-radius: var(--rs-radius-1);
+  background: var(--rs-color-background-base-primary);
+  border: 1px solid var(--rs-color-border-base-secondary);
+  color: var(--rs-color-foreground-accent-emphasis);
+}
+
+.checkIndicator[data-checked] {
+  background: var(--rs-color-background-accent-emphasis);
+  border: none;
+}
+
+.checkIndicator svg {
+  width: 100%;
+  height: 100%;
 }
 
 .label {
@@ -75,7 +117,7 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .trigger {
-    transition: all 0.2s ease;
+    transition: var(--rs-transition-interactive);
   }
 }
 
@@ -134,11 +176,15 @@
   color: var(--rs-color-foreground-base-primary);
 }
 
-.trigger:focus-visible {
-  outline: 1px solid var(--rs-color-border-accent-emphasis);
+.trigger:active:not([data-disabled]):not(:disabled) {
+  background-color: var(--rs-color-background-neutral-secondary);
 }
 
-.trigger:focus {
+.trigger:focus-visible {
+  outline: var(--rs-focus-ring);
+}
+
+.trigger:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -154,6 +200,8 @@
   letter-spacing: var(--rs-letter-spacing-small);
 }
 
+/* Static up/down caret — the pop-up-button affordance ("pick a value").
+   It does not rotate on open; the menu appearing is the feedback. */
 .triggerIcon {
   width: var(--rs-space-5);
   height: var(--rs-space-5);

--- a/packages/raystack/components/side-panel/side-panel.module.css
+++ b/packages/raystack/components/side-panel/side-panel.module.css
@@ -1,7 +1,7 @@
 .side-panel {
   width: 400px;
   background: var(--rs-color-background-base-primary);
-  overflow: scroll;
+  overflow: auto;
 }
 
 .side-panel-left {

--- a/packages/raystack/components/sidebar/__tests__/sidebar.test.tsx
+++ b/packages/raystack/components/sidebar/__tests__/sidebar.test.tsx
@@ -276,10 +276,11 @@ describe('Sidebar', () => {
       expect(item).toHaveTextContent('Custom Item');
     });
 
-    it('hides text when collapsed and sets aria-label for screen readers', () => {
+    it('keeps text mounted and sets aria-label when collapsed', () => {
       render(<BasicSidebar open={false} />);
 
-      expect(screen.queryByText(DASHBOARD_ITEM_TEXT)).not.toBeInTheDocument();
+      // The label stays mounted so it can collapse with the sidebar (CSS hides
+      // it); the item is named via aria-label so screen readers still get it.
       const dashboardLink = screen.getByRole('listitem', {
         name: DASHBOARD_ITEM_TEXT
       });

--- a/packages/raystack/components/sidebar/__tests__/sidebar.test.tsx
+++ b/packages/raystack/components/sidebar/__tests__/sidebar.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { Sidebar } from '../sidebar';
 import styles from '../sidebar.module.css';
@@ -564,6 +565,35 @@ describe('Sidebar', () => {
 
       expect(screen.getByText('Logs')).toBeInTheDocument();
       expect(screen.getByText('Audit')).toBeInTheDocument();
+    });
+
+    it('marks the keyboard-focused More item with data-highlighted', async () => {
+      const user = userEvent.setup();
+      render(
+        <BasicSidebar>
+          <Sidebar.More label='More items'>
+            <Sidebar.Item href='#'>Logs</Sidebar.Item>
+            <Sidebar.Item href='#'>Audit</Sidebar.Item>
+          </Sidebar.More>
+        </BasicSidebar>
+      );
+
+      const trigger = screen.getByText('More items').closest('button');
+      expect(trigger).toBeInTheDocument();
+      if (!trigger) return;
+      trigger.focus();
+      await user.keyboard('{Enter}');
+
+      const items = await screen.findAllByRole('menuitem');
+      expect(items.length).toBeGreaterThan(0);
+      await user.keyboard('{ArrowDown}');
+
+      // The CSS keys the keyboard highlight off [data-highlighted]; exactly
+      // one item should carry it as focus moves through the menu.
+      const highlighted = items.filter(el =>
+        el.hasAttribute('data-highlighted')
+      );
+      expect(highlighted).toHaveLength(1);
     });
 
     it('sets aria-label for collapsed More trigger', () => {

--- a/packages/raystack/components/sidebar/sidebar-item.tsx
+++ b/packages/raystack/components/sidebar/sidebar-item.tsx
@@ -62,11 +62,11 @@ export function SidebarItem({
         fallbackText={shouldShowFallback ? children : undefined}
         className={classNames?.leadingIcon}
       />
-      {!isCollapsed && (
-        <span className={cx(styles['nav-text'], classNames?.text)}>
-          {children}
-        </span>
-      )}
+      {/* Kept mounted so it can collapse with the sidebar (max-width → 0)
+          instead of popping out; CSS hides it when closed. */}
+      <span className={cx(styles['nav-text'], classNames?.text)}>
+        {children}
+      </span>
     </>
   );
 

--- a/packages/raystack/components/sidebar/sidebar-more.tsx
+++ b/packages/raystack/components/sidebar/sidebar-more.tsx
@@ -50,11 +50,9 @@ export function SidebarMore({
         leadingIcon={triggerIcon}
         className={classNames?.leadingIcon}
       />
-      {!isCollapsed && (
-        <span className={cx(styles['nav-text'], classNames?.text)}>
-          {label}
-        </span>
-      )}
+      {/* Kept mounted so it can collapse with the sidebar (max-width → 0)
+          instead of popping out; CSS hides it when closed. */}
+      <span className={cx(styles['nav-text'], classNames?.text)}>{label}</span>
     </button>
   );
 

--- a/packages/raystack/components/sidebar/sidebar.module.css
+++ b/packages/raystack/components/sidebar/sidebar.module.css
@@ -88,7 +88,6 @@
   color: var(--rs-color-foreground-base-secondary);
   cursor: pointer;
   text-decoration: none;
-  transition: var(--rs-transition-interactive);
   box-sizing: border-box;
 }
 

--- a/packages/raystack/components/sidebar/sidebar.module.css
+++ b/packages/raystack/components/sidebar/sidebar.module.css
@@ -155,7 +155,10 @@
   text-align: left;
 }
 
-.more-menu-item:hover {
+/* data-highlighted is the menu's arrow-key focus; keep it identical to hover
+   so pointer and keyboard highlight can't drift apart. */
+.more-menu-item:hover,
+.more-menu-item[data-highlighted] {
   background-color: var(--rs-color-background-base-primary-hover);
   color: var(--rs-color-foreground-base-primary);
 }
@@ -234,6 +237,13 @@
   background-color: var(--rs-color-border-base-primary);
 }
 
+/* Inset ring: the handle straddles the sidebar edge (translateX(50%)), so an
+   outward ring would sit partly outside the sidebar and risk clipping. */
+.resizeHandle:focus-visible {
+  outline: var(--rs-focus-ring);
+  outline-offset: var(--rs-focus-ring-offset-inset);
+}
+
 .root[data-position="right"] .resizeHandle {
   left: 0;
   right: auto;
@@ -297,6 +307,11 @@
   cursor: pointer;
   color: inherit;
   text-align: left;
+}
+
+.nav-group-trigger:focus-visible {
+  outline: var(--rs-focus-ring);
+  outline-offset: var(--rs-focus-ring-offset-inset);
 }
 
 .nav-group-chevron {

--- a/packages/raystack/components/sidebar/sidebar.module.css
+++ b/packages/raystack/components/sidebar/sidebar.module.css
@@ -61,8 +61,18 @@
   align-items: flex-start;
 }
 
+.root [data-collapse-hidden] {
+  /* Cap width so the collapse animates to 0; 240px = the sidebar's open width,
+     so wider consumer content is already clipped by the sidebar itself. */
+  max-width: 240px;
+}
+
 .root[data-closed] [data-collapse-hidden] {
-  display: none;
+  max-width: 0;
+  min-width: 0;
+  overflow: hidden;
+  opacity: 0;
+  visibility: hidden;
 }
 
 .footer {
@@ -82,12 +92,7 @@
   color: var(--rs-color-foreground-base-secondary);
   cursor: pointer;
   text-decoration: none;
-  transition:
-    background-color 0.2s ease,
-    color 0.2s ease,
-    border-color 0.2s ease,
-    box-shadow 0.2s ease,
-    opacity 0.2s ease;
+  transition: var(--rs-transition-interactive);
   box-sizing: border-box;
 }
 
@@ -110,6 +115,11 @@
 .nav-item:focus-visible {
   outline: none;
   background-color: var(--rs-color-background-base-primary-hover);
+  color: var(--rs-color-foreground-base-primary);
+}
+
+.nav-item:active:not([data-disabled="true"]) {
+  background-color: var(--rs-color-background-neutral-secondary);
   color: var(--rs-color-foreground-base-primary);
 }
 
@@ -201,13 +211,16 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  transition: opacity 0.2s ease;
+  /* Cap the width so the collapse can animate to 0 (width: auto can't
+     transition). 200px clears any real label; the sidebar caps them narrower. */
+  max-width: 200px;
 }
 
 .root[data-closed] .nav-text {
-  width: 0;
+  max-width: 0;
+  min-width: 0;
   opacity: 0;
-  display: none;
+  visibility: hidden;
 }
 
 .resizeHandle {
@@ -216,8 +229,8 @@
   right: 0;
   width: var(--rs-space-2);
   height: 100%;
-  cursor: ew-resize;
-  transition: background-color 0.2s ease;
+  cursor: pointer;
+  transition: background-color var(--rs-duration-normal) var(--rs-ease-out);
   transform: translateX(50%);
 }
 
@@ -232,7 +245,6 @@
 .root[data-position="right"] .resizeHandle {
   left: 0;
   right: auto;
-  cursor: ew-resize;
   transform: translateX(-50%);
 }
 
@@ -304,7 +316,7 @@
   height: var(--rs-space-4);
   color: var(--rs-color-foreground-base-secondary);
   transform: rotate(-90deg);
-  transition: transform 0.2s ease;
+  transition: transform var(--rs-duration-normal) var(--rs-ease-out);
   flex-shrink: 0;
 }
 
@@ -319,7 +331,7 @@
   padding: var(--rs-space-2) var(--rs-space-3);
   color: var(--rs-color-foreground-base-secondary);
   opacity: 0;
-  transition: opacity 0.2s ease;
+  transition: opacity var(--rs-duration-normal) var(--rs-ease-out);
 }
 
 .nav-group-header:hover .nav-group-trailing-icon {
@@ -340,7 +352,6 @@
 .nav-group-panel {
   height: var(--accordion-panel-height);
   overflow: hidden;
-  transition: height 0.2s ease;
 }
 
 .nav-group-panel[data-starting-style],
@@ -381,11 +392,27 @@
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  .root,
-  .nav-item,
-  .nav-text,
-  .resizeHandle,
-  .nav-group-panel {
+  .root {
     transition: width 0.2s ease;
+  }
+
+  .nav-group-panel {
+    transition:
+      width 0.2s ease,
+      height 0.2s ease;
+  }
+
+  .nav-text {
+    transition:
+      max-width var(--rs-duration-normal) var(--rs-ease-out),
+      opacity var(--rs-duration-normal) var(--rs-ease-out),
+      visibility var(--rs-duration-normal) var(--rs-ease-out);
+  }
+
+  .root [data-collapse-hidden] {
+    transition:
+      max-width 0.2s ease,
+      opacity 0.2s ease,
+      visibility 0.2s ease;
   }
 }

--- a/packages/raystack/components/sidebar/sidebar.module.css
+++ b/packages/raystack/components/sidebar/sidebar.module.css
@@ -57,10 +57,6 @@
   align-items: flex-start;
 }
 
-.root[data-closed] .main {
-  align-items: flex-start;
-}
-
 .root [data-collapse-hidden] {
   /* Cap width so the collapse animates to 0; 240px = the sidebar's open width,
      so wider consumer content is already clipped by the sidebar itself. */
@@ -101,10 +97,6 @@
   border: 0;
   background: transparent;
   text-align: left;
-}
-
-.root[data-closed] .nav-item {
-  justify-content: flex-start;
 }
 
 .nav-item:hover {
@@ -259,10 +251,6 @@
   margin-top: var(--rs-space-4);
 }
 
-.root[data-closed] .nav-group {
-  align-items: flex-start;
-}
-
 .nav-group-header {
   display: flex;
   height: var(--rs-space-7);
@@ -316,7 +304,6 @@
   height: var(--rs-space-4);
   color: var(--rs-color-foreground-base-secondary);
   transform: rotate(-90deg);
-  transition: transform var(--rs-duration-normal) var(--rs-ease-out);
   flex-shrink: 0;
 }
 
@@ -393,13 +380,15 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .root {
-    transition: width 0.2s ease;
+    transition: width var(--rs-duration-normal) var(--rs-ease-out);
+  }
+
+  .nav-group-chevron {
+    transition: transform var(--rs-duration-normal) var(--rs-ease-out);
   }
 
   .nav-group-panel {
-    transition:
-      width 0.2s ease,
-      height 0.2s ease;
+    transition: height var(--rs-duration-normal) var(--rs-ease-out);
   }
 
   .nav-text {
@@ -411,8 +400,8 @@
 
   .root [data-collapse-hidden] {
     transition:
-      max-width 0.2s ease,
-      opacity 0.2s ease,
-      visibility 0.2s ease;
+      max-width var(--rs-duration-normal) var(--rs-ease-out),
+      opacity var(--rs-duration-normal) var(--rs-ease-out),
+      visibility var(--rs-duration-normal) var(--rs-ease-out);
   }
 }

--- a/packages/raystack/components/skeleton/skeleton.module.css
+++ b/packages/raystack/components/skeleton/skeleton.module.css
@@ -37,6 +37,6 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .animate::after {
-    animation: shimmer var(--skeleton-duration) infinite;
+    animation: shimmer var(--skeleton-duration) linear infinite;
   }
 }

--- a/packages/raystack/components/slider/slider.module.css
+++ b/packages/raystack/components/slider/slider.module.css
@@ -49,12 +49,13 @@
   outline: none;
 }
 
-.thumb:focus-visible {
+.thumb :focus-visible {
   outline: none;
 }
 
-.thumb:hover {
-  border-color: var(--rs-color-border-accent-emphasis-hover);
+.thumb:has(:focus-visible) .thumbLarge,
+.thumb:has(:focus-visible) .thumbSmall {
+  outline: var(--rs-focus-ring);
 }
 
 .thumbLarge {
@@ -90,6 +91,23 @@
 .thumb:hover .thumbLarge,
 .thumb:hover .thumbSmall {
   background-color: var(--rs-color-background-base-secondary);
+}
+
+/* Grabbing: the thumb grows slightly and lifts. Scale lives on the child
+   so the thumb's track position (set inline by Base UI) is never animated. */
+.thumb:active .thumbLarge,
+.thumb:active .thumbSmall {
+  transform: scale(1.08);
+  box-shadow: var(--rs-shadow-lifted);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .thumbLarge,
+  .thumbSmall {
+    transition:
+      transform var(--rs-duration-press) var(--rs-ease-out),
+      box-shadow var(--rs-duration-press) var(--rs-ease-out);
+  }
 }
 
 .label {

--- a/packages/raystack/components/spinner/spinner.module.css
+++ b/packages/raystack/components/spinner/spinner.module.css
@@ -16,41 +16,49 @@
 .pole:nth-child(1) {
   transform: rotate(0deg);
   animation-delay: 0s;
+  opacity: 0.8;
 }
 
 .pole:nth-child(2) {
   transform: rotate(-45deg);
-  animation-delay: -0.15s;
+  animation-delay: -0.1125s;
+  opacity: 0.7;
 }
 
 .pole:nth-child(3) {
   transform: rotate(-90deg);
-  animation-delay: -0.3s;
+  animation-delay: -0.225s;
+  opacity: 0.6;
 }
 
 .pole:nth-child(4) {
   transform: rotate(-135deg);
-  animation-delay: -0.45s;
+  animation-delay: -0.3375s;
+  opacity: 0.5;
 }
 
 .pole:nth-child(5) {
   transform: rotate(-180deg);
-  animation-delay: -0.6s;
+  animation-delay: -0.45s;
+  opacity: 0.4;
 }
 
 .pole:nth-child(6) {
   transform: rotate(-225deg);
-  animation-delay: -0.75s;
+  animation-delay: -0.5625s;
+  opacity: 0.3;
 }
 
 .pole:nth-child(7) {
   transform: rotate(-270deg);
-  animation-delay: -0.9s;
+  animation-delay: -0.675s;
+  opacity: 0.2;
 }
 
 .pole:nth-child(8) {
   transform: rotate(-315deg);
-  animation-delay: -1.05s;
+  animation-delay: -0.7875s;
+  opacity: 0.1;
 }
 
 @keyframes spin {
@@ -90,7 +98,7 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .pole {
-    animation: spin 1.2s linear infinite;
+    animation: spin 0.9s linear infinite;
   }
 }
 

--- a/packages/raystack/components/switch/switch.module.css
+++ b/packages/raystack/components/switch/switch.module.css
@@ -9,6 +9,16 @@
   cursor: pointer;
   background: var(--rs-color-background-neutral-secondary);
   border-radius: var(--rs-radius-full);
+  transition: background-color var(--rs-duration-normal) var(--rs-ease-out);
+}
+
+.switch:focus-visible {
+  outline: var(--rs-focus-ring);
+}
+
+/* Checked = accent track: offset the ring so it clears it. */
+.switch[data-checked]:focus-visible {
+  outline-offset: var(--rs-focus-ring-offset-accent);
 }
 
 .switch.large {
@@ -55,7 +65,7 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .thumb {
-    transition: transform 200ms ease-in-out;
+    transition: transform var(--rs-duration-normal) var(--rs-ease-in-out);
   }
 }
 
@@ -72,4 +82,21 @@
 /* Small switch thumb positioning */
 .switch.small[data-checked] .thumb {
   transform: translateX(var(--rs-space-4));
+}
+
+/* Pressed: the thumb stretches toward the track center (iOS behavior).
+   transform-origin only affects the scale; the translateX values must
+   exactly mirror the resting rules above. */
+.switch:active:not([data-disabled]) .thumb {
+  transform: translateX(var(--rs-space-1)) scaleX(1.15);
+  transform-origin: left center;
+}
+
+.switch[data-checked]:active:not([data-disabled]) .thumb {
+  transform: translateX(var(--rs-space-5)) scaleX(1.15);
+  transform-origin: right center;
+}
+
+.switch.small[data-checked]:active:not([data-disabled]) .thumb {
+  transform: translateX(var(--rs-space-4)) scaleX(1.15);
 }

--- a/packages/raystack/components/table/table.module.css
+++ b/packages/raystack/components/table/table.module.css
@@ -6,6 +6,8 @@
   overflow: visible;
   color: var(--rs-color-foreground-base-primary);
   border-collapse: collapse;
+  /* Align digits across rows/columns for numeric data. */
+  font-variant-numeric: tabular-nums;
 }
 
 .header {
@@ -65,4 +67,33 @@
   font-weight: var(--rs-font-weight-medium);
   line-height: var(--rs-line-height-small);
   letter-spacing: var(--rs-letter-spacing-small);
+}
+
+/* Row state hooks. `.row` is applied by Table.Row; visuals only kick in when
+   the consumer sets data-state="selected" or the `interactive` prop. Cells
+   inherit so the row color shows through the opaque .cell background. */
+.row {
+  background: var(--rs-color-background-base-primary);
+}
+
+.row > .cell {
+  background: inherit;
+}
+
+.row-interactive {
+  cursor: pointer;
+}
+
+.row-interactive:hover {
+  background: var(--rs-color-background-base-primary-hover);
+}
+
+.row-interactive:active {
+  background: var(--rs-color-background-neutral-secondary);
+}
+
+.row[data-state="selected"],
+.row[data-state="selected"]:hover,
+.row[data-state="selected"]:active {
+  background: var(--rs-color-background-accent-primary);
 }

--- a/packages/raystack/components/table/table.tsx
+++ b/packages/raystack/components/table/table.tsx
@@ -25,8 +25,19 @@ function TableBody({ ...props }: ComponentProps<'tbody'>) {
 }
 TableBody.displayName = 'Table.Body';
 
-function TableRow({ ...props }: ComponentProps<'tr'>) {
-  return <tr {...props} />;
+const row = cva(styles['row'], {
+  variants: {
+    interactive: {
+      true: styles['row-interactive']
+    }
+  }
+});
+function TableRow({
+  className,
+  interactive,
+  ...props
+}: ComponentProps<'tr'> & VariantProps<typeof row>) {
+  return <tr {...props} className={row({ interactive, className })} />;
 }
 TableRow.displayName = 'Table.Row';
 

--- a/packages/raystack/components/tabs/tabs.module.css
+++ b/packages/raystack/components/tabs/tabs.module.css
@@ -50,7 +50,7 @@
   color: var(--rs-color-foreground-base-secondary);
   cursor: pointer;
   border-radius: var(--rs-radius-2);
-  transition: color 0.2s ease;
+  transition: color var(--rs-duration-normal) var(--rs-ease-out);
   flex: 1;
   text-align: center;
   text-overflow: ellipsis;
@@ -79,6 +79,24 @@
   pointer-events: none;
 }
 
+.trigger:focus-visible {
+  outline: var(--rs-focus-ring);
+}
+
+/* Pressed: the label dips inward. No background box on any variant, so the
+   press never competes with the indicator chip that glides in on release. */
+.trigger:active:not([data-disabled]):not([data-active]) {
+  transform: scale(var(--rs-scale-pressed));
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .trigger {
+    transition:
+      color var(--rs-duration-normal) var(--rs-ease-out),
+      transform var(--rs-duration-press) var(--rs-ease-out);
+  }
+}
+
 .trigger-icon {
   display: inline-flex;
   width: var(--rs-space-5);
@@ -94,8 +112,9 @@
   background-color: var(--rs-color-background-base-primary);
   border-radius: var(--rs-radius-2);
   box-shadow: var(--rs-shadow-feather);
-  top: var(--active-tab-top, 0);
-  left: var(--active-tab-left, 0);
+  top: 0;
+  left: 0;
+  translate: var(--active-tab-left, 0) var(--active-tab-top, 0);
   width: var(--active-tab-width, 0);
   height: var(--active-tab-height, 0);
   z-index: 0;
@@ -104,10 +123,9 @@
 @media (prefers-reduced-motion: no-preference) {
   .indicator {
     transition:
-      top 0.25s cubic-bezier(0.4, 0, 0.2, 1),
-      left 0.25s cubic-bezier(0.4, 0, 0.2, 1),
-      width 0.25s cubic-bezier(0.4, 0, 0.2, 1),
-      height 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+      translate var(--rs-duration-moderate) var(--rs-ease-in-out),
+      width var(--rs-duration-moderate) var(--rs-ease-in-out),
+      height var(--rs-duration-moderate) var(--rs-ease-in-out);
   }
 }
 
@@ -127,9 +145,22 @@
   box-shadow: none;
 }
 
-.variant-standalone .indicator,
+/* Standalone: the indicator is the active chip fill, gliding between tabs. */
+.variant-standalone .indicator {
+  background-color: var(--rs-color-background-neutral-primary);
+  border: 0.5px solid var(--rs-color-border-base-secondary);
+  box-sizing: border-box;
+  box-shadow: none;
+}
+
+/* Plain: the indicator is a 1px underline sliding along the bottom edge. */
 .variant-plain .indicator {
-  display: none;
+  height: 1px;
+  translate: var(--active-tab-left, 0px)
+    calc(var(--active-tab-top, 0px) + var(--active-tab-height, 0px) - 1px);
+  background-color: var(--rs-color-border-base-emphasis);
+  border-radius: 0;
+  box-shadow: none;
 }
 
 /* Standalone variant: chip-like tabs with independent borders */
@@ -140,8 +171,8 @@
 }
 
 .variant-standalone .trigger[data-active] {
-  background: var(--rs-color-background-neutral-primary);
-  border: 0.5px solid var(--rs-color-border-base-secondary);
+  background: transparent;
+  border-color: transparent;
 }
 
 /* Plain variant: text-like tabs with larger gaps */
@@ -159,8 +190,4 @@
   border-radius: 0;
   /* Reserve underline space to prevent layout/typography shifting when active */
   border-bottom: 1px solid transparent;
-}
-
-.variant-plain .trigger[data-active] {
-  border-bottom-color: var(--rs-color-border-base-emphasis);
 }

--- a/packages/raystack/components/tabs/tabs.module.css
+++ b/packages/raystack/components/tabs/tabs.module.css
@@ -167,21 +167,17 @@
 .variant-standalone .trigger {
   /* Chip look: no outer padding and visible border */
   border: 0.5px solid var(--rs-color-border-base-primary);
-  background: transparent;
 }
 
 .variant-standalone .trigger[data-active] {
-  background: transparent;
   border-color: transparent;
 }
 
 /* Plain variant: text-like tabs with larger gaps */
 .variant-plain .list {
   gap: var(--rs-space-6);
-  background-color: transparent;
   padding: 0;
   border-radius: 0;
-  box-shadow: none;
   justify-content: center;
 }
 

--- a/packages/raystack/components/text-area/text-area.module.css
+++ b/packages/raystack/components/text-area/text-area.module.css
@@ -16,13 +16,8 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .textarea {
-    transition: all 0.2s ease;
+    transition: var(--rs-transition-interactive);
   }
-}
-
-.textarea:hover {
-  border-color: var(--rs-color-border-base-focus);
-  background: var(--rs-color-background-base-primary-hover);
 }
 
 .textarea:focus:not(:disabled) {
@@ -53,10 +48,6 @@
   border-color: var(--rs-color-border-danger-emphasis);
 }
 
-.textarea[data-invalid]:hover {
-  border-color: var(--rs-color-border-danger-emphasis-hover);
-}
-
 .textarea[data-invalid]:focus {
   border-color: var(--rs-color-border-danger-emphasis-hover);
 }
@@ -79,11 +70,11 @@
   border-color: transparent;
 }
 
-.variant-borderless:hover {
-  border-color: transparent;
-}
-
 .variant-borderless:focus:not(:disabled) {
   border-color: transparent;
   outline: none;
+}
+
+.variant-borderless:focus-visible:not(:disabled) {
+  box-shadow: var(--rs-focus-ring-shadow);
 }

--- a/packages/raystack/components/text-area/text-area.module.css
+++ b/packages/raystack/components/text-area/text-area.module.css
@@ -34,8 +34,7 @@
 }
 
 .textarea:disabled,
-.textarea[data-disabled],
-.disabled {
+.textarea[data-disabled] {
   opacity: 0.5;
   cursor: not-allowed;
 }
@@ -62,10 +61,6 @@
 }
 
 /* Variant styles */
-.variant-default {
-  border: 0.5px solid var(--rs-color-border-base-tertiary);
-}
-
 .variant-borderless {
   border-color: transparent;
 }

--- a/packages/raystack/components/text/__tests__/text.test.tsx
+++ b/packages/raystack/components/text/__tests__/text.test.tsx
@@ -169,7 +169,7 @@ describe('Text', () => {
       expect(container.firstChild).toHaveClass(styles['text-strike-through']);
       expect(container.firstChild).toHaveClass(styles['text-underline']);
       expect(container.firstChild).toHaveClass(
-        styles['text-italic-strike-through']
+        styles['text-underline-strike-through']
       );
     });
   });

--- a/packages/raystack/components/text/text.module.css
+++ b/packages/raystack/components/text/text.module.css
@@ -138,7 +138,7 @@
   text-decoration-line: line-through;
 }
 
-.text-italic-strike-through {
+.text-underline-strike-through {
   text-decoration-line: underline line-through;
 }
 

--- a/packages/raystack/components/text/text.tsx
+++ b/packages/raystack/components/text/text.tsx
@@ -62,7 +62,7 @@ export const textVariants = cva(styles.text, {
     {
       strikeThrough: true,
       underline: true,
-      className: styles['text-italic-strike-through']
+      className: styles['text-underline-strike-through']
     }
   ]
 });

--- a/packages/raystack/components/theme-provider/__tests__/theme.test.tsx
+++ b/packages/raystack/components/theme-provider/__tests__/theme.test.tsx
@@ -820,16 +820,16 @@ describe('ThemeSwitcher', () => {
       expect(icon).toBeInTheDocument();
     });
 
-    it('applies custom size', () => {
+    it('applies custom size to the button box', () => {
       render(
         <Theme defaultTheme='light' enableSystem={false}>
           <ThemeSwitcher size={40} />
         </Theme>
       );
 
-      const icon = document.querySelector('svg');
-      expect(icon).toHaveAttribute('width', '40');
-      expect(icon).toHaveAttribute('height', '40');
+      // size drives the button box; the icon fills it via IconButton's CSS.
+      const button = document.querySelector('button');
+      expect(button).toHaveStyle({ width: '40px', height: '40px' });
     });
   });
 

--- a/packages/raystack/components/theme-provider/__tests__/theme.test.tsx
+++ b/packages/raystack/components/theme-provider/__tests__/theme.test.tsx
@@ -5,6 +5,7 @@ import {
   screen,
   waitFor
 } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ThemeSwitcher } from '../switcher';
@@ -856,6 +857,45 @@ describe('ThemeSwitcher', () => {
       fireEvent.click(icon!);
 
       expect(localStorageMock.setItem).toHaveBeenCalledWith('theme', 'light');
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('renders a button with an accessible name', () => {
+      render(
+        <Theme defaultTheme='light' enableSystem={false}>
+          <ThemeSwitcher />
+        </Theme>
+      );
+
+      expect(
+        screen.getByRole('button', { name: /switch to dark theme/i })
+      ).toBeInTheDocument();
+    });
+
+    it('toggles the theme with Enter and Space', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Theme defaultTheme='light' enableSystem={false}>
+          <ThemeSwitcher />
+        </Theme>
+      );
+
+      const button = screen.getByRole('button', { name: /theme/i });
+      button.focus();
+
+      await user.keyboard('{Enter}');
+      expect(localStorageMock.setItem).toHaveBeenLastCalledWith(
+        'theme',
+        'dark'
+      );
+
+      await user.keyboard(' ');
+      expect(localStorageMock.setItem).toHaveBeenLastCalledWith(
+        'theme',
+        'light'
+      );
     });
   });
 });

--- a/packages/raystack/components/theme-provider/switcher.tsx
+++ b/packages/raystack/components/theme-provider/switcher.tsx
@@ -27,11 +27,9 @@ export function ThemeSwitcher({ size = 30, ...props }: Props) {
       style={{ width: size, height: size }}
       {...props}
     >
-      {isDark ? (
-        <SunIcon width={size} height={size} />
-      ) : (
-        <MoonIcon width={size} height={size} />
-      )}
+      {/* size drives the button box; IconButton's CSS sizes the icon to fill
+          the padded content area, so the icons don't set their own dimensions. */}
+      {isDark ? <SunIcon /> : <MoonIcon />}
     </IconButton>
   );
 }

--- a/packages/raystack/components/theme-provider/switcher.tsx
+++ b/packages/raystack/components/theme-provider/switcher.tsx
@@ -2,7 +2,7 @@
 
 import { MoonIcon, SunIcon } from '@radix-ui/react-icons';
 
-import { Box } from '../box';
+import { IconButton } from '../icon-button';
 import { useTheme } from './theme';
 
 enum Theme {
@@ -11,19 +11,29 @@ enum Theme {
 }
 
 type Props = { size?: number };
+
 export function ThemeSwitcher({ size = 30, ...props }: Props) {
   const { theme, setTheme } = useTheme();
+  const isDark = theme === Theme.DARK;
+
   const onClickHandler = () => {
-    setTheme(theme === Theme.DARK ? Theme.LIGHT : Theme.DARK);
+    setTheme(isDark ? Theme.LIGHT : Theme.DARK);
   };
 
   return (
-    <Box {...props}>
-      {theme === Theme.DARK ? (
-        <SunIcon width={size} height={size} onClick={onClickHandler} />
+    <IconButton
+      aria-label={isDark ? 'Switch to light theme' : 'Switch to dark theme'}
+      onClick={onClickHandler}
+      style={{ width: size, height: size }}
+      {...props}
+    >
+      {isDark ? (
+        <SunIcon width={size} height={size} />
       ) : (
-        <MoonIcon width={size} height={size} onClick={onClickHandler} />
+        <MoonIcon width={size} height={size} />
       )}
-    </Box>
+    </IconButton>
   );
 }
+
+ThemeSwitcher.displayName = 'ThemeSwitcher';

--- a/packages/raystack/components/toast/toast.module.css
+++ b/packages/raystack/components/toast/toast.module.css
@@ -66,7 +66,7 @@
   cursor: default;
   z-index: calc(1000 - var(--toast-index));
 
-  transition: opacity 500ms;
+  transition: opacity var(--rs-duration-slow) var(--rs-ease-out);
 }
 
 /* ===== Vertical position: bottom ===== */
@@ -167,6 +167,10 @@
   transform: translateY(calc(-100% - var(--rs-space-7)));
 }
 
+.root[data-starting-style] {
+  opacity: 0;
+}
+
 /* ===== Limited state ===== */
 .root[data-limited] {
   opacity: 0;
@@ -207,7 +211,7 @@
 
 /* ===== Content (stacking visibility) ===== */
 .content {
-  transition: opacity 250ms;
+  transition: opacity var(--rs-duration-moderate) var(--rs-ease-out);
 }
 
 .content[data-behind] {
@@ -294,8 +298,13 @@
 @media (prefers-reduced-motion: no-preference) {
   .root {
     transition:
-      transform 500ms cubic-bezier(0.22, 1, 0.36, 1),
-      opacity 500ms,
-      height 150ms;
+      transform var(--rs-duration-slow) var(--rs-ease-out),
+      opacity var(--rs-duration-slow) var(--rs-ease-out),
+      height var(--rs-duration-fast) var(--rs-ease-out);
   }
+}
+
+/* Track the finger 1:1 while dragging; transitions resume on release. */
+.root[data-swiping] {
+  transition: none;
 }

--- a/packages/raystack/components/toggle/toggle.module.css
+++ b/packages/raystack/components/toggle/toggle.module.css
@@ -89,10 +89,11 @@
   outline: var(--rs-focus-ring);
 }
 
-/* Inside a group the container clips overflow and items sit 1px apart:
-   keep the ring fully inside the item. */
+/* Inside a group the container clips overflow and items sit 1px apart, and the
+   toggle has its own border: hug it with the ring so it stays inside the item
+   and doesn't read as two separate lines. */
 .group .toggle:focus-visible {
-  outline-offset: var(--rs-focus-ring-offset-inset);
+  outline-offset: var(--rs-focus-ring-offset-inset-border);
 }
 
 .size-1 {

--- a/packages/raystack/components/toggle/toggle.module.css
+++ b/packages/raystack/components/toggle/toggle.module.css
@@ -6,7 +6,7 @@
   color: var(--rs-color-foreground-base-secondary);
   cursor: pointer;
   padding: var(--rs-space-1);
-  transition: color 0.2s ease;
+  transition: color var(--rs-duration-normal) var(--rs-ease-out);
   background-color: var(--rs-color-background-base-secondary);
   border: 0.5px solid var(--rs-color-border-base-primary);
   border-radius: var(--rs-radius-1);
@@ -24,19 +24,75 @@
   height: 100%;
 }
 
-.toggle:hover,
+@media (prefers-reduced-motion: no-preference) {
+  .toggleContent {
+    transition:
+      background-color var(--rs-duration-fast) var(--rs-ease-out),
+      box-shadow var(--rs-duration-fast) var(--rs-ease-out);
+  }
+
+  .group .toggle {
+    /* color entry matches .toggle's own transition (line 9) so both are
+       driven by the same token */
+    transition:
+      color var(--rs-duration-normal) var(--rs-ease-out),
+      background-color var(--rs-duration-fast) var(--rs-ease-out),
+      box-shadow var(--rs-duration-fast) var(--rs-ease-out);
+  }
+}
+
+.toggle:hover {
+  color: var(--rs-color-foreground-base-primary);
+}
+.toggle:hover .toggleContent {
+  background-color: var(--rs-color-background-base-primary-hover);
+}
+
 .toggle[data-pressed] {
   color: var(--rs-color-foreground-base-primary);
 }
-.toggle:hover .toggleContent,
 .toggle[data-pressed] .toggleContent {
-  background-color: var(--rs-color-background-base-primary-hover);
+  background-color: var(--rs-color-background-neutral-secondary);
+  box-shadow: var(--rs-shadow-inset);
+}
+.toggle[data-pressed]:hover .toggleContent {
+  background-color: var(--rs-color-background-neutral-secondary-hover);
 }
 
 .toggle[data-disabled] {
   opacity: 0.5;
-  pointer-events: none;
+  pointer-events: initial;
   cursor: not-allowed;
+}
+
+.toggle[data-disabled]:not([data-pressed]):hover {
+  color: var(--rs-color-foreground-base-secondary);
+}
+
+.toggle[data-disabled]:not([data-pressed]):hover .toggleContent {
+  background-color: transparent;
+  box-shadow: none;
+}
+
+/* A disabled toggle must not react to hover even when it is on (pressed):
+   hold the pressed resting fill instead of the hover-deepened one. */
+.toggle[data-disabled][data-pressed]:hover .toggleContent {
+  background-color: var(--rs-color-background-neutral-secondary);
+}
+
+.group .toggle[data-disabled]:not([data-pressed]):hover {
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.toggle:focus-visible {
+  outline: var(--rs-focus-ring);
+}
+
+/* Inside a group the container clips overflow and items sit 1px apart:
+   keep the ring fully inside the item. */
+.group .toggle:focus-visible {
+  outline-offset: var(--rs-focus-ring-offset-inset);
 }
 
 .size-1 {
@@ -79,13 +135,21 @@
 }
 
 .group .toggle:hover {
-  background-color: var(--rs-color-background-base-primary);
-  box-shadow: var(--rs-shadow-inset);
+  background-color: var(--rs-color-background-base-primary-hover);
 }
 
 .group .toggle[data-pressed] {
   background-color: var(--rs-color-background-base-primary);
   box-shadow: var(--rs-shadow-inset);
+}
+
+/* In a group the container carries the pressed fill, so keep the inner content
+   transparent — otherwise the standalone content fill paints a second, darker
+   box inside the 2px padding (a halo) and doubles the inset shadow. */
+.group .toggle[data-pressed] .toggleContent,
+.group .toggle[data-pressed]:hover .toggleContent {
+  background-color: transparent;
+  box-shadow: none;
 }
 
 /* Vertical group */
@@ -95,6 +159,6 @@
 
 .group[data-disabled] {
   opacity: 0.5;
-  pointer-events: none;
+  pointer-events: initial;
   cursor: not-allowed;
 }

--- a/packages/raystack/components/toolbar/toolbar.module.css
+++ b/packages/raystack/components/toolbar/toolbar.module.css
@@ -37,5 +37,5 @@
 }
 .group {
   padding: 0;
-  background-color: none;
+  background-color: transparent;
 }

--- a/packages/raystack/components/tooltip/tooltip.module.css
+++ b/packages/raystack/components/tooltip/tooltip.module.css
@@ -9,7 +9,7 @@
   border-radius: var(--rs-radius-2);
   background: var(--rs-color-background-base-primary);
   border: 0.5px solid var(--rs-color-border-base-primary);
-  box-shadow: var(--rs-shadow-lifted);
+  box-shadow: var(--rs-shadow-soft);
   color: var(--rs-color-foreground-base-primary);
   font-size: var(--rs-font-size-mini);
   font-weight: var(--rs-font-weight-medium);

--- a/packages/raystack/components/tooltip/tooltip.module.css
+++ b/packages/raystack/components/tooltip/tooltip.module.css
@@ -1,7 +1,3 @@
-.trigger {
-  width: fit-content;
-  display: flex;
-}
 .positioner {
   z-index: var(--rs-z-index-portal);
 }

--- a/packages/raystack/components/tooltip/tooltip.module.css
+++ b/packages/raystack/components/tooltip/tooltip.module.css
@@ -21,7 +21,7 @@
   letter-spacing: var(--rs-letter-spacing-mini);
   width: fit-content;
   max-width: 400px;
-  transform-origin: var(--transform-origin);
+  transition: opacity var(--rs-duration-fast) var(--rs-ease-out);
 }
 
 .arrow svg {
@@ -55,106 +55,68 @@
   transform: translateY(-50%) translateX(-100%) rotate(90deg);
 }
 
-@keyframes fade {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-@keyframes slideUpAndFade {
-  from {
-    opacity: 0;
-    transform: translateY(var(--rs-space-1));
-  }
-}
-@keyframes slideRightAndFade {
-  from {
-    opacity: 0;
-    transform: translateX(calc(-1 * var(--rs-space-1)));
-  }
+.content[data-starting-style],
+.content[data-ending-style] {
+  opacity: 0;
 }
 
-@keyframes slideDownAndFade {
-  from {
-    opacity: 0;
+/* Base UI sets data-instant (focus/click/dismiss and grouped-trigger moves):
+   skip the animation but keep the transition machinery. */
+.content[data-instant] {
+  transition-duration: 0ms;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .content {
+    transition:
+      opacity var(--rs-duration-fast) var(--rs-ease-out),
+      transform var(--rs-duration-fast) var(--rs-ease-out);
+  }
+
+  /* Per-side directional offset — same vectors as the old keyframes */
+  .content[data-side="top"][data-starting-style],
+  .content[data-side="top"][data-ending-style] {
     transform: translateY(calc(-1 * var(--rs-space-1)));
   }
-}
 
-@keyframes slideLeftAndFade {
-  from {
-    opacity: 0;
+  .content[data-side="right"][data-starting-style],
+  .content[data-side="right"][data-ending-style] {
     transform: translateX(var(--rs-space-1));
   }
-}
 
-@keyframes slideDownRightAndFade {
-  from {
-    opacity: 0;
+  .content[data-side="bottom"][data-starting-style],
+  .content[data-side="bottom"][data-ending-style] {
+    transform: translateY(var(--rs-space-1));
+  }
+
+  .content[data-side="left"][data-starting-style],
+  .content[data-side="left"][data-ending-style] {
+    transform: translateX(calc(-1 * var(--rs-space-1)));
+  }
+
+  /* Aligned variants get a diagonal offset — same vectors as before.
+     Higher specificity (0,4,0) than the side rules (0,3,0), so they win
+     when data-align is start/end. */
+  .content[data-side="top"][data-align="start"][data-starting-style],
+  .content[data-side="top"][data-align="start"][data-ending-style] {
     transform: translate(
       calc(-1 * var(--rs-space-1)),
       calc(-1 * var(--rs-space-1))
     );
   }
-}
 
-@keyframes slideDownLeftAndFade {
-  from {
-    opacity: 0;
+  .content[data-side="top"][data-align="end"][data-starting-style],
+  .content[data-side="top"][data-align="end"][data-ending-style] {
     transform: translate(var(--rs-space-1), calc(-1 * var(--rs-space-1)));
   }
-}
 
-@keyframes slideUpRightAndFade {
-  from {
-    opacity: 0;
+  .content[data-side="bottom"][data-align="start"][data-starting-style],
+  .content[data-side="bottom"][data-align="start"][data-ending-style] {
     transform: translate(calc(-1 * var(--rs-space-1)), var(--rs-space-1));
   }
-}
 
-@keyframes slideUpLeftAndFade {
-  from {
-    opacity: 0;
+  .content[data-side="bottom"][data-align="end"][data-starting-style],
+  .content[data-side="bottom"][data-align="end"][data-ending-style] {
     transform: translate(var(--rs-space-1), var(--rs-space-1));
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .content {
-    animation-duration: 400ms;
-  }
-
-  .content[data-open][data-side="top"]:not([data-instant]) {
-    animation-name: slideDownAndFade;
-  }
-
-  .content[data-open][data-side="right"]:not([data-instant]) {
-    animation-name: slideLeftAndFade;
-  }
-
-  .content[data-open][data-side="bottom"]:not([data-instant]) {
-    animation-name: slideUpAndFade;
-  }
-
-  .content[data-open][data-side="left"]:not([data-instant]) {
-    animation-name: slideRightAndFade;
-  }
-
-  .content[data-side="top"][data-align="start"]:not([data-instant]) {
-    animation-name: slideDownRightAndFade;
-  }
-
-  .content[data-side="top"][data-align="end"]:not([data-instant]) {
-    animation-name: slideDownLeftAndFade;
-  }
-
-  .content[data-side="bottom"][data-align="start"]:not([data-instant]) {
-    animation-name: slideUpRightAndFade;
-  }
-
-  .content[data-side="bottom"][data-align="end"]:not([data-instant]) {
-    animation-name: slideUpLeftAndFade;
   }
 }

--- a/packages/raystack/components/tour-beta/tour.module.css
+++ b/packages/raystack/components/tour-beta/tour.module.css
@@ -10,7 +10,7 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .overlay {
-    animation: tour-fade-in 250ms ease;
+    animation: tour-fade-in var(--rs-duration-moderate) var(--rs-ease-out);
   }
 }
 
@@ -31,11 +31,11 @@
 @media (prefers-reduced-motion: no-preference) {
   .spotlight {
     transition:
-      left 300ms cubic-bezier(0.22, 1, 0.36, 1),
-      top 300ms cubic-bezier(0.22, 1, 0.36, 1),
-      width 300ms cubic-bezier(0.22, 1, 0.36, 1),
-      height 300ms cubic-bezier(0.22, 1, 0.36, 1),
-      border-radius 300ms cubic-bezier(0.22, 1, 0.36, 1);
+      left 300ms var(--rs-ease-out),
+      top 300ms var(--rs-ease-out),
+      width 300ms var(--rs-ease-out),
+      height 300ms var(--rs-ease-out),
+      border-radius 300ms var(--rs-ease-out);
   }
 }
 
@@ -52,7 +52,7 @@
    otherwise the first open would animate in from the viewport origin. */
 @media (prefers-reduced-motion: no-preference) {
   .positioner:has(.popup:not([data-starting-style])) {
-    transition: transform 350ms cubic-bezier(0.22, 1, 0.36, 1);
+    transition: transform var(--rs-duration-slow) var(--rs-ease-out);
   }
 }
 
@@ -72,15 +72,21 @@
   line-height: var(--rs-line-height-small);
   letter-spacing: var(--rs-letter-spacing-small);
   transform-origin: var(--transform-origin);
-  transition:
-    opacity 200ms ease,
-    scale 200ms ease;
+  transition: opacity var(--rs-duration-normal) var(--rs-ease-out);
 }
 
 .popup[data-starting-style],
 .popup[data-ending-style] {
   opacity: 0;
   scale: 0.96;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .popup {
+    transition:
+      opacity var(--rs-duration-normal) var(--rs-ease-out),
+      scale var(--rs-duration-normal) var(--rs-ease-out);
+  }
 }
 
 .stepContent {
@@ -91,7 +97,7 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .stepContent {
-    animation: tour-step-in 250ms cubic-bezier(0.22, 1, 0.36, 1);
+    animation: tour-step-in var(--rs-duration-moderate) var(--rs-ease-out);
   }
 }
 

--- a/packages/raystack/components/tour-beta/tour.module.css
+++ b/packages/raystack/components/tour-beta/tour.module.css
@@ -72,7 +72,6 @@
   line-height: var(--rs-line-height-small);
   letter-spacing: var(--rs-letter-spacing-small);
   transform-origin: var(--transform-origin);
-  transition: opacity var(--rs-duration-normal) var(--rs-ease-out);
 }
 
 .popup[data-starting-style],

--- a/packages/raystack/components/tour/tour-root.tsx
+++ b/packages/raystack/components/tour/tour-root.tsx
@@ -26,8 +26,8 @@ import { usePrefersReducedMotion } from './use-prefers-reduced-motion';
 import { resolveTourTarget, useTourTarget } from './use-tour-target';
 import { rectsEqual } from './utils';
 
-// Must match the overlay's opacity transition in `tour.module.css`.
-const FADE_OUT_MS = 160;
+// Must match --rs-duration-fast — the .spotlightCover fade in tour.module.css.
+const FADE_OUT_MS = 150;
 
 const REVEAL_TIMEOUT_MS = 2000;
 

--- a/packages/raystack/components/tour/tour.module.css
+++ b/packages/raystack/components/tour/tour.module.css
@@ -98,7 +98,6 @@
 .popup[data-starting-style],
 .popup[data-ending-style] {
   opacity: 0;
-  scale: 0.96;
 }
 
 @media (prefers-reduced-motion: no-preference) {
@@ -107,12 +106,17 @@
       opacity var(--rs-duration-normal) var(--rs-ease-out),
       scale var(--rs-duration-normal) var(--rs-ease-out);
   }
+
+  .popup[data-starting-style],
+  .popup[data-ending-style] {
+    scale: 0.96;
+  }
 }
 
 /* Fade mode: the card is hidden until its target settles. Hiding is instant
    (transition: none) so the reposition and content swap between steps are not
    seen; revealing uses the .popup transition above for a soft fade-in in place. */
-.popup[data-transition="fade"][data-visible="false"] {
+.popup[data-visible="false"] {
   opacity: 0;
   scale: 0.98;
   transition: none;

--- a/packages/raystack/components/tour/tour.module.css
+++ b/packages/raystack/components/tour/tour.module.css
@@ -23,7 +23,7 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .overlay {
-    transition: opacity 200ms ease;
+    transition: opacity var(--rs-duration-normal) var(--rs-ease-out);
   }
 }
 
@@ -54,7 +54,7 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .spotlightCover {
-    transition: opacity 160ms ease;
+    transition: opacity var(--rs-duration-fast) var(--rs-ease-out);
   }
 }
 
@@ -72,7 +72,7 @@
    origin. `fade` mode repositions the card while it is hidden, so no glide. */
 @media (prefers-reduced-motion: no-preference) {
   .positioner[data-transition="move"]:has(.popup:not([data-starting-style])) {
-    transition: transform 460ms cubic-bezier(0.33, 0.7, 0, 1);
+    transition: transform var(--rs-duration-slow) var(--rs-ease-out);
   }
 }
 
@@ -92,15 +92,21 @@
   line-height: var(--rs-line-height-small);
   letter-spacing: var(--rs-letter-spacing-small);
   transform-origin: var(--transform-origin);
-  transition:
-    opacity 200ms ease,
-    scale 200ms ease;
+  transition: opacity var(--rs-duration-normal) var(--rs-ease-out);
 }
 
 .popup[data-starting-style],
 .popup[data-ending-style] {
   opacity: 0;
   scale: 0.96;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .popup {
+    transition:
+      opacity var(--rs-duration-normal) var(--rs-ease-out),
+      scale var(--rs-duration-normal) var(--rs-ease-out);
+  }
 }
 
 /* Fade mode: the card is hidden until its target settles. Hiding is instant
@@ -120,7 +126,7 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .stepContent {
-    animation: tour-step-in 250ms cubic-bezier(0.22, 1, 0.36, 1);
+    animation: tour-step-in var(--rs-duration-moderate) var(--rs-ease-out);
   }
 }
 

--- a/packages/raystack/package.json
+++ b/packages/raystack/package.json
@@ -97,8 +97,6 @@
     "dotenv": "^17.2.2",
     "identity-obj-proxy": "^3.0.0",
     "jsdom": "^26.1.0",
-    "np": "^8.0.4",
-    "npm": "^9.7.1",
     "parcel": "^2.9.2",
     "postcss": "^8.4.24",
     "postcss-import": "^16.1.0",

--- a/packages/raystack/styles/effects.css
+++ b/packages/raystack/styles/effects.css
@@ -37,12 +37,14 @@
 
   /* Pressed scale: a control shrinks slightly under the finger. Smaller
        targets need a larger delta to read, so there are two steps. */
-  --rs-scale-pressed: 0.97; /* buttons, tabs, larger controls */
-  --rs-scale-pressed-strong: 0.92; /* checkbox, radio, chip dismiss */
+  --rs-scale-pressed: 0.98; /* buttons, tabs, larger controls */
+  --rs-scale-pressed-strong: 0.94; /* checkbox, radio, chip dismiss */
 
   /* Focus ring: keyboard-focus indicator. The shadow variant is for
-       chromeless text-entry surfaces that have no border to ring. */
-  --rs-focus-ring: 0.5px solid var(--rs-color-border-accent-emphasis);
+       chromeless text-entry surfaces that have no border to ring. Accent by
+       default; a colored control (danger, success, …) overrides
+       `outline-color` in its own :focus-visible rule to match. */
+  --rs-focus-ring: 1px solid var(--rs-color-border-accent-emphasis);
   --rs-focus-ring-shadow: 0 0 0 1.5px var(--rs-color-border-accent-primary);
 
   /* Ring offset: rings sit flush (0) by default. A control adds one of these

--- a/packages/raystack/styles/effects.css
+++ b/packages/raystack/styles/effects.css
@@ -50,25 +50,21 @@
   /* Ring offset: rings sit flush (0) by default. A control adds one of these
        in its own :focus-visible rule when it needs to — accent-filled controls
        push the ring out so it clears the same-colour fill; controls in a
-       clipped container pull it in so the ring isn't cut off. */
+       clipped container pull it in so the ring isn't cut off. The -border
+       variant pulls in just 1px so the ring hugs a bordered control instead
+       of leaving a gap that reads as a double line. */
   --rs-focus-ring-offset-accent: 2px;
   --rs-focus-ring-offset-inset: -2px;
+  --rs-focus-ring-offset-inset-border: -1px;
 
   /* Motion */
   /* Example usage: transition: opacity var(--rs-duration-normal) var(--rs-ease-out); */
-  --rs-ease-out: cubic-bezier(
-    0.22,
-    1,
-    0.36,
-    1
-  ); /* entrances, exits, value changes */
-  --rs-ease-in-out: cubic-bezier(
-    0.77,
-    0,
-    0.175,
-    1
-  ); /* elements moving on screen */
-  --rs-ease-drawer: cubic-bezier(0.32, 0.72, 0, 1); /* iOS-like drawer slide */
+  /* entrances, exits, value changes */
+  --rs-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  /* elements moving on screen */
+  --rs-ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
+  /* iOS-like drawer slide */
+  --rs-ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
   --rs-duration-press: 100ms; /* pressed/active feedback */
   --rs-duration-fast: 150ms; /* tooltips, menus, small popups */
   --rs-duration-normal: 200ms; /* popovers, dialogs, switches */

--- a/packages/raystack/styles/effects.css
+++ b/packages/raystack/styles/effects.css
@@ -45,7 +45,9 @@
        default; a colored control (danger, success, …) overrides
        `outline-color` in its own :focus-visible rule to match. */
   --rs-focus-ring: 1px solid var(--rs-color-border-accent-emphasis);
-  --rs-focus-ring-shadow: 0 0 0 1.5px var(--rs-color-border-accent-primary);
+  /* Box-shadow form of the ring above, for borderless inputs with no border to
+     outline. Kept 1px + accent-emphasis so it matches the outline ring. */
+  --rs-focus-ring-shadow: 0 0 0 1px var(--rs-color-border-accent-emphasis);
 
   /* Ring offset: rings sit flush (0) by default. A control adds one of these
        in its own :focus-visible rule when it needs to — accent-filled controls

--- a/packages/raystack/styles/effects.css
+++ b/packages/raystack/styles/effects.css
@@ -1,4 +1,5 @@
-:root {
+:root,
+[data-theme="light"] {
   /* Shadows */
   /* Example usage: box-shadow: var(--rs-shadow-feather); */
   --rs-shadow-feather:
@@ -14,7 +15,9 @@
       0 0 0 / 0.04
     ), 0px 4px 30px 0px oklch(0 0 0 / 0.13); /* xl */
   --rs-shadow-inset: 0px 1px 1px 0px oklch(0 0 0 / 0.04) inset;
+}
 
+:root {
   /* Transitions */
   --rs-transition-interactive:
     background-color var(--rs-duration-normal) var(--rs-ease-out),
@@ -77,22 +80,6 @@
   --rs-blur-md: blur(1px);
   --rs-blur-lg: blur(2px);
   --rs-blur-xl: blur(4px);
-}
-
-[data-theme="light"] {
-  --rs-shadow-feather:
-    0px 1px 1px 0px oklch(0 0 0 / 0.06), 0px 4px 4px -1px oklch(0 0 0 / 0.02);
-  --rs-shadow-soft:
-    0px 2px 4px 0px oklch(0 0 0 / 0.04), 0px 1px 2px 0px oklch(0 0 0 / 0.04);
-  --rs-shadow-lifted:
-    0px 1px 1px 0px oklch(0 0 0 / 0.07), 0px 2px 5px 0px oklch(0 0 0 / 0.07), 0px 3px 8px 0px oklch(
-      0 0 0 / 0.07
-    );
-  --rs-shadow-floating:
-    0px 1px 1px 0px oklch(0 0 0 / 0.04), 0px 2px 8px 0px oklch(0 0 0 / 0.04), 0px 3px 17px 0px oklch(
-      0 0 0 / 0.04
-    ), 0px 4px 30px 0px oklch(0 0 0 / 0.13);
-  --rs-shadow-inset: 0px 1px 1px 0px oklch(0 0 0 / 0.04) inset;
 }
 
 [data-theme="dark"] {

--- a/packages/raystack/styles/effects.css
+++ b/packages/raystack/styles/effects.css
@@ -1,35 +1,112 @@
 :root {
-    /* Shadows */
-    /* Example usage: box-shadow: var(--rs-shadow-feather); */
-    --rs-shadow-feather: 0px 1px 1px 0px oklch(0 0 0 / 0.06), 0px 4px 4px -1px oklch(0 0 0 / 0.02); /* sm */
-    --rs-shadow-soft: 0px 2px 4px 0px oklch(0 0 0 / 0.04), 0px 1px 2px 0px oklch(0 0 0 / 0.04); /* md */
-    --rs-shadow-lifted: 0px 1px 1px 0px oklch(0 0 0 / 0.07), 0px 2px 5px 0px oklch(0 0 0 / 0.07), 0px 3px 8px 0px oklch(0 0 0 / 0.07); /* lg */
-    --rs-shadow-floating: 0px 1px 1px 0px oklch(0 0 0 / 0.04), 0px 2px 8px 0px oklch(0 0 0 / 0.04), 0px 3px 17px 0px oklch(0 0 0 / 0.04), 0px 4px 30px 0px oklch(0 0 0 / 0.13); /* xl */
-    --rs-shadow-inset: 0px 1px 1px 0px oklch(0 0 0 / 0.04) inset;
+  /* Shadows */
+  /* Example usage: box-shadow: var(--rs-shadow-feather); */
+  --rs-shadow-feather:
+    0px 1px 1px 0px oklch(0 0 0 / 0.06), 0px 4px 4px -1px oklch(0 0 0 / 0.02); /* sm */
+  --rs-shadow-soft:
+    0px 2px 4px 0px oklch(0 0 0 / 0.04), 0px 1px 2px 0px oklch(0 0 0 / 0.04); /* md */
+  --rs-shadow-lifted:
+    0px 1px 1px 0px oklch(0 0 0 / 0.07), 0px 2px 5px 0px oklch(0 0 0 / 0.07), 0px 3px 8px 0px oklch(
+      0 0 0 / 0.07
+    ); /* lg */
+  --rs-shadow-floating:
+    0px 1px 1px 0px oklch(0 0 0 / 0.04), 0px 2px 8px 0px oklch(0 0 0 / 0.04), 0px 3px 17px 0px oklch(
+      0 0 0 / 0.04
+    ), 0px 4px 30px 0px oklch(0 0 0 / 0.13); /* xl */
+  --rs-shadow-inset: 0px 1px 1px 0px oklch(0 0 0 / 0.04) inset;
 
-    /* Transitions */
-    --rs-transition-interactive: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  /* Transitions */
+  --rs-transition-interactive:
+    background-color var(--rs-duration-normal) var(--rs-ease-out),
+    border-color var(--rs-duration-normal) var(--rs-ease-out),
+    color var(--rs-duration-normal) var(--rs-ease-out),
+    box-shadow var(--rs-duration-normal) var(--rs-ease-out),
+    opacity var(--rs-duration-normal) var(--rs-ease-out);
+  /* Pressed states: acknowledge pointer-down near-instantly. Apply on
+       `:active`; releasing falls back to --rs-transition-interactive (200ms). */
+  --rs-transition-pressed:
+    background-color var(--rs-duration-press) var(--rs-ease-out),
+    border-color var(--rs-duration-press) var(--rs-ease-out),
+    color var(--rs-duration-press) var(--rs-ease-out),
+    box-shadow var(--rs-duration-press) var(--rs-ease-out),
+    opacity var(--rs-duration-press) var(--rs-ease-out),
+    transform var(--rs-duration-press) var(--rs-ease-out);
 
-    /* Blurs */
-    /* Example usage: backdrop-filter:: var(--rs-blur-sm); */
-    --rs-blur-sm: blur(0.5px);
-    --rs-blur-md: blur(1px);
-    --rs-blur-lg: blur(2px);
-    --rs-blur-xl: blur(4px);
+  /* Pressed scale: a control shrinks slightly under the finger. Smaller
+       targets need a larger delta to read, so there are two steps. */
+  --rs-scale-pressed: 0.97; /* buttons, tabs, larger controls */
+  --rs-scale-pressed-strong: 0.92; /* checkbox, radio, chip dismiss */
+
+  /* Focus ring: keyboard-focus indicator. The shadow variant is for
+       chromeless text-entry surfaces that have no border to ring. */
+  --rs-focus-ring: 0.5px solid var(--rs-color-border-accent-emphasis);
+  --rs-focus-ring-shadow: 0 0 0 1.5px var(--rs-color-border-accent-primary);
+
+  /* Ring offset: rings sit flush (0) by default. A control adds one of these
+       in its own :focus-visible rule when it needs to — accent-filled controls
+       push the ring out so it clears the same-colour fill; controls in a
+       clipped container pull it in so the ring isn't cut off. */
+  --rs-focus-ring-offset-accent: 2px;
+  --rs-focus-ring-offset-inset: -2px;
+
+  /* Motion */
+  /* Example usage: transition: opacity var(--rs-duration-normal) var(--rs-ease-out); */
+  --rs-ease-out: cubic-bezier(
+    0.22,
+    1,
+    0.36,
+    1
+  ); /* entrances, exits, value changes */
+  --rs-ease-in-out: cubic-bezier(
+    0.77,
+    0,
+    0.175,
+    1
+  ); /* elements moving on screen */
+  --rs-ease-drawer: cubic-bezier(0.32, 0.72, 0, 1); /* iOS-like drawer slide */
+  --rs-duration-press: 100ms; /* pressed/active feedback */
+  --rs-duration-fast: 150ms; /* tooltips, menus, small popups */
+  --rs-duration-normal: 200ms; /* popovers, dialogs, switches */
+  --rs-duration-moderate: 250ms; /* tabs indicator, preview card, tour steps */
+  --rs-duration-slow: 400ms; /* toasts */
+  --rs-duration-drawer: 450ms; /* drawer */
+
+  /* Blurs */
+  /* Example usage: backdrop-filter:: var(--rs-blur-sm); */
+  --rs-blur-sm: blur(0.5px);
+  --rs-blur-md: blur(1px);
+  --rs-blur-lg: blur(2px);
+  --rs-blur-xl: blur(4px);
 }
 
 [data-theme="light"] {
-  --rs-shadow-feather: 0px 1px 1px 0px oklch(0 0 0 / 0.06), 0px 4px 4px -1px oklch(0 0 0 / 0.02);
-  --rs-shadow-soft: 0px 2px 4px 0px oklch(0 0 0 / 0.04), 0px 1px 2px 0px oklch(0 0 0 / 0.04);
-  --rs-shadow-lifted: 0px 1px 1px 0px oklch(0 0 0 / 0.07), 0px 2px 5px 0px oklch(0 0 0 / 0.07), 0px 3px 8px 0px oklch(0 0 0 / 0.07);
-  --rs-shadow-floating: 0px 1px 1px 0px oklch(0 0 0 / 0.04), 0px 2px 8px 0px oklch(0 0 0 / 0.04), 0px 3px 17px 0px oklch(0 0 0 / 0.04), 0px 4px 30px 0px oklch(0 0 0 / 0.13);
+  --rs-shadow-feather:
+    0px 1px 1px 0px oklch(0 0 0 / 0.06), 0px 4px 4px -1px oklch(0 0 0 / 0.02);
+  --rs-shadow-soft:
+    0px 2px 4px 0px oklch(0 0 0 / 0.04), 0px 1px 2px 0px oklch(0 0 0 / 0.04);
+  --rs-shadow-lifted:
+    0px 1px 1px 0px oklch(0 0 0 / 0.07), 0px 2px 5px 0px oklch(0 0 0 / 0.07), 0px 3px 8px 0px oklch(
+      0 0 0 / 0.07
+    );
+  --rs-shadow-floating:
+    0px 1px 1px 0px oklch(0 0 0 / 0.04), 0px 2px 8px 0px oklch(0 0 0 / 0.04), 0px 3px 17px 0px oklch(
+      0 0 0 / 0.04
+    ), 0px 4px 30px 0px oklch(0 0 0 / 0.13);
   --rs-shadow-inset: 0px 1px 1px 0px oklch(0 0 0 / 0.04) inset;
 }
 
 [data-theme="dark"] {
-  --rs-shadow-feather: 0px 1px 1px 0px oklch(0 0 0 / 0.3), 0px 4px 4px -1px oklch(0 0 0 / 0.25);
-  --rs-shadow-soft: 0px 2px 4px 0px oklch(0 0 0 / 0.3), 0px 1px 2px 0px oklch(0 0 0 / 0.25);
-  --rs-shadow-lifted: 0px 1px 1px 0px oklch(0 0 0 / 0.35), 0px 2px 5px 0px oklch(0 0 0 / 0.35), 0px 3px 8px 0px oklch(0 0 0 / 0.35);
-  --rs-shadow-floating: 0px 1px 1px 0px oklch(0 0 0 / 0.3), 0px 2px 8px 0px oklch(0 0 0 / 0.3), 0px 3px 17px 0px oklch(0 0 0 / 0.3), 0px 4px 30px 0px oklch(0 0 0 / 0.4);
+  --rs-shadow-feather:
+    0px 1px 1px 0px oklch(0 0 0 / 0.3), 0px 4px 4px -1px oklch(0 0 0 / 0.25);
+  --rs-shadow-soft:
+    0px 2px 4px 0px oklch(0 0 0 / 0.3), 0px 1px 2px 0px oklch(0 0 0 / 0.25);
+  --rs-shadow-lifted:
+    0px 1px 1px 0px oklch(0 0 0 / 0.35), 0px 2px 5px 0px oklch(0 0 0 / 0.35), 0px 3px 8px 0px oklch(
+      0 0 0 / 0.35
+    );
+  --rs-shadow-floating:
+    0px 1px 1px 0px oklch(0 0 0 / 0.3), 0px 2px 8px 0px oklch(0 0 0 / 0.3), 0px 3px 17px 0px oklch(
+      0 0 0 / 0.3
+    ), 0px 4px 30px 0px oklch(0 0 0 / 0.4);
   --rs-shadow-inset: 0px 1px 1px 0px oklch(0 0 0 / 0.25) inset;
 }

--- a/packages/raystack/styles/primitives/accent.css
+++ b/packages/raystack/styles/primitives/accent.css
@@ -83,7 +83,8 @@
   --rs-accent-10: oklch(0.8401 0.0988 178.42);
   --rs-accent-11: oklch(0.5117 0.0955 175.6);
   --rs-accent-12: oklch(0.3496 0.0505 181.31);
-  --rs-accent-contrast: oklch(1 0 0);
+  /* mint-9/10 are light (L~0.87); needs dark text, not white */
+  --rs-accent-contrast: oklch(0 0 0);
 }
 
 [data-accent-color="mint"][data-theme="dark"] {
@@ -99,5 +100,6 @@
   --rs-accent-10: oklch(0.9156 0.079 180);
   --rs-accent-11: oklch(0.7954 0.1181 176.46);
   --rs-accent-12: oklch(0.9306 0.057 168.28);
-  --rs-accent-contrast: oklch(1 0 0);
+  /* mint-9/10 stay light in dark theme too; keep dark text */
+  --rs-accent-contrast: oklch(0 0 0);
 }

--- a/packages/raystack/styles/typography.css
+++ b/packages/raystack/styles/typography.css
@@ -14,7 +14,8 @@
   /* Font Families */
   --rs-font-title: var(--rs-font-inter), sans-serif;
   --rs-font-body: var(--rs-font-inter), sans-serif;
-  --rs-font-mono: var(--rs-font-menlo), var(--rs-font-jetbrains-mono), monospace;
+  --rs-font-mono:
+    var(--rs-font-menlo), var(--rs-font-jetbrains-mono), monospace;
 
   /* Font Weights */
   --rs-font-weight-regular: 400;
@@ -81,6 +82,10 @@
 }
 
 [data-style="modern"] {
+  /* Re-declare (not just inherit from :root) so a modern theme nested inside a
+     traditional one resets to Inter instead of inheriting Lora/Josefin. */
+  --rs-font-title: var(--rs-font-inter), sans-serif;
+  --rs-font-body: var(--rs-font-inter), sans-serif;
   font-family: var(--rs-font-body);
 }
 
@@ -137,4 +142,3 @@ input,
 textarea {
   caret-color: var(--rs-color-border-accent-emphasis);
 }
-

--- a/packages/raystack/styles/typography.css
+++ b/packages/raystack/styles/typography.css
@@ -81,8 +81,6 @@
 }
 
 [data-style="modern"] {
-  --rs-font-title: var(--rs-font-inter), sans-serif;
-  --rs-font-body: var(--rs-font-inter), sans-serif;
   font-family: var(--rs-font-body);
 }
 

--- a/packages/raystack/styles/typography.css
+++ b/packages/raystack/styles/typography.css
@@ -1,7 +1,7 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Lora:wght@400;500&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Josefin+Sans:wght@400;500&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital@0;1&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,500;1,400;1,500&display=swap");
 
 :root {
   /* Fonts */
@@ -97,6 +97,10 @@ body {
   /* Font Smoothing */
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  /* Only weights 400 and 500 are loaded (see @import above). Fail visibly
+     on any missing weight or style instead of rendering a faked bold/italic. */
+  font-synthesis: none;
 }
 
 h1 {
@@ -104,24 +108,28 @@ h1 {
   font-size: var(--rs-font-size-t4);
   font-weight: var(--rs-font-weight-medium);
   line-height: var(--rs-line-height-t4);
+  text-wrap: balance;
 }
 h2 {
   font-family: var(--rs-font-title);
   font-size: var(--rs-font-size-t3);
   font-weight: var(--rs-font-weight-medium);
   line-height: var(--rs-line-height-t3);
+  text-wrap: balance;
 }
 h3 {
   font-family: var(--rs-font-title);
   font-size: var(--rs-font-size-t2);
   font-weight: var(--rs-font-weight-medium);
   line-height: var(--rs-line-height-t2);
+  text-wrap: balance;
 }
 h4 {
   font-family: var(--rs-font-title);
   font-size: var(--rs-font-size-t1);
   font-weight: var(--rs-font-weight-medium);
   line-height: var(--rs-line-height-t1);
+  text-wrap: balance;
 }
 
 /* CSS for the text cursor */

--- a/packages/raystack/styles/typography.css
+++ b/packages/raystack/styles/typography.css
@@ -29,17 +29,19 @@
 
   /* Body Line Heights */
   --rs-line-height-micro: 12px;
-  --rs-line-height-mini: 16px;
+  --rs-line-height-mini: 14px;
   --rs-line-height-small: 16px;
   --rs-line-height-regular: 20px;
   --rs-line-height-large: 24px;
 
-  /* Body Letter spacing */
-  --rs-letter-spacing-micro: 0.5px;
-  --rs-letter-spacing-mini: 0.5px;
-  --rs-letter-spacing-small: 0.4px;
-  --rs-letter-spacing-regular: 0.25px;
-  --rs-letter-spacing-large: 0.5px;
+  /* Body Letter spacing — tuned for Inter, which is spaced generously already.
+     Near-zero at small sizes, slightly negative as size grows. em-based so it
+     scales with font-size. */
+  --rs-letter-spacing-micro: 0.01em;
+  --rs-letter-spacing-mini: 0.005em;
+  --rs-letter-spacing-small: 0em;
+  --rs-letter-spacing-regular: -0.006em;
+  --rs-letter-spacing-large: -0.011em;
 
   /* Title Font Sizes */
   --rs-font-size-t1: 20px;
@@ -48,16 +50,16 @@
   --rs-font-size-t4: 32px;
 
   /* Title Line Heights */
-  --rs-line-height-t1: 24px;
+  --rs-line-height-t1: 28px;
   --rs-line-height-t2: 32px;
   --rs-line-height-t3: 36px;
   --rs-line-height-t4: 40px;
 
   /* Title Letter Spacing */
-  --rs-letter-spacing-t1: 0;
-  --rs-letter-spacing-t2: 0;
-  --rs-letter-spacing-t3: 0;
-  --rs-letter-spacing-t4: 0;
+  --rs-letter-spacing-t1: -0.01em;
+  --rs-letter-spacing-t2: -0.013em;
+  --rs-letter-spacing-t3: -0.016em;
+  --rs-letter-spacing-t4: -0.02em;
 
   /* Mono Font Sizes */
   --rs-font-size-mono-mini: 11px;
@@ -103,19 +105,19 @@ h1 {
   font-family: var(--rs-font-title);
   font-size: var(--rs-font-size-t4);
   font-weight: var(--rs-font-weight-medium);
-  line-height: var(--rs-line-height-t1);
+  line-height: var(--rs-line-height-t4);
 }
 h2 {
   font-family: var(--rs-font-title);
   font-size: var(--rs-font-size-t3);
   font-weight: var(--rs-font-weight-medium);
-  line-height: var(--rs-line-height-t1);
+  line-height: var(--rs-line-height-t3);
 }
 h3 {
   font-family: var(--rs-font-title);
   font-size: var(--rs-font-size-t2);
   font-weight: var(--rs-font-weight-medium);
-  line-height: var(--rs-line-height-t1);
+  line-height: var(--rs-line-height-t2);
 }
 h4 {
   font-family: var(--rs-font-title);
@@ -130,13 +132,3 @@ textarea {
   caret-color: var(--rs-color-border-accent-emphasis);
 }
 
-/* Keyframe Animation */
-@keyframes dissolve-hide {
-  0%,
-  50% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-  }
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,43 @@ importers:
         specifier: '4.7'
         version: 4.7.2
 
+  apps/playground:
+    dependencies:
+      '@raystack/apsara':
+        specifier: workspace:*
+        version: link:../../packages/raystack
+      apsara-before:
+        specifier: npm:@raystack/apsara@1.0.1
+        version: '@raystack/apsara@1.0.1(@date-fns/tz@1.2.0)(@types/react@19.2.2)(date-fns@4.1.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)'
+      next:
+        specifier: 16.0.7
+        version: 16.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      next-themes:
+        specifier: ^0.4.4
+        version: 0.4.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      react:
+        specifier: ^19.2.1
+        version: 19.2.1
+      react-dom:
+        specifier: ^19.2.1
+        version: 19.2.1(react@19.2.1)
+    devDependencies:
+      '@raystack/tools-config':
+        specifier: workspace:*
+        version: link:../../packages/tools-config
+      '@types/node':
+        specifier: ^24.9.2
+        version: 24.10.0
+      '@types/react':
+        specifier: ^19.2.2
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19.2.2
+        version: 19.2.2(@types/react@19.2.2)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   apps/www:
     dependencies:
       '@radix-ui/react-icons':
@@ -263,12 +300,6 @@ importers:
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
-      np:
-        specifier: ^8.0.4
-        version: 8.0.4(typescript@5.4.3)
-      npm:
-        specifier: ^9.7.1
-        version: 9.7.1
       parcel:
         specifier: ^2.9.2
         version: 2.9.2(@swc/helpers@0.5.15)(postcss@8.4.24)(terser@5.39.0)(typescript@5.4.3)
@@ -1034,9 +1065,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@bconnorwhite/module@2.0.2':
-    resolution: {integrity: sha512-ck1me5WMgZKp06gnJrVKEkytpehTTQbvsAMbF1nGPeHri/AZNhj87++PSE2LOxmZqM0EtGMaqeLdx7Lw7SUnTA==}
-
   '@biomejs/biome@2.3.8':
     resolution: {integrity: sha512-Qjsgoe6FEBxWAUzwFGFrB+1+M8y/y5kwmg5CHac+GSVOdmOIqsAiXM5QMVGZJ1eCUCLlPZtq4aFAQ0eawEUuUA==}
     engines: {node: '>=14.21.3'}
@@ -1591,10 +1619,6 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
-
-  '@inquirer/figures@1.0.3':
-    resolution: {integrity: sha512-ErXXzENMH5pJt5/ssXV0DfWUZqly8nGzf0UcBV9xTnP+KyffE2mqyxIMBrZ8ijQck2nU0TQm40EQB53YreyWHw==}
-    engines: {node: '>=18'}
 
   '@isaacs/balanced-match@4.0.1':
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
@@ -2320,18 +2344,6 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
-
-  '@pnpm/config.env-replace@1.1.0':
-    resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
-    engines: {node: '>=12.22.0'}
-
-  '@pnpm/network.ca-file@1.0.2':
-    resolution: {integrity: sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==}
-    engines: {node: '>=12.22.0'}
-
-  '@pnpm/npm-conf@2.2.2':
-    resolution: {integrity: sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==}
-    engines: {node: '>=12'}
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -3093,6 +3105,17 @@ packages:
       '@types/react':
         optional: true
 
+  '@raystack/apsara@1.0.1':
+    resolution: {integrity: sha512-w5f0dhInJVPih2Le1vA08IwQQtOPRNVBe7nyGqqpHan1Vqy5EFi2Q0zSOgnvq4E+3PzWOvnFLHi/rsfT3n6H4Q==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@types/react': ^19
+      react: ^19
+      react-dom: ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@rollup/plugin-commonjs@25.0.2':
     resolution: {integrity: sha512-NGTwaJxIO0klMs+WSFFtBP7b9TdTJ3K76HZkewT8/+yHzMiUGVQgaPtLQxNVYIgT5F7lxkEyVID+yS3K7bhCow==}
     engines: {node: '>=14.0.0'}
@@ -3242,18 +3265,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@samverschueren/stream-to-observable@0.3.1':
-    resolution: {integrity: sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==}
-    engines: {node: '>=6'}
-    peerDependencies:
-      rxjs: '*'
-      zen-observable: '*'
-    peerDependenciesMeta:
-      rxjs:
-        optional: true
-      zen-observable:
-        optional: true
-
   '@secretlint/config-creator@9.3.4':
     resolution: {integrity: sha512-GRMYfHJ+rewwB26CC3USVObqSQ/mDLXzXcUMJw/wJisPr3HDZmdsYlcsNnaAcGN+EZmvqSDkgSibQm1hyZpzbg==}
     engines: {node: ^14.13.1 || >=16.0.0}
@@ -3343,14 +3354,6 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
-
-  '@sindresorhus/is@4.6.0':
-    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
-    engines: {node: '>=10'}
-
-  '@sindresorhus/is@5.6.0':
-    resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
-    engines: {node: '>=14.16'}
 
   '@sindresorhus/merge-streams@2.3.0':
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
@@ -3578,9 +3581,6 @@ packages:
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
-  '@swc/helpers@0.5.12':
-    resolution: {integrity: sha512-KMZNXiGibsW9kvZAO1Pam2JPTDBm+KSHMMHWdsyI/1DbIZjT2A6Gy3hblVXUMEDvUAKq+e0vL0X0o54owWji7g==}
-
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -3589,14 +3589,6 @@ packages:
 
   '@swc/types@0.1.9':
     resolution: {integrity: sha512-qKnCno++jzcJ4lM4NTfYifm1EFSCeIfKiAHAfkENZAV5Kl9PjJIyd2yeeVv6c/2CckuLyv2NmRC5pv6pm2WQBg==}
-
-  '@szmarczak/http-timer@4.0.6':
-    resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
-    engines: {node: '>=10'}
-
-  '@szmarczak/http-timer@5.0.1':
-    resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
-    engines: {node: '>=14.16'}
 
   '@tanstack/match-sorter-utils@8.8.4':
     resolution: {integrity: sha512-rKH8LjZiszWEvmi01NR72QWZ8m4xmXre0OOwlRGnjU01Eqz/QnN+cqpty2PJ0efHblq09+KilvyR7lsbzmXVEw==}
@@ -3701,9 +3693,6 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
-  '@types/cacheable-request@6.0.3':
-    resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
-
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
@@ -3731,14 +3720,8 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
-  '@types/http-cache-semantics@4.0.4':
-    resolution: {integrity: sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==}
-
   '@types/inquirer@6.5.0':
     resolution: {integrity: sha512-rjaYQ9b9y/VFGOpqBEXRavc3jh0a+e6evAbI31tMda8VlPaSy0AZJfXsvmIe3wklc7W6C3zCSfleuMXR7NOyXw==}
-
-  '@types/keyv@3.1.4':
-    resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -3786,9 +3769,6 @@ packages:
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
-  '@types/responselike@1.0.3':
-    resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
-
   '@types/sarif@2.1.7':
     resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
 
@@ -3810,6 +3790,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -3935,43 +3916,15 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
-  aggregate-error@4.0.1:
-    resolution: {integrity: sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==}
-    engines: {node: '>=12'}
-
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
-
-  all-package-names@2.0.897:
-    resolution: {integrity: sha512-ZWd7bk4fK2Doei5nLP28ytHa5hTD+qr8bWuJQh1Bbi36Ij4RVXSL6tM0zEni85usEhX0iQ32IuYlyoYM0sKFyQ==}
-    hasBin: true
 
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
 
-  ansi-escapes@3.2.0:
-    resolution: {integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==}
-    engines: {node: '>=4'}
-
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
-
-  ansi-escapes@5.0.0:
-    resolution: {integrity: sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==}
-    engines: {node: '>=12'}
-
-  ansi-regex@2.1.1:
-    resolution: {integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==}
-    engines: {node: '>=0.10.0'}
-
-  ansi-regex@3.0.1:
-    resolution: {integrity: sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==}
-    engines: {node: '>=4'}
-
-  ansi-regex@4.1.1:
-    resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
-    engines: {node: '>=6'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -3980,10 +3933,6 @@ packages:
   ansi-regex@6.0.1:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
-
-  ansi-styles@2.2.1:
-    resolution: {integrity: sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==}
-    engines: {node: '>=0.10.0'}
 
   ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
@@ -4000,18 +3949,6 @@ packages:
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
-
-  any-observable@0.3.0:
-    resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
-    engines: {node: '>=6'}
-    peerDependencies:
-      rxjs: '*'
-      zenObservable: '*'
-    peerDependenciesMeta:
-      rxjs:
-        optional: true
-      zenObservable:
-        optional: true
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -4099,10 +4036,6 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  big-integer@1.6.52:
-    resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
-    engines: {node: '>=0.6'}
-
   binaryextensions@6.11.0:
     resolution: {integrity: sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==}
     engines: {node: '>=4'}
@@ -4119,14 +4052,6 @@ packages:
   boxen@5.1.1:
     resolution: {integrity: sha512-JtIQYts08AFAYGF4eSh3pUt3NQkYV/e75pRtQmAVTLNWR/1L7Bsswxlgzgk8nmLEM+gFszsIlA9BgD3XnSqp3g==}
     engines: {node: '>=10'}
-
-  boxen@7.1.1:
-    resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
-    engines: {node: '>=14.16'}
-
-  bplist-parser@0.2.0:
-    resolution: {integrity: sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==}
-    engines: {node: '>= 5.10.0'}
 
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -4168,35 +4093,12 @@ packages:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
     engines: {node: '>=6'}
 
-  builtins@1.0.3:
-    resolution: {integrity: sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==}
-
-  bundle-name@3.0.0:
-    resolution: {integrity: sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==}
-    engines: {node: '>=12'}
-
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-
-  cacheable-lookup@5.0.4:
-    resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
-    engines: {node: '>=10.6.0'}
-
-  cacheable-lookup@7.0.0:
-    resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
-    engines: {node: '>=14.16'}
-
-  cacheable-request@10.2.14:
-    resolution: {integrity: sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==}
-    engines: {node: '>=14.16'}
-
-  cacheable-request@7.0.4:
-    resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
     engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
@@ -4215,10 +4117,6 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  callsites@4.2.0:
-    resolution: {integrity: sha512-kfzR4zzQtAE9PC7CzZsjl3aBNbXWuXiSeOCdLcPpBfGW8YuCqQHcRPFDbr/BPVmd3EEPVpuFzLyuT/cUhPr4OQ==}
-    engines: {node: '>=12.20'}
-
   camel-case@3.0.0:
     resolution: {integrity: sha512-+MbKztAYHXPr1jNTSKQF52VpcFjwY5RkR7fxksV8Doo4KAYc5Fl4UJRgthBbTmEx8C54DqahhbLJkDwjI3PI/w==}
 
@@ -4226,15 +4124,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  camelcase@7.0.1:
-    resolution: {integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==}
-    engines: {node: '>=14.16'}
-
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
-
-  caniuse-lite@1.0.30001642:
-    resolution: {integrity: sha512-3XQ0DoRgLijXJErLSl+bLnJ+Et4KqV1PY6JJBGAFlsNsz31zeAIncyeZfLCabHK/jtSh+671RM9YMldxjUPZtA==}
 
   caniuse-lite@1.0.30001701:
     resolution: {integrity: sha512-faRs/AW3jA9nTwmJBSO1PQ6L/EOgsB5HMQQq4iCu5zhPgVVgO/pZRHlmatwijZKetFw8/Pr4q6dEN8sJuq8qTw==}
@@ -4245,10 +4136,6 @@ packages:
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
-
-  chalk@1.1.3:
-    resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==}
-    engines: {node: '>=0.10.0'}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -4261,10 +4148,6 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
-
-  chalk@5.3.0:
-    resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   change-case@3.1.0:
     resolution: {integrity: sha512-2AZp7uJZbYEzRPsFoa+ijKdvp9zsrnnt6+yFokfwEpeJm0xuJDVoxiRCAaTzyJND8GJkofo2IcKWaUZ/OECVzw==}
@@ -4306,10 +4189,6 @@ packages:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
 
-  ci-info@3.9.0:
-    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
-    engines: {node: '>=8'}
-
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -4317,21 +4196,9 @@ packages:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
 
-  clean-stack@4.2.0:
-    resolution: {integrity: sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==}
-    engines: {node: '>=12'}
-
   cli-boxes@2.2.1:
     resolution: {integrity: sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==}
     engines: {node: '>=6'}
-
-  cli-boxes@3.0.0:
-    resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
-    engines: {node: '>=10'}
-
-  cli-cursor@2.1.0:
-    resolution: {integrity: sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==}
-    engines: {node: '>=4'}
 
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
@@ -4341,20 +4208,9 @@ packages:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
 
-  cli-truncate@0.2.1:
-    resolution: {integrity: sha512-f4r4yJnbT++qUPI9NR4XLDLq41gQ+uqnPItWG0F5ZkehuNiTTa3EY0S4AqTSUOeJ7/zU41oWPQSNkW5BqPL9bg==}
-    engines: {node: '>=0.10.0'}
-
-  cli-width@2.2.1:
-    resolution: {integrity: sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==}
-
   cli-width@3.0.0:
     resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
     engines: {node: '>= 10'}
-
-  cli-width@4.1.0:
-    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
-    engines: {node: '>= 12'}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -4362,9 +4218,6 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
-
-  clone-response@1.0.3:
-    resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
 
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -4390,10 +4243,6 @@ packages:
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
-
-  code-point-at@1.1.0:
-    resolution: {integrity: sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==}
-    engines: {node: '>=0.10.0'}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -4437,9 +4286,6 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
-  commander-version@1.1.0:
-    resolution: {integrity: sha512-9aNW4N6q6EPDUszLRH6k9IwO6OoGYh3HRgUF/fA7Zs+Mz1v1x5akSqT7QGB8JsGY7AG7qMA7oRRB/4yyn33FYA==}
-
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
@@ -4457,10 +4303,6 @@ packages:
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
-    engines: {node: '>= 6'}
-
-  commander@6.2.1:
-    resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
     engines: {node: '>= 6'}
 
   commander@7.2.0:
@@ -4486,13 +4328,6 @@ packages:
     resolution: {integrity: sha512-H9MWcoPsYddwbOGM6difjVwVZHl63nwMEwDJG/L7VGtuaJhb12h2caPG2tVPWs7emuYix252iGfqOyrz1GczTQ==}
     engines: {node: '>=18'}
     hasBin: true
-
-  config-chain@1.1.13:
-    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
-
-  configstore@6.0.0:
-    resolution: {integrity: sha512-cD31W1v3GqUlQvbBCGcXmd2Nj9SvLDOP1oQ0YFuLETufzSPaKp11rYBsSOm7rCsW3OnIRAFM3OxRhceaXNYHkA==}
-    engines: {node: '>=12'}
 
   constant-case@2.0.0:
     resolution: {integrity: sha512-eS0N9WwmjTqrOmR3o83F5vW8Z+9R1HnVz3xmzT2PMFug9ly+Au/fxRWlEBSb6LcZwspSsEn9Xs1uw9YgzAg1EQ==}
@@ -4527,17 +4362,9 @@ packages:
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
-  cross-spawn@7.0.3:
-    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
-    engines: {node: '>= 8'}
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
-
-  crypto-random-string@4.0.0:
-    resolution: {integrity: sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==}
-    engines: {node: '>=12'}
 
   css-declaration-sorter@6.4.1:
     resolution: {integrity: sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==}
@@ -4619,9 +4446,6 @@ packages:
   date-fns-jalali@4.1.0-0:
     resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
 
-  date-fns@1.30.1:
-    resolution: {integrity: sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==}
-
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
@@ -4672,17 +4496,9 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
-  default-browser-id@3.0.0:
-    resolution: {integrity: sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==}
-    engines: {node: '>=12'}
-
   default-browser-id@5.0.0:
     resolution: {integrity: sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==}
     engines: {node: '>=18'}
-
-  default-browser@4.0.0:
-    resolution: {integrity: sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==}
-    engines: {node: '>=14.16'}
 
   default-browser@5.2.1:
     resolution: {integrity: sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==}
@@ -4690,10 +4506,6 @@ packages:
 
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
-
-  defer-to-connect@2.0.1:
-    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
-    engines: {node: '>=10'}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -4710,10 +4522,6 @@ packages:
   del@5.1.0:
     resolution: {integrity: sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==}
     engines: {node: '>=8'}
-
-  del@7.1.0:
-    resolution: {integrity: sha512-v2KyNk7efxhlyHpjEvfyxaAihKKK0nWCuf6ZtqZcFFpQRG0bJ12Qsr0RpvsICMjAAZ8DOVCxrlqpxISlMHC4Kg==}
-    engines: {node: '>=14.16'}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -4785,14 +4593,6 @@ packages:
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
 
-  dot-prop@6.0.1:
-    resolution: {integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==}
-    engines: {node: '>=10'}
-
-  dot-prop@7.2.0:
-    resolution: {integrity: sha512-Ol/IPXUARn9CSbkrdV4VJo7uCy1I3VuSiWCaFSg+8BdUOzF9n3jefIpcgAydvUZbTdEBZs2vEiTiS9m61ssiDA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   dotenv-expand@5.1.0:
     resolution: {integrity: sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==}
 
@@ -4827,10 +4627,6 @@ packages:
 
   electron-to-chromium@1.5.109:
     resolution: {integrity: sha512-AidaH9JETVRr9DIPGfp1kAarm/W6hRJTPuCnkF+2MqhF4KaAgRIcBc8nvjk+YMXZhwfISof/7WG29eS4iGxQLQ==}
-
-  elegant-spinner@1.0.1:
-    resolution: {integrity: sha512-B+ZM+RXvRqQaAmkMlO/oSe5nMUOaUnyfGYCEHoR8wrXsZR2mA0XVibsxV1bvTwxdRWah1PkQqso2EzhILGHtEQ==}
-    engines: {node: '>=0.10.0'}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -4912,10 +4708,6 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
-  escape-goat@4.0.0:
-    resolution: {integrity: sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==}
-    engines: {node: '>=12'}
-
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
@@ -4968,18 +4760,6 @@ packages:
 
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
-
-  execa@5.1.1:
-    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
-    engines: {node: '>=10'}
-
-  execa@7.2.0:
-    resolution: {integrity: sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==}
-    engines: {node: ^14.18.0 || ^16.14.0 || >=18.0.0}
-
-  exit-hook@3.2.0:
-    resolution: {integrity: sha512-aIQN7Q04HGAV/I5BszisuHTZHXNoC23WtLkxdCLuYZMdWviRD0TMIt2bnUBi9MrHaF/hH8b3gwG9iaAUHKnJGA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
@@ -5039,14 +4819,6 @@ packages:
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
-  figures@1.7.0:
-    resolution: {integrity: sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==}
-    engines: {node: '>=0.10.0'}
-
-  figures@2.0.0:
-    resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
-    engines: {node: '>=4'}
-
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
@@ -5055,17 +4827,9 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
-  find-up@4.1.0:
-    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
-    engines: {node: '>=8'}
-
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
-
-  find-up@6.3.0:
-    resolution: {integrity: sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
@@ -5076,10 +4840,6 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
-
-  form-data-encoder@2.1.4:
-    resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
-    engines: {node: '>= 14.17'}
 
   form-data@4.0.1:
     resolution: {integrity: sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==}
@@ -5227,22 +4987,11 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
-  get-stream@5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
-
-  get-stream@6.0.1:
-    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
-    engines: {node: '>=10'}
-
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
-
-  github-url-from-git@1.5.0:
-    resolution: {integrity: sha512-WWOec4aRI7YAykQ9+BHmzjyNlkfJFG8QLXnDTsLz/kZefq7qkzdfo4p6fkYYMIq1aj+gZcQs/1HQhQh3DPPxlQ==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -5250,11 +4999,13 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.3:
     resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.1.0:
@@ -5265,16 +5016,12 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
-
-  global-dirs@3.0.1:
-    resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
-    engines: {node: '>=10'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -5288,10 +5035,6 @@ packages:
     resolution: {integrity: sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==}
     engines: {node: '>=8'}
 
-  globby@13.2.2:
-    resolution: {integrity: sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   globby@14.1.0:
     resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
     engines: {node: '>=18'}
@@ -5302,17 +5045,6 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
-
-  got@11.8.6:
-    resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
-    engines: {node: '>=10.19.0'}
-
-  got@12.6.1:
-    resolution: {integrity: sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==}
-    engines: {node: '>=14.16'}
-
-  graceful-fs@4.2.10:
-    resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -5327,10 +5059,6 @@ packages:
 
   harmony-reflect@1.6.2:
     resolution: {integrity: sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==}
-
-  has-ansi@2.0.0:
-    resolution: {integrity: sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==}
-    engines: {node: '>=0.10.0'}
 
   has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
@@ -5362,10 +5090,6 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  has-yarn@3.0.0:
-    resolution: {integrity: sha512-IrsVwUHhEULx3R8f/aA8AHuEzAorplsab/v8HBzEiIukwq5i/EC+xmOW+HfP1OaDP+2JkgT1yILHN2O3UFIbcA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
@@ -5391,10 +5115,6 @@ packages:
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
-
-  hosted-git-info@6.1.1:
-    resolution: {integrity: sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
@@ -5442,20 +5162,9 @@ packages:
   htmlparser2@7.2.0:
     resolution: {integrity: sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==}
 
-  http-cache-semantics@4.1.1:
-    resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
-
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
-
-  http2-wrapper@1.0.3:
-    resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
-    engines: {node: '>=10.19.0'}
-
-  http2-wrapper@2.2.1:
-    resolution: {integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==}
-    engines: {node: '>=10.19.0'}
 
   https-proxy-agent@7.0.5:
     resolution: {integrity: sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==}
@@ -5464,14 +5173,6 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
-
-  human-signals@2.1.0:
-    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
-    engines: {node: '>=10.17.0'}
-
-  human-signals@4.3.1:
-    resolution: {integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==}
-    engines: {node: '>=14.18.0'}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -5496,10 +5197,6 @@ packages:
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-
-  ignore-walk@6.0.5:
-    resolution: {integrity: sha512-VuuG0wCnjhnylG1ABXT3dAuIpTNDs/G8jlpmwXY03fXoXy/8ZK8/T+hMzt8L4WnrLCJgdybqgPagnF/f97cg3A==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   ignore@5.3.1:
     resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
@@ -5526,30 +5223,9 @@ packages:
     resolution: {integrity: sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==}
     engines: {node: '>=8'}
 
-  import-lazy@4.0.0:
-    resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
-    engines: {node: '>=8'}
-
-  import-local@3.1.0:
-    resolution: {integrity: sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==}
-    engines: {node: '>=8'}
-    hasBin: true
-
-  imurmurhash@0.1.4:
-    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
-    engines: {node: '>=0.8.19'}
-
-  indent-string@3.2.0:
-    resolution: {integrity: sha512-BYqTHXTGUIvg7t1r4sJNKcbDZkL92nkXA8YtRpbjFHRHGDL/NtUeiBJMeE60kIFN/Mg8ESaWQvftaYMGJzQZCQ==}
-    engines: {node: '>=4'}
-
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
-
-  indent-string@5.0.0:
-    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
-    engines: {node: '>=12'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -5561,19 +5237,8 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
-  ini@2.0.0:
-    resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
-    engines: {node: '>=10'}
-
   inline-style-parser@0.2.4:
     resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
-
-  inquirer-autosubmit-prompt@0.2.0:
-    resolution: {integrity: sha512-mzNrusCk5L6kSzlN0Ioddn8yzrhYNLli+Sn2ZxMuLechMYAzakiFCIULxsxlQb5YKzthLGfrFACcWoAvM7p04Q==}
-
-  inquirer@6.5.2:
-    resolution: {integrity: sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==}
-    engines: {node: '>=6.0.0'}
 
   inquirer@7.3.3:
     resolution: {integrity: sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==}
@@ -5582,10 +5247,6 @@ packages:
   inquirer@8.2.6:
     resolution: {integrity: sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==}
     engines: {node: '>=12.0.0'}
-
-  inquirer@9.3.5:
-    resolution: {integrity: sha512-SVRCRovA7KaT6nqWB2mCNpTvU4cuZ0hOXo5KPyiyOcNNUIZwq/JKtvXuDJNaxfuJKabBYRu1ecHze0YEwDYoRQ==}
-    engines: {node: '>=18'}
 
   internal-slot@1.0.7:
     resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
@@ -5623,10 +5284,6 @@ packages:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
 
-  is-ci@3.0.1:
-    resolution: {integrity: sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==}
-    hasBin: true
-
   is-core-module@2.14.0:
     resolution: {integrity: sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==}
     engines: {node: '>= 0.4'}
@@ -5638,11 +5295,6 @@ packages:
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
-  is-docker@2.2.1:
-    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
-    engines: {node: '>=8'}
-    hasBin: true
-
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -5651,14 +5303,6 @@ packages:
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
-
-  is-fullwidth-code-point@1.0.0:
-    resolution: {integrity: sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==}
-    engines: {node: '>=0.10.0'}
-
-  is-fullwidth-code-point@2.0.0:
-    resolution: {integrity: sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==}
-    engines: {node: '>=4'}
 
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -5676,17 +5320,9 @@ packages:
     engines: {node: '>=14.16'}
     hasBin: true
 
-  is-installed-globally@0.4.0:
-    resolution: {integrity: sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==}
-    engines: {node: '>=10'}
-
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
-
-  is-interactive@2.0.0:
-    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
-    engines: {node: '>=12'}
 
   is-json@2.0.1:
     resolution: {integrity: sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==}
@@ -5701,13 +5337,6 @@ packages:
   is-module@1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
 
-  is-name-taken@2.0.0:
-    resolution: {integrity: sha512-W+FUWF5g7ONVJTx3rldZeVizmPzrMMUdscpSQ96vyYerx+4b2NcqaujLJJDWruGzE0FjzGZO9RFIipOGxx/WIw==}
-
-  is-npm@6.0.0:
-    resolution: {integrity: sha512-JEjxbSmtPSt1c8XTkVrlujcXdKV1/tvuQ7GwKcAlyiVLeYFQ2VHat8xfrDJsIkhCdF/tZ7CiIR3sy141c6+gPQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   is-number-object@1.0.7:
     resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
     engines: {node: '>= 0.4'}
@@ -5716,29 +5345,13 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
-  is-obj@2.0.0:
-    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
-    engines: {node: '>=8'}
-
-  is-observable@1.1.0:
-    resolution: {integrity: sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==}
-    engines: {node: '>=4'}
-
   is-path-cwd@2.2.0:
     resolution: {integrity: sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==}
     engines: {node: '>=6'}
 
-  is-path-cwd@3.0.0:
-    resolution: {integrity: sha512-kyiNFFLU0Ampr6SDZitD/DwUo4Zs1nSdnygUBqsu3LooL00Qvb5j+UnvApUn/TTj1J3OuE6BTdQ5rudKmU2ZaA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
-
-  is-path-inside@4.0.0:
-    resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
-    engines: {node: '>=12'}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -5747,19 +5360,12 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
-  is-promise@2.2.2:
-    resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
-
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
 
   is-regex@1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
     engines: {node: '>= 0.4'}
-
-  is-scoped@3.0.0:
-    resolution: {integrity: sha512-ezxLUq30kiTvP0w/5n9tj4qTOKlrA07Oty1hwTQ+lcqw11x6uc8sp7VRb2OVGRzKfCHZ2A22T5Zsau/Q2Akb0g==}
-    engines: {node: '>=12'}
 
   is-set@2.0.3:
     resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
@@ -5769,18 +5375,6 @@ packages:
     resolution: {integrity: sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==}
     engines: {node: '>= 0.4'}
 
-  is-stream@1.1.0:
-    resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
-    engines: {node: '>=0.10.0'}
-
-  is-stream@2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
-    engines: {node: '>=8'}
-
-  is-stream@3.0.0:
-    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
     engines: {node: '>= 0.4'}
@@ -5789,23 +5383,12 @@ packages:
     resolution: {integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==}
     engines: {node: '>= 0.4'}
 
-  is-typedarray@1.0.0:
-    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
-
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
 
-  is-unicode-supported@1.3.0:
-    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
-    engines: {node: '>=12'}
-
   is-upper-case@1.1.2:
     resolution: {integrity: sha512-GQYSJMgfeAmVwh9ixyk888l7OIhNAGKtY6QA+IrWlu9MDTCaXmeozOZ2S9Knj7bQwBO/H6J2kb+pbyTUiMNbsw==}
-
-  is-url-superb@6.1.0:
-    resolution: {integrity: sha512-LXdhGlYqUPdvEyIhWPEEwYYK3yrUiPcBjmFGlZNv1u5GtIL5qQRf7ddDyPNAvsMFqdzS923FROpTQU97tLe3JQ==}
-    engines: {node: '>=12'}
 
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
@@ -5815,17 +5398,9 @@ packages:
     resolution: {integrity: sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==}
     engines: {node: '>= 0.4'}
 
-  is-wsl@2.2.0:
-    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
-    engines: {node: '>=8'}
-
   is-wsl@3.1.0:
     resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
     engines: {node: '>=16'}
-
-  is-yarn-global@0.4.1:
-    resolution: {integrity: sha512-/kppl+R+LO5VmhYSEWARUFjodS25D68gvj8W7z0I7OWhUla5xWu8KL6CtB2V0R6yqhnRgbcaREMr4EEM6htLPQ==}
-    engines: {node: '>=12'}
 
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -5836,10 +5411,6 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  issue-regex@4.1.0:
-    resolution: {integrity: sha512-X3HBmm7+Th+l4/kMtqwcHHgELD0Lfl0Ina6S3+grr+mKmTxsrM84NAO1UuRPIxIbGLIl3TCEu45S1kdu21HYbQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   istextorbinary@9.5.0:
     resolution: {integrity: sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==}
@@ -5901,9 +5472,6 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  json-buffer@3.0.1:
-    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
-
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
@@ -5938,16 +5506,9 @@ packages:
   keytar@7.9.0:
     resolution: {integrity: sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==}
 
-  keyv@4.5.4:
-    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
-
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
-
-  latest-version@7.0.0:
-    resolution: {integrity: sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==}
-    engines: {node: '>=14.16'}
 
   lefthook-darwin-arm64@1.11.12:
     resolution: {integrity: sha512-nB3rZVGoign6lhlbdfT1/knk4fV4Kx7kgbho8oSFcpw/o2qRQpLqmclCWUTtf+Pyj4vCzE7hiee/m+uQtvu19w==}
@@ -6149,28 +5710,6 @@ packages:
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
-  listr-input@0.2.1:
-    resolution: {integrity: sha512-oa8iVG870qJq+OuuMK3DjGqFcwsK1SDu+kULp9kEq09TY231aideIZenr3lFOQdASpAr6asuyJBbX62/a3IIhg==}
-    engines: {node: '>=6'}
-
-  listr-silent-renderer@1.1.1:
-    resolution: {integrity: sha512-L26cIFm7/oZeSNVhWB6faeorXhMg4HNlb/dS/7jHhr708jxlXrtrBWo4YUxZQkc6dGoxEAe6J/D3juTRBUzjtA==}
-    engines: {node: '>=4'}
-
-  listr-update-renderer@0.5.0:
-    resolution: {integrity: sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==}
-    engines: {node: '>=6'}
-    peerDependencies:
-      listr: ^0.14.2
-
-  listr-verbose-renderer@0.5.0:
-    resolution: {integrity: sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==}
-    engines: {node: '>=4'}
-
-  listr@0.14.3:
-    resolution: {integrity: sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==}
-    engines: {node: '>=6'}
-
   lmdb@2.7.11:
     resolution: {integrity: sha512-x9bD4hVp7PFLUoELL8RglbNXhAMt5CYhkmss+CEau9KlNoilsTzNi9QDsPZb3KMpOGZXG6jmXhW3bBxE2XVztw==}
     hasBin: true
@@ -6183,17 +5722,9 @@ packages:
     resolution: {integrity: sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==}
     engines: {node: '>= 12.13.0'}
 
-  locate-path@5.0.0:
-    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
-    engines: {node: '>=8'}
-
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
-
-  locate-path@7.2.0:
-    resolution: {integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
@@ -6203,16 +5734,13 @@ packages:
 
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
 
   lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
-
-  lodash.isequal@4.5.0:
-    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
-    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
@@ -6241,30 +5769,15 @@ packages:
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
 
-  lodash.zip@4.2.0:
-    resolution: {integrity: sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==}
-
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
-  log-symbols@1.0.2:
-    resolution: {integrity: sha512-mmPrW0Fh2fxOzdBbFv4g1m6pR72haFLPJ2G5SJEELf1y+iaQrDG6cWCPjy54RHYbZAt7X+ls690Kw62AdWXBzQ==}
-    engines: {node: '>=0.10.0'}
-
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
-
-  log-symbols@5.1.0:
-    resolution: {integrity: sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==}
-    engines: {node: '>=12'}
-
-  log-update@2.3.0:
-    resolution: {integrity: sha512-vlP11XfFGyeNQlmEn9tJ66rEW1coA/79m5z6BCkudjbAGE83uhAcGYrBFwfs3AdLiLzGRusRPAbSPK9xZteCmg==}
-    engines: {node: '>=4'}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -6281,14 +5794,6 @@ packages:
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
-  lowercase-keys@2.0.0:
-    resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
-    engines: {node: '>=8'}
-
-  lowercase-keys@3.0.0:
-    resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -6302,10 +5807,6 @@ packages:
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
-
-  lru-cache@7.18.3:
-    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
-    engines: {node: '>=12'}
 
   lucide-react@0.548.0:
     resolution: {integrity: sha512-63b16z63jM9yc1MwxajHeuu0FRZFsDtljtDjYm26Kd86UQ5HQzu9ksEtoUUw4RBuewodw/tGFmvipePvRsKeDA==}
@@ -6400,13 +5901,6 @@ packages:
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
-
-  meow@12.1.1:
-    resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
-    engines: {node: '>=16.10'}
-
-  merge-stream@2.0.0:
-    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -6538,29 +6032,13 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  mimic-fn@1.2.0:
-    resolution: {integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==}
-    engines: {node: '>=4'}
-
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
-  mimic-fn@4.0.0:
-    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
-    engines: {node: '>=12'}
-
-  mimic-response@1.0.1:
-    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
-    engines: {node: '>=4'}
-
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
-
-  mimic-response@4.0.0:
-    resolution: {integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -6626,15 +6104,8 @@ packages:
   msgpackr@1.8.5:
     resolution: {integrity: sha512-mpPs3qqTug6ahbblkThoUY2DQdNXcm4IapwOS3Vm/87vmpzLVelvp9h3It1y9l1VPpiFLV11vfOXnmeEwiIXwg==}
 
-  mute-stream@0.0.7:
-    resolution: {integrity: sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==}
-
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
-
-  mute-stream@1.0.0:
-    resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -6659,10 +6130,6 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  new-github-release-url@2.0.0:
-    resolution: {integrity: sha512-NHDDGYudnvRutt/VhKFlX26IotXe1w0cmkDm6JGquh5bz/bDTw0LufSmH/GxTjEdpHEO+bVKFTwdrcGa/9XlKQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   next-themes@0.4.4:
     resolution: {integrity: sha512-LDQ2qIOJF0VnuVrrMSMLrWGjRMkq+0mpgl6e0juCLqdJ+oo8Q84JRWT6Wh11VDQKkMMe+dVzDKLWs5n87T+PkQ==}
     peerDependencies:
@@ -6678,6 +6145,7 @@ packages:
   next@16.0.7:
     resolution: {integrity: sha512-3mBRJyPxT4LOxAJI6IsXeFtKfiJUbjCLgvXO02fV8Wy/lIhPvP94Fe7dGhUgHXcQy4sSuYwQNcOLhIfOm0rL0A==}
     engines: {node: '>=20.9.0'}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -6741,10 +6209,6 @@ packages:
     resolution: {integrity: sha512-Pzr3rol8fvhG/oJjIq2NTVB0vmdNNlz22FENhhPojYRZ4/ee08CfK4YuKmuL54V9MLhI1kpzxfOJ/63LzmZzDg==}
     engines: {node: '>=14'}
 
-  normalize-package-data@3.0.3:
-    resolution: {integrity: sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==}
-    engines: {node: '>=10'}
-
   normalize-package-data@6.0.2:
     resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -6753,111 +6217,15 @@ packages:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
 
-  normalize-url@8.0.1:
-    resolution: {integrity: sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==}
-    engines: {node: '>=14.16'}
-
-  np@8.0.4:
-    resolution: {integrity: sha512-a4s1yESHcIwsrk/oaTekfbhb1R/2z2yyfVLX6Atl54w/9+QR01qeYyK3vMWgJ0UY+kYsGzQXausgvUX0pkmIMg==}
-    engines: {git: '>=2.11.0', node: '>=16.6.0', npm: '>=7.19.0', yarn: '>=1.7.0'}
-    hasBin: true
-
-  npm-name@7.1.1:
-    resolution: {integrity: sha512-lyOwsFndLoozriMEsaqJ5lXvhCATYOEhDvxlom8TNvB9a/htDXuLgpVhMUOBd9zCewUXCyBXAPxrGr2TK2adgQ==}
-    engines: {node: '>=12'}
-
-  npm-run-path@4.0.1:
-    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
-    engines: {node: '>=8'}
-
-  npm-run-path@5.3.0:
-    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   npm-to-yarn@3.0.1:
     resolution: {integrity: sha512-tt6PvKu4WyzPwWUzy/hvPFqn+uwXO0K1ZHka8az3NnrhWJDmSqI8ncWq0fkL0k/lmmi5tAC11FXwXuh0rFbt1A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  npm@9.7.1:
-    resolution: {integrity: sha512-kxMviaiLX4Lfnjy2dt7EWB87v5QdLiGpy04S2ORdKLmPqFhgy8g4cgJjQfnWob4mJIaNHjBO+hk45CvLlsZZ8g==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-    hasBin: true
-    bundledDependencies:
-      - '@isaacs/string-locale-compare'
-      - '@npmcli/arborist'
-      - '@npmcli/config'
-      - '@npmcli/map-workspaces'
-      - '@npmcli/package-json'
-      - '@npmcli/run-script'
-      - abbrev
-      - archy
-      - cacache
-      - chalk
-      - ci-info
-      - cli-columns
-      - cli-table3
-      - columnify
-      - fastest-levenshtein
-      - fs-minipass
-      - glob
-      - graceful-fs
-      - hosted-git-info
-      - ini
-      - init-package-json
-      - is-cidr
-      - json-parse-even-better-errors
-      - libnpmaccess
-      - libnpmdiff
-      - libnpmexec
-      - libnpmfund
-      - libnpmhook
-      - libnpmorg
-      - libnpmpack
-      - libnpmpublish
-      - libnpmsearch
-      - libnpmteam
-      - libnpmversion
-      - make-fetch-happen
-      - minimatch
-      - minipass
-      - minipass-pipeline
-      - ms
-      - node-gyp
-      - nopt
-      - npm-audit-report
-      - npm-install-checks
-      - npm-package-arg
-      - npm-pick-manifest
-      - npm-profile
-      - npm-registry-fetch
-      - npm-user-validate
-      - npmlog
-      - p-map
-      - pacote
-      - parse-conflict-json
-      - proc-log
-      - qrcode-terminal
-      - read
-      - semver
-      - sigstore
-      - ssri
-      - tar
-      - text-table
-      - tiny-relative-date
-      - treeverse
-      - validate-npm-package-name
-      - which
-      - write-file-atomic
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
-
-  number-is-nan@1.0.1:
-    resolution: {integrity: sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==}
-    engines: {node: '>=0.10.0'}
 
   nwsapi@2.2.16:
     resolution: {integrity: sha512-F1I/bimDpj3ncaNDhfyMWuFqmQDBwDB0Fogc2qpL3BWvkQteFD/8BzWuIRl83rq0DXfm8SGt/HFhLXZyljTXcQ==}
@@ -6889,17 +6257,9 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
-  onetime@2.0.1:
-    resolution: {integrity: sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==}
-    engines: {node: '>=4'}
-
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
-
-  onetime@6.0.0:
-    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
-    engines: {node: '>=12'}
 
   oniguruma-parser@0.12.1:
     resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
@@ -6911,10 +6271,6 @@ packages:
     resolution: {integrity: sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==}
     engines: {node: '>=18'}
 
-  open@9.1.0:
-    resolution: {integrity: sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==}
-    engines: {node: '>=14.16'}
-
   ora@5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
     engines: {node: '>=10'}
@@ -6925,63 +6281,24 @@ packages:
   ordered-binary@1.5.3:
     resolution: {integrity: sha512-oGFr3T+pYdTGJ+YFEILMpS3es+GiIbs9h/XQrclBXUtd44ey7XwfsMzM31f64I1SQOawDoDr/D823kNCADI8TA==}
 
-  org-regex@1.0.0:
-    resolution: {integrity: sha512-7bqkxkEJwzJQUAlyYniqEZ3Ilzjh0yoa62c7gL6Ijxj5bEpPL+8IE1Z0PFj0ywjjXQcdrwR51g9MIcLezR0hKQ==}
-    engines: {node: '>=8'}
-
   os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
 
-  ow@1.1.1:
-    resolution: {integrity: sha512-sJBRCbS5vh1Jp9EOgwp1Ws3c16lJrUkJYlvWTYC03oyiYVwS/ns7lKRWow4w4XjDyTrA2pplQv4B2naWSR6yDA==}
-    engines: {node: '>=14.16'}
-
   oxc-transform@0.51.0:
     resolution: {integrity: sha512-5hmju6LD5cGXWzvweduIg9hCcBKWMIq2ILvwwiKEgb03cxPoKYsx65FfITJPVOkBzHFYRGri2AXo/mY1DJRmJQ==}
-
-  p-cancelable@2.1.1:
-    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
-    engines: {node: '>=8'}
-
-  p-cancelable@3.0.0:
-    resolution: {integrity: sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==}
-    engines: {node: '>=12.20'}
 
   p-finally@1.0.0:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
     engines: {node: '>=4'}
 
-  p-limit@2.3.0:
-    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
-    engines: {node: '>=6'}
-
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
-  p-limit@4.0.0:
-    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  p-locate@4.1.0:
-    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
-    engines: {node: '>=8'}
-
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
-
-  p-locate@6.0.0:
-    resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  p-lock@2.1.0:
-    resolution: {integrity: sha512-pi2yT8gNhVrV4LgsUvJWQy58TXH1HG2+NXDby9+UrsS/9fXb0FJH9aCxbdHJ0EAQ6XC7ggSP6GAzuR5puDArUQ==}
-
-  p-map@2.1.0:
-    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
-    engines: {node: '>=6'}
 
   p-map@3.0.0:
     resolution: {integrity: sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==}
@@ -6991,14 +6308,6 @@ packages:
     resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
     engines: {node: '>=10'}
 
-  p-map@5.5.0:
-    resolution: {integrity: sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==}
-    engines: {node: '>=12'}
-
-  p-memoize@7.1.1:
-    resolution: {integrity: sha512-DZ/bONJILHkQ721hSr/E9wMz5Am/OTJ9P6LhLFo2Tu+jL8044tgc9LwHO8g4PiaYePnlVVRAJcKmgy8J9MVFrA==}
-    engines: {node: '>=14.16'}
-
   p-queue@6.6.2:
     resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
     engines: {node: '>=8'}
@@ -7007,23 +6316,8 @@ packages:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
     engines: {node: '>=8'}
 
-  p-timeout@6.1.2:
-    resolution: {integrity: sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==}
-    engines: {node: '>=14.16'}
-
-  p-try@2.2.0:
-    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
-    engines: {node: '>=6'}
-
   package-json-from-dist@1.0.0:
     resolution: {integrity: sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==}
-
-  package-json@8.1.1:
-    resolution: {integrity: sha512-cbH9IAIJHNj9uXi196JVsRlt7cHKak6u/e6AkL/bkRelZ7rlL3X1YKxsZwa36xipOEKAsdtmaG6aAJoM1fx2zA==}
-    engines: {node: '>=14.16'}
-
-  package-name-conflict@1.0.3:
-    resolution: {integrity: sha512-DPBNWSUWC0wPofXeNThao0uP4a93J7r90UyhagmJS0QcacTTkorZwXYsOop70phn1hKdcf/2e9lJIhazS8bx5A==}
 
   pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
@@ -7042,12 +6336,6 @@ packages:
 
   parse-entities@4.0.1:
     resolution: {integrity: sha512-SWzvYcSJh4d/SGLIOQfZ/CoNv6BTlI6YEQ7Nj82oDVnRpwe/Z/F1EMx42x3JAOwGBlCjeCH0BRJQbQ/opHL17w==}
-
-  parse-json-object@1.1.0:
-    resolution: {integrity: sha512-4w5s6uJY1tW9REY8UwUOyaZKSKsrbQrMEzlV/Le/g5t4iMWuuyK83pZZ0OZimSOL9iyv2ORvRSgz71Ekd7iD3g==}
-
-  parse-json-object@2.0.1:
-    resolution: {integrity: sha512-/oF7PUUBjCqHmMEE6xIQeX5ZokQ9+miudACzPt4KBU2qi6CxZYPdisPXx4ad7wpZJYi2ZpcW2PacLTU3De3ebw==}
 
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
@@ -7082,10 +6370,6 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
-  path-exists@5.0.0:
-    resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -7093,10 +6377,6 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-
-  path-key@4.0.0:
-    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
-    engines: {node: '>=12'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -7155,14 +6435,6 @@ packages:
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
-
-  pkg-dir@4.2.0:
-    resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
-    engines: {node: '>=8'}
-
-  pkg-dir@7.0.0:
-    resolution: {integrity: sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==}
-    engines: {node: '>=14.16'}
 
   pluralize@2.0.0:
     resolution: {integrity: sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==}
@@ -7430,6 +6702,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prettier@2.8.8:
@@ -7450,10 +6723,6 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
-  progress@2.0.3:
-    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
-    engines: {node: '>=0.4.0'}
-
   promise.series@0.2.0:
     resolution: {integrity: sha512-VWQJyU2bcDTgZw8kpfBpB/ejZASlCrzwz5f2hjb/zlujOEB4oeiAhHygAWq8ubsX2GVkD4kCU5V2dwOTaCY5EQ==}
     engines: {node: '>=0.12'}
@@ -7464,9 +6733,6 @@ packages:
 
   property-information@7.0.0:
     resolution: {integrity: sha512-7D/qOz/+Y4X/rzSB6jKxKUsQnphO046ei8qxG59mtM3RG3DHgTK81HrxrmoDVINJb8NKT5ZsRbwHvQ6B68Iyhg==}
-
-  proto-list@1.2.4:
-    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
@@ -7482,10 +6748,6 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  pupa@3.1.0:
-    resolution: {integrity: sha512-FLpr4flz5xZTSJxSeaheeMKN/EDzMdK7b8PTOC6a5PYFKTucWbdqjgqaEyH0shFiSJrVB1+Qqi4Tk19ccU6Aug==}
-    engines: {node: '>=12.20'}
-
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
@@ -7495,10 +6757,6 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-
-  quick-lru@5.1.1:
-    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
-    engines: {node: '>=10'}
 
   radix-ui@1.4.3:
     resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
@@ -7607,20 +6865,6 @@ packages:
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
-  read-file-safe@1.0.10:
-    resolution: {integrity: sha512-qW25fd2uMX3dV6Ui/R0jYK1MhTpjx8FO/VHaHTXzwWsGnkNwLRcqYfCXd9qDM+NZ273DPUvP2RaimYuLSu1K/g==}
-
-  read-json-safe@1.0.5:
-    resolution: {integrity: sha512-SJyNY/U9+vW35FPus22Qvv1oilnR7PCfN2E70uKQEGaJS313A5/cz9Yhv7ZtWzZ+XIwrtEPxXf10BOyYemHehA==}
-
-  read-pkg-up@9.1.0:
-    resolution: {integrity: sha512-vaMRR1AC1nrd5CQM0PhlRsO5oc2AAigqr7cCrZ/MW/Rsaflz4RlgzkpL4qoU/z1F6wrbd85iFv1OQj/y5RdGvg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  read-pkg@7.1.0:
-    resolution: {integrity: sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==}
-    engines: {node: '>=12.20'}
-
   read-pkg@8.1.0:
     resolution: {integrity: sha512-PORM8AgzXeskHO/WEv312k9U03B8K9JSiWF/8N9sUuFjBa+9SF2u6K7VClzXwDXab51jCd8Nd36CNM+zR97ScQ==}
     engines: {node: '>=16'}
@@ -7689,21 +6933,9 @@ packages:
   registry-auth-token@3.3.2:
     resolution: {integrity: sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==}
 
-  registry-auth-token@4.2.2:
-    resolution: {integrity: sha512-PC5ZysNb42zpFME6D/XlIgtNGdTl8bBOCw90xQLVMpzuuubJKYDWFAEuUNc+Cn8Z8724tg2SDhDRrkVEsqfDMg==}
-    engines: {node: '>=6.0.0'}
-
-  registry-auth-token@5.0.2:
-    resolution: {integrity: sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==}
-    engines: {node: '>=14'}
-
   registry-url@3.1.0:
     resolution: {integrity: sha512-ZbgR5aZEdf4UKZVBPYIgaglBmSF2Hi94s2PcIHhRGFjKYu+chjJdYfHn4rt3hB6eCKLJ8giVIIfgMa1ehDfZKA==}
     engines: {node: '>=0.10.0'}
-
-  registry-url@6.0.1:
-    resolution: {integrity: sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==}
-    engines: {node: '>=12'}
 
   regjsgen@0.8.0:
     resolution: {integrity: sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==}
@@ -7753,13 +6985,6 @@ packages:
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
-  resolve-alpn@1.2.1:
-    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
-
-  resolve-cwd@3.0.0:
-    resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
-    engines: {node: '>=8'}
-
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -7771,17 +6996,6 @@ packages:
   resolve@1.22.8:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
     hasBin: true
-
-  responselike@2.0.1:
-    resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
-
-  responselike@3.0.0:
-    resolution: {integrity: sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==}
-    engines: {node: '>=14.16'}
-
-  restore-cursor@2.0.0:
-    resolution: {integrity: sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==}
-    engines: {node: '>=4'}
 
   restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
@@ -7842,20 +7056,12 @@ packages:
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
-  run-applescript@5.0.0:
-    resolution: {integrity: sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==}
-    engines: {node: '>=12'}
-
   run-applescript@7.0.0:
     resolution: {integrity: sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==}
     engines: {node: '>=18'}
 
   run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
-    engines: {node: '>=0.12.0'}
-
-  run-async@3.0.0:
-    resolution: {integrity: sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==}
     engines: {node: '>=0.12.0'}
 
   run-parallel@1.2.0:
@@ -7887,10 +7093,6 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
-  scoped-regex@3.0.0:
-    resolution: {integrity: sha512-yEsN6TuxZhZ1Tl9iB81frTNS292m0I/IG7+w8lTvfcJQP2x3vnpOoevjBoE3Np5A6KnZM2+RtVenihj9t6NiYg==}
-    engines: {node: '>=12'}
-
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
@@ -7898,10 +7100,6 @@ packages:
     resolution: {integrity: sha512-iNOzgMX/+W1SQNW/TW6eikGChyaPiazr2AEXjzjpoB0R6QJEulvlwhn0KLT1/xjPfdYrk3yiXZM40csUqET8uQ==}
     engines: {node: ^14.13.1 || >=16.0.0}
     hasBin: true
-
-  semver-diff@4.0.0:
-    resolution: {integrity: sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==}
-    engines: {node: '>=12'}
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -8006,17 +7204,9 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
-  slash@4.0.0:
-    resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
-    engines: {node: '>=12'}
-
   slash@5.1.0:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
-
-  slice-ansi@0.0.4:
-    resolution: {integrity: sha512-up04hB2hR92PgjpyU3y/eg91yIBILyjVY26NvvciY3EVVPjybkMszMpXQ9QAkcS3I5rtJBDLoTxxg+qvW8c7rw==}
-    engines: {node: '>=0.10.0'}
 
   slice-ansi@4.0.0:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
@@ -8092,14 +7282,6 @@ packages:
   string-hash@1.1.3:
     resolution: {integrity: sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==}
 
-  string-width@1.0.2:
-    resolution: {integrity: sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==}
-    engines: {node: '>=0.10.0'}
-
-  string-width@2.1.1:
-    resolution: {integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==}
-    engines: {node: '>=4'}
-
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -8114,32 +7296,12 @@ packages:
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
-  strip-ansi@3.0.1:
-    resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==}
-    engines: {node: '>=0.10.0'}
-
-  strip-ansi@4.0.0:
-    resolution: {integrity: sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==}
-    engines: {node: '>=4'}
-
-  strip-ansi@5.2.0:
-    resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
-    engines: {node: '>=6'}
-
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
-    engines: {node: '>=12'}
-
-  strip-final-newline@2.0.0:
-    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
-    engines: {node: '>=6'}
-
-  strip-final-newline@3.0.0:
-    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
 
   strip-indent@3.0.0:
@@ -8189,10 +7351,6 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
-  supports-color@2.0.0:
-    resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}
-    engines: {node: '>=0.8.0'}
-
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -8229,14 +7387,6 @@ packages:
   swap-case@1.1.2:
     resolution: {integrity: sha512-BAmWG6/bx8syfc6qXPprof3Mn5vQgf5dwdUNJhsNqU9WdPt5P+ES/wQ5bxfijy8zwZgZZHslC3iAsxsuQMCzJQ==}
 
-  symbol-observable@1.2.0:
-    resolution: {integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==}
-    engines: {node: '>=0.10.0'}
-
-  symbol-observable@4.0.0:
-    resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
-    engines: {node: '>=0.10'}
-
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -8264,10 +7414,6 @@ packages:
   terminal-link@2.1.1:
     resolution: {integrity: sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==}
     engines: {node: '>=8'}
-
-  terminal-link@3.0.0:
-    resolution: {integrity: sha512-flFL3m4wuixmf6IfhFJd1YPiLiMuxEc8uHRM1buzIeZPm22Au2pDqBJQgdo7n1WfPU1ONFGv7YDwpFBmHGF6lg==}
-    engines: {node: '>=12'}
 
   terser@5.39.0:
     resolution: {integrity: sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==}
@@ -8328,10 +7474,6 @@ packages:
 
   title-case@2.1.1:
     resolution: {integrity: sha512-EkJoZ2O3zdCz3zJsYCsxyq2OC5hrxR9mfdd5I+w8h/tmFfeOxJ+vvkxsKxdmN0WtS9zLdHEgfgVOiMVgv+Po4Q==}
-
-  titleize@3.0.0:
-    resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}
-    engines: {node: '>=12'}
 
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
@@ -8462,14 +7604,6 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
-  type-fest@1.4.0:
-    resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
-    engines: {node: '>=10'}
-
-  type-fest@2.19.0:
-    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
-    engines: {node: '>=12.20'}
-
   type-fest@3.13.1:
     resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
     engines: {node: '>=14.16'}
@@ -8480,18 +7614,6 @@ packages:
 
   typed-rest-client@1.8.11:
     resolution: {integrity: sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==}
-
-  typedarray-to-buffer@3.1.5:
-    resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
-
-  types-eslintrc@1.0.3:
-    resolution: {integrity: sha512-zKTR6aKHEudQpl+JoZjS3qh0B5IzSpQK/BCpYBECujcnKtqL87DJJ1sJKe5B8k/y8/UJ5sukq42QDvlaJyCO2w==}
-
-  types-json@1.2.2:
-    resolution: {integrity: sha512-VfVLISHypS7ayIHvhacOESOTib4Sm4mAhnsgR8fzQdGp89YoBwMqvGmqENjtYehUQzgclT+7NafpEXkK/MHKwA==}
-
-  types-pkg-json@1.2.1:
-    resolution: {integrity: sha512-Wj75lCkPwfj1BhmaJxMPpTQj9YGpihjs3WICigt1IjTAswr7zPXP0iJYPZjU0Rw/IriODhMJjAImkCIxt9KeuQ==}
 
   typescript-paths@1.5.1:
     resolution: {integrity: sha512-lYErSLCON2MSplVV5V/LBgD4UNjMgY3guATdFCZY2q1Nr6OZEu4q6zX/rYMsG1TaWqqQSszg6C9EU7AGWMDrIw==}
@@ -8569,10 +7691,6 @@ packages:
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
-  unique-string@3.0.0:
-    resolution: {integrity: sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==}
-    engines: {node: '>=12'}
-
   unist-util-is@6.0.0:
     resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
 
@@ -8602,10 +7720,6 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  untildify@4.0.0:
-    resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
-    engines: {node: '>=8'}
-
   update-browserslist-db@1.1.0:
     resolution: {integrity: sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==}
     hasBin: true
@@ -8620,10 +7734,6 @@ packages:
 
   update-check@1.5.4:
     resolution: {integrity: sha512-5YHsflzHP4t1G+8WGPlvKbJEbAJGCgw+Em+dGR1KmBUbr1J36SJBqlHLjR7oob7sco5hWHGQVcr9B2poIVDDTQ==}
-
-  update-notifier@6.0.2:
-    resolution: {integrity: sha512-EDxhTEVPZZRLWYcJ4ZXjGFN0oP7qYvbXWzEgRm/Yql4dHX5wDbvh89YHP6PK1lzZJYrMtXUuZZz8XGK+U6U1og==}
-    engines: {node: '>=14.16'}
 
   upper-case-first@1.1.2:
     resolution: {integrity: sha512-wINKYvI3Db8dtjikdAqoBbZoP6Q+PZUyfMR7pmwHzjC2quzSkUq5DmPrTtPEqHaz8AGtmsB4TqwapMTM1QAQOQ==}
@@ -8676,20 +7786,14 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
-  vali-date@1.0.0:
-    resolution: {integrity: sha512-sgECfZthyaCKW10N0fm27cg8HYTFK5qMWgypqkXMQ4Wbl/zZKx7xZICgcoxIIE+WFAP/MBL2EFwC/YvLxw3Zeg==}
-    engines: {node: '>=0.10.0'}
-
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
-
-  validate-npm-package-name@3.0.0:
-    resolution: {integrity: sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==}
 
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
@@ -8816,6 +7920,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -8850,16 +7955,8 @@ packages:
     resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==}
     engines: {node: '>=8'}
 
-  widest-line@4.0.1:
-    resolution: {integrity: sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==}
-    engines: {node: '>=12'}
-
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
-
-  wrap-ansi@3.0.1:
-    resolution: {integrity: sha512-iXR3tDXpbnTpzjKSylUJRkLuOrEC7hwEB221cgn6wtF8wpmz28puFXAEfPT5zrjM3wahygB//VuWEr1vTkDcNQ==}
-    engines: {node: '>=4'}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -8876,9 +7973,6 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  write-file-atomic@3.0.3:
-    resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
-
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
     engines: {node: '>=10.0.0'}
@@ -8890,10 +7984,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-
-  xdg-basedir@5.1.0:
-    resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
-    engines: {node: '>=12'}
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -8948,14 +8038,6 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-
-  yocto-queue@1.1.1:
-    resolution: {integrity: sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==}
-    engines: {node: '>=12.20'}
-
-  yoctocolors-cjs@2.1.2:
-    resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
-    engines: {node: '>=18'}
 
   zod-validation-error@3.5.3:
     resolution: {integrity: sha512-OT5Y8lbUadqVZCsnyFaTQ4/O2mys4tj7PqhdbBCp7McPwvIEKfPtdA6QfPeFQK2/Rz5LgwmAXRJTugBNBi0btw==}
@@ -9895,6 +8977,20 @@ snapshots:
       '@types/react': 19.1.9
       date-fns: 4.1.0
 
+  '@base-ui/react@1.4.1(@date-fns/tz@1.2.0)(@types/react@19.2.2)(date-fns@4.1.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@base-ui/utils': 0.2.8(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      use-sync-external-store: 1.6.0(react@19.2.1)
+    optionalDependencies:
+      '@date-fns/tz': 1.2.0
+      '@types/react': 19.2.2
+      date-fns: 4.1.0
+
   '@base-ui/utils@0.2.6(@types/react@19.1.9)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@babel/runtime': 7.28.6
@@ -9917,11 +9013,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.9
 
-  '@bconnorwhite/module@2.0.2':
+  '@base-ui/utils@0.2.8(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      find-up: 5.0.0
-      read-json-safe: 1.0.5
-      types-pkg-json: 1.2.1
+      '@babel/runtime': 7.29.2
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.2.2
 
   '@biomejs/biome@2.3.8':
     optionalDependencies:
@@ -10292,8 +9393,6 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.4':
     optional: true
-
-  '@inquirer/figures@1.0.3': {}
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -10930,6 +10029,7 @@ snapshots:
       '@parcel/types': 2.12.0(@parcel/core@2.12.0)
     transitivePeerDependencies:
       - '@parcel/core'
+      - '@swc/helpers'
 
   '@parcel/plugin@2.9.2(@parcel/core@2.12.0)':
     dependencies:
@@ -11082,7 +10182,7 @@ snapshots:
       '@parcel/source-map': 2.1.1
       '@parcel/utils': 2.9.2
       '@parcel/workers': 2.9.2(@parcel/core@2.9.2)
-      '@swc/helpers': 0.5.12
+      '@swc/helpers': 0.5.15
       browserslist: 4.23.2
       nullthrows: 1.1.1
       regenerator-runtime: 0.13.11
@@ -11348,6 +10448,8 @@ snapshots:
       '@parcel/types': 2.12.0(@parcel/core@2.12.0)
       '@parcel/utils': 2.12.0
       nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@swc/helpers'
 
   '@parcel/workers@2.9.2(@parcel/core@2.12.0)':
     dependencies:
@@ -11371,18 +10473,6 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
-
-  '@pnpm/config.env-replace@1.1.0': {}
-
-  '@pnpm/network.ca-file@1.0.2':
-    dependencies:
-      graceful-fs: 4.2.10
-
-  '@pnpm/npm-conf@2.2.2':
-    dependencies:
-      '@pnpm/config.env-replace': 1.1.0
-      '@pnpm/network.ca-file': 1.0.2
-      config-chain: 1.1.13
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -12213,6 +11303,28 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react-dom'
 
+  '@raystack/apsara@1.0.1(@date-fns/tz@1.2.0)(@types/react@19.2.2)(date-fns@4.1.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@base-ui/react': 1.4.1(@date-fns/tz@1.2.0)(@types/react@19.2.2)(date-fns@4.1.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@base-ui/utils': 0.2.8(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-icons': 1.3.2(react@19.2.1)
+      '@tanstack/match-sorter-utils': 8.8.4
+      '@tanstack/react-table': 8.9.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@tanstack/react-virtual': 3.13.13(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@tanstack/table-core': 8.9.2
+      class-variance-authority: 0.7.1
+      culori: 4.0.2
+      dayjs: 1.11.20
+      prism-react-renderer: 2.4.1(react@19.2.1)
+      react: 19.2.1
+      react-day-picker: 9.6.7(react@19.2.1)
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.2.2
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - date-fns
+
   '@rollup/plugin-commonjs@25.0.2(rollup@3.25.1)':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@3.25.1)
@@ -12318,14 +11430,6 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.48.1':
     optional: true
-
-  '@samverschueren/stream-to-observable@0.3.1(rxjs@6.6.7)':
-    dependencies:
-      any-observable: 0.3.0(rxjs@6.6.7)
-    optionalDependencies:
-      rxjs: 6.6.7
-    transitivePeerDependencies:
-      - zenObservable
 
   '@secretlint/config-creator@9.3.4':
     dependencies:
@@ -12478,10 +11582,6 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
-
-  '@sindresorhus/is@4.6.0': {}
-
-  '@sindresorhus/is@5.6.0': {}
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
@@ -12677,10 +11777,6 @@ snapshots:
 
   '@swc/counter@0.1.3': {}
 
-  '@swc/helpers@0.5.12':
-    dependencies:
-      tslib: 2.6.3
-
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -12692,14 +11788,6 @@ snapshots:
   '@swc/types@0.1.9':
     dependencies:
       '@swc/counter': 0.1.3
-
-  '@szmarczak/http-timer@4.0.6':
-    dependencies:
-      defer-to-connect: 2.0.1
-
-  '@szmarczak/http-timer@5.0.1':
-    dependencies:
-      defer-to-connect: 2.0.1
 
   '@tanstack/match-sorter-utils@8.8.4':
     dependencies:
@@ -12837,13 +11925,6 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
-  '@types/cacheable-request@6.0.3':
-    dependencies:
-      '@types/http-cache-semantics': 4.0.4
-      '@types/keyv': 3.1.4
-      '@types/node': 24.10.0
-      '@types/responselike': 1.0.3
-
   '@types/chai@5.2.2':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -12873,16 +11954,10 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.2
 
-  '@types/http-cache-semantics@4.0.4': {}
-
   '@types/inquirer@6.5.0':
     dependencies:
       '@types/through': 0.0.33
       rxjs: 6.6.7
-
-  '@types/keyv@3.1.4':
-    dependencies:
-      '@types/node': 24.10.0
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -12926,10 +12001,6 @@ snapshots:
 
   '@types/resolve@1.20.2': {}
 
-  '@types/responselike@1.0.3':
-    dependencies:
-      '@types/node': 24.10.0
-
   '@types/sarif@2.1.7': {}
 
   '@types/through@0.0.33':
@@ -12946,7 +12017,7 @@ snapshots:
     dependencies:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.5
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
@@ -13109,11 +12180,6 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  aggregate-error@4.0.1:
-    dependencies:
-      clean-stack: 4.2.0
-      indent-string: 5.0.0
-
   ajv@8.17.1:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -13121,39 +12187,17 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  all-package-names@2.0.897:
-    dependencies:
-      commander-version: 1.1.0
-      p-lock: 2.1.0
-      parse-json-object: 2.0.1
-      progress: 2.0.3
-      types-json: 1.2.2
-
   ansi-align@3.0.1:
     dependencies:
       string-width: 4.2.3
-
-  ansi-escapes@3.2.0: {}
 
   ansi-escapes@4.3.2:
     dependencies:
       type-fest: 0.21.3
 
-  ansi-escapes@5.0.0:
-    dependencies:
-      type-fest: 1.4.0
-
-  ansi-regex@2.1.1: {}
-
-  ansi-regex@3.0.1: {}
-
-  ansi-regex@4.1.1: {}
-
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.0.1: {}
-
-  ansi-styles@2.2.1: {}
 
   ansi-styles@3.2.1:
     dependencies:
@@ -13166,10 +12210,6 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.1: {}
-
-  any-observable@0.3.0(rxjs@6.6.7):
-    optionalDependencies:
-      rxjs: 6.6.7
 
   any-promise@1.3.0: {}
 
@@ -13257,8 +12297,6 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  big-integer@1.6.52: {}
-
   binaryextensions@6.11.0:
     dependencies:
       editions: 6.21.0
@@ -13284,21 +12322,6 @@ snapshots:
       widest-line: 3.1.0
       wrap-ansi: 7.0.0
 
-  boxen@7.1.1:
-    dependencies:
-      ansi-align: 3.0.1
-      camelcase: 7.0.1
-      chalk: 5.3.0
-      cli-boxes: 3.0.0
-      string-width: 5.1.2
-      type-fest: 2.19.0
-      widest-line: 4.0.1
-      wrap-ansi: 8.1.0
-
-  bplist-parser@0.2.0:
-    dependencies:
-      big-integer: 1.6.52
-
   brace-expansion@1.1.11:
     dependencies:
       balanced-match: 1.0.2
@@ -13318,7 +12341,7 @@ snapshots:
 
   browserslist@4.23.2:
     dependencies:
-      caniuse-lite: 1.0.30001642
+      caniuse-lite: 1.0.30001701
       electron-to-chromium: 1.4.827
       node-releases: 2.0.14
       update-browserslist-db: 1.1.0(browserslist@4.23.2)
@@ -13344,41 +12367,11 @@ snapshots:
 
   builtin-modules@3.3.0: {}
 
-  builtins@1.0.3: {}
-
-  bundle-name@3.0.0:
-    dependencies:
-      run-applescript: 5.0.0
-
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.0.0
 
   cac@6.7.14: {}
-
-  cacheable-lookup@5.0.4: {}
-
-  cacheable-lookup@7.0.0: {}
-
-  cacheable-request@10.2.14:
-    dependencies:
-      '@types/http-cache-semantics': 4.0.4
-      get-stream: 6.0.1
-      http-cache-semantics: 4.1.1
-      keyv: 4.5.4
-      mimic-response: 4.0.0
-      normalize-url: 8.0.1
-      responselike: 3.0.0
-
-  cacheable-request@7.0.4:
-    dependencies:
-      clone-response: 1.0.3
-      get-stream: 5.2.0
-      http-cache-semantics: 4.1.1
-      keyv: 4.5.4
-      lowercase-keys: 2.0.0
-      normalize-url: 6.1.0
-      responselike: 2.0.1
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -13400,8 +12393,6 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  callsites@4.2.0: {}
-
   camel-case@3.0.0:
     dependencies:
       no-case: 2.3.2
@@ -13409,16 +12400,12 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  camelcase@7.0.1: {}
-
   caniuse-api@3.0.0:
     dependencies:
       browserslist: 4.23.2
       caniuse-lite: 1.0.30001701
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
-
-  caniuse-lite@1.0.30001642: {}
 
   caniuse-lite@1.0.30001701: {}
 
@@ -13431,14 +12418,6 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.2.1
       pathval: 2.0.1
-
-  chalk@1.1.3:
-    dependencies:
-      ansi-styles: 2.2.1
-      escape-string-regexp: 1.0.5
-      has-ansi: 2.0.0
-      strip-ansi: 3.0.1
-      supports-color: 2.0.0
 
   chalk@2.4.2:
     dependencies:
@@ -13455,8 +12434,6 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-
-  chalk@5.3.0: {}
 
   change-case@3.1.0:
     dependencies:
@@ -13523,25 +12500,13 @@ snapshots:
 
   chrome-trace-event@1.0.4: {}
 
-  ci-info@3.9.0: {}
-
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
 
   clean-stack@2.2.0: {}
 
-  clean-stack@4.2.0:
-    dependencies:
-      escape-string-regexp: 5.0.0
-
   cli-boxes@2.2.1: {}
-
-  cli-boxes@3.0.0: {}
-
-  cli-cursor@2.1.0:
-    dependencies:
-      restore-cursor: 2.0.0
 
   cli-cursor@3.1.0:
     dependencies:
@@ -13549,16 +12514,7 @@ snapshots:
 
   cli-spinners@2.9.2: {}
 
-  cli-truncate@0.2.1:
-    dependencies:
-      slice-ansi: 0.0.4
-      string-width: 1.0.2
-
-  cli-width@2.2.1: {}
-
   cli-width@3.0.0: {}
-
-  cli-width@4.1.0: {}
 
   client-only@0.0.1: {}
 
@@ -13567,10 +12523,6 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
-
-  clone-response@1.0.3:
-    dependencies:
-      mimic-response: 1.0.1
 
   clone@1.0.4: {}
 
@@ -13593,8 +12545,6 @@ snapshots:
   cockatiel@3.2.1: {}
 
   code-block-writer@13.0.3: {}
-
-  code-point-at@1.1.0: {}
 
   collapse-white-space@2.1.0: {}
 
@@ -13633,11 +12583,6 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
-  commander-version@1.1.0:
-    dependencies:
-      '@bconnorwhite/module': 2.0.2
-      commander: 6.2.1
-
   commander@10.0.1: {}
 
   commander@11.1.0: {}
@@ -13648,8 +12593,6 @@ snapshots:
     optional: true
 
   commander@4.1.1: {}
-
-  commander@6.2.1: {}
 
   commander@7.2.0: {}
 
@@ -13674,19 +12617,6 @@ snapshots:
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
-
-  config-chain@1.1.13:
-    dependencies:
-      ini: 1.3.8
-      proto-list: 1.2.4
-
-  configstore@6.0.0:
-    dependencies:
-      dot-prop: 6.0.1
-      graceful-fs: 4.2.11
-      unique-string: 3.0.0
-      write-file-atomic: 3.0.3
-      xdg-basedir: 5.1.0
 
   constant-case@2.0.0:
     dependencies:
@@ -13721,21 +12651,11 @@ snapshots:
 
   create-require@1.1.1: {}
 
-  cross-spawn@7.0.3:
-    dependencies:
-      path-key: 3.1.1
-      shebang-command: 2.0.0
-      which: 2.0.2
-
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-
-  crypto-random-string@4.0.0:
-    dependencies:
-      type-fest: 1.4.0
 
   css-declaration-sorter@6.4.1(postcss@8.4.24):
     dependencies:
@@ -13846,8 +12766,6 @@ snapshots:
 
   date-fns-jalali@4.1.0-0: {}
 
-  date-fns@1.30.1: {}
-
   date-fns@4.1.0: {}
 
   dayjs@1.11.20: {}
@@ -13869,6 +12787,7 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
+    optional: true
 
   deep-eql@5.0.2: {}
 
@@ -13897,19 +12816,7 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
-  default-browser-id@3.0.0:
-    dependencies:
-      bplist-parser: 0.2.0
-      untildify: 4.0.0
-
   default-browser-id@5.0.0: {}
-
-  default-browser@4.0.0:
-    dependencies:
-      bundle-name: 3.0.0
-      default-browser-id: 3.0.0
-      execa: 7.2.0
-      titleize: 3.0.0
 
   default-browser@5.2.1:
     dependencies:
@@ -13919,8 +12826,6 @@ snapshots:
   defaults@1.0.4:
     dependencies:
       clone: 1.0.4
-
-  defer-to-connect@2.0.1: {}
 
   define-data-property@1.1.4:
     dependencies:
@@ -13946,17 +12851,6 @@ snapshots:
       p-map: 3.0.0
       rimraf: 3.0.2
       slash: 3.0.0
-
-  del@7.1.0:
-    dependencies:
-      globby: 13.2.2
-      graceful-fs: 4.2.11
-      is-glob: 4.0.3
-      is-path-cwd: 3.0.0
-      is-path-inside: 4.0.0
-      p-map: 5.5.0
-      rimraf: 3.0.2
-      slash: 4.0.0
 
   delayed-stream@1.0.0: {}
 
@@ -14026,15 +12920,7 @@ snapshots:
   dot-case@3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.3
-
-  dot-prop@6.0.1:
-    dependencies:
-      is-obj: 2.0.0
-
-  dot-prop@7.2.0:
-    dependencies:
-      type-fest: 2.19.0
+      tslib: 2.8.1
 
   dotenv-expand@5.1.0: {}
 
@@ -14064,8 +12950,6 @@ snapshots:
 
   electron-to-chromium@1.5.109: {}
 
-  elegant-spinner@1.0.1: {}
-
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -14078,6 +12962,7 @@ snapshots:
   end-of-stream@1.4.4:
     dependencies:
       once: 1.4.0
+    optional: true
 
   entities@2.2.0: {}
 
@@ -14194,8 +13079,6 @@ snapshots:
 
   escalade@3.2.0: {}
 
-  escape-goat@4.0.0: {}
-
   escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@5.0.0: {}
@@ -14250,32 +13133,6 @@ snapshots:
   esutils@2.0.3: {}
 
   eventemitter3@4.0.7: {}
-
-  execa@5.1.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      get-stream: 6.0.1
-      human-signals: 2.1.0
-      is-stream: 2.0.1
-      merge-stream: 2.0.0
-      npm-run-path: 4.0.1
-      onetime: 5.1.2
-      signal-exit: 3.0.7
-      strip-final-newline: 2.0.0
-
-  execa@7.2.0:
-    dependencies:
-      cross-spawn: 7.0.3
-      get-stream: 6.0.1
-      human-signals: 4.3.1
-      is-stream: 3.0.0
-      merge-stream: 2.0.0
-      npm-run-path: 5.3.0
-      onetime: 6.0.0
-      signal-exit: 3.0.7
-      strip-final-newline: 3.0.0
-
-  exit-hook@3.2.0: {}
 
   expand-template@2.0.3:
     optional: true
@@ -14332,15 +13189,6 @@ snapshots:
 
   fflate@0.8.2: {}
 
-  figures@1.7.0:
-    dependencies:
-      escape-string-regexp: 1.0.5
-      object-assign: 4.1.1
-
-  figures@2.0.0:
-    dependencies:
-      escape-string-regexp: 1.0.5
-
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -14349,20 +13197,10 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  find-up@4.1.0:
-    dependencies:
-      locate-path: 5.0.0
-      path-exists: 4.0.0
-
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
-
-  find-up@6.3.0:
-    dependencies:
-      locate-path: 7.2.0
-      path-exists: 5.0.0
 
   flatted@3.3.3: {}
 
@@ -14374,8 +13212,6 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
-
-  form-data-encoder@2.1.4: {}
 
   form-data@4.0.1:
     dependencies:
@@ -14578,18 +13414,10 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
-  get-stream@5.2.0:
-    dependencies:
-      pump: 3.0.0
-
-  get-stream@6.0.1: {}
-
   github-from-package@0.0.0:
     optional: true
 
   github-slugger@2.0.0: {}
-
-  github-url-from-git@1.5.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -14639,10 +13467,6 @@ snapshots:
       minimatch: 5.1.6
       once: 1.4.0
 
-  global-dirs@3.0.1:
-    dependencies:
-      ini: 2.0.0
-
   globals@11.12.0: {}
 
   globals@13.24.0:
@@ -14660,14 +13484,6 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
-  globby@13.2.2:
-    dependencies:
-      dir-glob: 3.0.1
-      fast-glob: 3.3.2
-      ignore: 5.3.1
-      merge2: 1.4.1
-      slash: 4.0.0
-
   globby@14.1.0:
     dependencies:
       '@sindresorhus/merge-streams': 2.3.0
@@ -14682,36 +13498,6 @@ snapshots:
       get-intrinsic: 1.2.4
 
   gopd@1.2.0: {}
-
-  got@11.8.6:
-    dependencies:
-      '@sindresorhus/is': 4.6.0
-      '@szmarczak/http-timer': 4.0.6
-      '@types/cacheable-request': 6.0.3
-      '@types/responselike': 1.0.3
-      cacheable-lookup: 5.0.4
-      cacheable-request: 7.0.4
-      decompress-response: 6.0.0
-      http2-wrapper: 1.0.3
-      lowercase-keys: 2.0.0
-      p-cancelable: 2.1.1
-      responselike: 2.0.1
-
-  got@12.6.1:
-    dependencies:
-      '@sindresorhus/is': 5.6.0
-      '@szmarczak/http-timer': 5.0.1
-      cacheable-lookup: 7.0.0
-      cacheable-request: 10.2.14
-      decompress-response: 6.0.0
-      form-data-encoder: 2.1.4
-      get-stream: 6.0.1
-      http2-wrapper: 2.2.1
-      lowercase-keys: 3.0.0
-      p-cancelable: 3.0.0
-      responselike: 3.0.0
-
-  graceful-fs@4.2.10: {}
 
   graceful-fs@4.2.11: {}
 
@@ -14730,10 +13516,6 @@ snapshots:
       uglify-js: 3.18.0
 
   harmony-reflect@1.6.2: {}
-
-  has-ansi@2.0.0:
-    dependencies:
-      ansi-regex: 2.1.1
 
   has-bigints@1.0.2: {}
 
@@ -14754,8 +13536,6 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.0.3
-
-  has-yarn@3.0.0: {}
 
   hasown@2.0.2:
     dependencies:
@@ -14833,10 +13613,6 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
-  hosted-git-info@6.1.1:
-    dependencies:
-      lru-cache: 7.18.3
-
   hosted-git-info@7.0.2:
     dependencies:
       lru-cache: 10.4.3
@@ -14873,24 +13649,12 @@ snapshots:
       domutils: 2.8.0
       entities: 3.0.1
 
-  http-cache-semantics@4.1.1: {}
-
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.1
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
-
-  http2-wrapper@1.0.3:
-    dependencies:
-      quick-lru: 5.1.1
-      resolve-alpn: 1.2.1
-
-  http2-wrapper@2.2.1:
-    dependencies:
-      quick-lru: 5.1.1
-      resolve-alpn: 1.2.1
 
   https-proxy-agent@7.0.5:
     dependencies:
@@ -14905,10 +13669,6 @@ snapshots:
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
-
-  human-signals@2.1.0: {}
-
-  human-signals@4.3.1: {}
 
   iconv-lite@0.4.24:
     dependencies:
@@ -14930,10 +13690,6 @@ snapshots:
 
   ieee754@1.2.1: {}
 
-  ignore-walk@6.0.5:
-    dependencies:
-      minimatch: 9.0.5
-
   ignore@5.3.1: {}
 
   ignore@7.0.5: {}
@@ -14953,20 +13709,7 @@ snapshots:
     dependencies:
       resolve-from: 5.0.0
 
-  import-lazy@4.0.0: {}
-
-  import-local@3.1.0:
-    dependencies:
-      pkg-dir: 4.2.0
-      resolve-cwd: 3.0.0
-
-  imurmurhash@0.1.4: {}
-
-  indent-string@3.2.0: {}
-
   indent-string@4.0.0: {}
-
-  indent-string@5.0.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -14977,31 +13720,7 @@ snapshots:
 
   ini@1.3.8: {}
 
-  ini@2.0.0: {}
-
   inline-style-parser@0.2.4: {}
-
-  inquirer-autosubmit-prompt@0.2.0:
-    dependencies:
-      chalk: 2.4.2
-      inquirer: 6.5.2
-      rxjs: 6.6.7
-
-  inquirer@6.5.2:
-    dependencies:
-      ansi-escapes: 3.2.0
-      chalk: 2.4.2
-      cli-cursor: 2.1.0
-      cli-width: 2.2.1
-      external-editor: 3.1.0
-      figures: 2.0.0
-      lodash: 4.17.21
-      mute-stream: 0.0.7
-      run-async: 2.4.1
-      rxjs: 6.6.7
-      string-width: 2.1.1
-      strip-ansi: 5.2.0
-      through: 2.3.8
 
   inquirer@7.3.3:
     dependencies:
@@ -15036,21 +13755,6 @@ snapshots:
       strip-ansi: 6.0.1
       through: 2.3.8
       wrap-ansi: 6.2.0
-
-  inquirer@9.3.5:
-    dependencies:
-      '@inquirer/figures': 1.0.3
-      ansi-escapes: 4.3.2
-      cli-width: 4.1.0
-      external-editor: 3.1.0
-      mute-stream: 1.0.0
-      ora: 5.4.1
-      run-async: 3.0.0
-      rxjs: 7.8.1
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 6.2.0
-      yoctocolors-cjs: 2.1.2
 
   internal-slot@1.0.7:
     dependencies:
@@ -15092,10 +13796,6 @@ snapshots:
 
   is-callable@1.2.7: {}
 
-  is-ci@3.0.1:
-    dependencies:
-      ci-info: 3.9.0
-
   is-core-module@2.14.0:
     dependencies:
       hasown: 2.0.2
@@ -15106,17 +13806,9 @@ snapshots:
 
   is-decimal@2.0.1: {}
 
-  is-docker@2.2.1: {}
-
   is-docker@3.0.0: {}
 
   is-extglob@2.1.1: {}
-
-  is-fullwidth-code-point@1.0.0:
-    dependencies:
-      number-is-nan: 1.0.1
-
-  is-fullwidth-code-point@2.0.0: {}
 
   is-fullwidth-code-point@3.0.0: {}
 
@@ -15130,14 +13822,7 @@ snapshots:
     dependencies:
       is-docker: 3.0.0
 
-  is-installed-globally@0.4.0:
-    dependencies:
-      global-dirs: 3.0.1
-      is-path-inside: 3.0.3
-
   is-interactive@1.0.0: {}
-
-  is-interactive@2.0.0: {}
 
   is-json@2.0.1: {}
 
@@ -15149,39 +13834,19 @@ snapshots:
 
   is-module@1.0.0: {}
 
-  is-name-taken@2.0.0:
-    dependencies:
-      all-package-names: 2.0.897
-      package-name-conflict: 1.0.3
-      validate-npm-package-name: 3.0.0
-
-  is-npm@6.0.0: {}
-
   is-number-object@1.0.7:
     dependencies:
       has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
 
-  is-obj@2.0.0: {}
-
-  is-observable@1.1.0:
-    dependencies:
-      symbol-observable: 1.2.0
-
   is-path-cwd@2.2.0: {}
 
-  is-path-cwd@3.0.0: {}
-
   is-path-inside@3.0.3: {}
-
-  is-path-inside@4.0.0: {}
 
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
-
-  is-promise@2.2.2: {}
 
   is-reference@1.2.1:
     dependencies:
@@ -15192,21 +13857,11 @@ snapshots:
       call-bind: 1.0.7
       has-tostringtag: 1.0.2
 
-  is-scoped@3.0.0:
-    dependencies:
-      scoped-regex: 3.0.0
-
   is-set@2.0.3: {}
 
   is-shared-array-buffer@1.0.3:
     dependencies:
       call-bind: 1.0.7
-
-  is-stream@1.1.0: {}
-
-  is-stream@2.0.1: {}
-
-  is-stream@3.0.0: {}
 
   is-string@1.0.7:
     dependencies:
@@ -15216,17 +13871,11 @@ snapshots:
     dependencies:
       has-symbols: 1.0.3
 
-  is-typedarray@1.0.0: {}
-
   is-unicode-supported@0.1.0: {}
-
-  is-unicode-supported@1.3.0: {}
 
   is-upper-case@1.1.2:
     dependencies:
       upper-case: 1.1.3
-
-  is-url-superb@6.1.0: {}
 
   is-weakmap@2.0.2: {}
 
@@ -15235,23 +13884,15 @@ snapshots:
       call-bind: 1.0.7
       get-intrinsic: 1.2.4
 
-  is-wsl@2.2.0:
-    dependencies:
-      is-docker: 2.2.1
-
   is-wsl@3.1.0:
     dependencies:
       is-inside-container: 1.0.0
-
-  is-yarn-global@0.4.1: {}
 
   isarray@2.0.5: {}
 
   isbinaryfile@4.0.10: {}
 
   isexe@2.0.0: {}
-
-  issue-regex@4.1.0: {}
 
   istextorbinary@9.5.0:
     dependencies:
@@ -15346,8 +13987,6 @@ snapshots:
 
   jsesc@3.1.0: {}
 
-  json-buffer@3.0.1: {}
-
   json-parse-even-better-errors@2.3.1: {}
 
   json-parse-even-better-errors@3.0.2: {}
@@ -15394,15 +14033,7 @@ snapshots:
       prebuild-install: 7.1.3
     optional: true
 
-  keyv@4.5.4:
-    dependencies:
-      json-buffer: 3.0.1
-
   kleur@3.0.3: {}
-
-  latest-version@7.0.0:
-    dependencies:
-      package-json: 8.1.1
 
   lefthook-darwin-arm64@1.11.12:
     optional: true
@@ -15550,49 +14181,6 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
-  listr-input@0.2.1:
-    dependencies:
-      inquirer: 7.3.3
-      inquirer-autosubmit-prompt: 0.2.0
-      rxjs: 6.6.7
-      through: 2.3.8
-
-  listr-silent-renderer@1.1.1: {}
-
-  listr-update-renderer@0.5.0(listr@0.14.3):
-    dependencies:
-      chalk: 1.1.3
-      cli-truncate: 0.2.1
-      elegant-spinner: 1.0.1
-      figures: 1.7.0
-      indent-string: 3.2.0
-      listr: 0.14.3
-      log-symbols: 1.0.2
-      log-update: 2.3.0
-      strip-ansi: 3.0.1
-
-  listr-verbose-renderer@0.5.0:
-    dependencies:
-      chalk: 2.4.2
-      cli-cursor: 2.1.0
-      date-fns: 1.30.1
-      figures: 2.0.0
-
-  listr@0.14.3:
-    dependencies:
-      '@samverschueren/stream-to-observable': 0.3.1(rxjs@6.6.7)
-      is-observable: 1.1.0
-      is-promise: 2.2.2
-      is-stream: 1.1.0
-      listr-silent-renderer: 1.1.1
-      listr-update-renderer: 0.5.0(listr@0.14.3)
-      listr-verbose-renderer: 0.5.0
-      p-map: 2.1.0
-      rxjs: 6.6.7
-    transitivePeerDependencies:
-      - zen-observable
-      - zenObservable
-
   lmdb@2.7.11:
     dependencies:
       msgpackr: 1.8.5
@@ -15625,17 +14213,9 @@ snapshots:
 
   loader-utils@3.3.1: {}
 
-  locate-path@5.0.0:
-    dependencies:
-      p-locate: 4.1.0
-
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
-
-  locate-path@7.2.0:
-    dependencies:
-      p-locate: 6.0.0
 
   lodash.camelcase@4.3.0: {}
 
@@ -15646,8 +14226,6 @@ snapshots:
   lodash.includes@4.3.0: {}
 
   lodash.isboolean@3.0.3: {}
-
-  lodash.isequal@4.5.0: {}
 
   lodash.isinteger@4.0.4: {}
 
@@ -15667,31 +14245,14 @@ snapshots:
 
   lodash.uniq@4.5.0: {}
 
-  lodash.zip@4.2.0: {}
-
   lodash@4.17.21: {}
 
   lodash@4.18.1: {}
-
-  log-symbols@1.0.2:
-    dependencies:
-      chalk: 1.1.3
 
   log-symbols@4.1.0:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
-
-  log-symbols@5.1.0:
-    dependencies:
-      chalk: 5.3.0
-      is-unicode-supported: 1.3.0
-
-  log-update@2.3.0:
-    dependencies:
-      ansi-escapes: 3.2.0
-      cli-cursor: 2.1.0
-      wrap-ansi: 3.0.1
 
   longest-streak@3.1.0: {}
 
@@ -15705,11 +14266,7 @@ snapshots:
 
   lower-case@2.0.2:
     dependencies:
-      tslib: 2.6.3
-
-  lowercase-keys@2.0.0: {}
-
-  lowercase-keys@3.0.0: {}
+      tslib: 2.8.1
 
   lru-cache@10.4.3: {}
 
@@ -15722,8 +14279,6 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
-
-  lru-cache@7.18.3: {}
 
   lucide-react@0.548.0(react@19.2.1):
     dependencies:
@@ -15926,10 +14481,6 @@ snapshots:
   mdn-data@2.0.30: {}
 
   mdurl@2.0.0: {}
-
-  meow@12.1.1: {}
-
-  merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -16217,17 +14768,10 @@ snapshots:
 
   mime@1.6.0: {}
 
-  mimic-fn@1.2.0: {}
-
   mimic-fn@2.1.0: {}
 
-  mimic-fn@4.0.0: {}
-
-  mimic-response@1.0.1: {}
-
-  mimic-response@3.1.0: {}
-
-  mimic-response@4.0.0: {}
+  mimic-response@3.1.0:
+    optional: true
 
   min-indent@1.0.1: {}
 
@@ -16294,11 +14838,7 @@ snapshots:
     optionalDependencies:
       msgpackr-extract: 3.0.3
 
-  mute-stream@0.0.7: {}
-
   mute-stream@0.0.8: {}
-
-  mute-stream@1.0.0: {}
 
   mz@2.7.0:
     dependencies:
@@ -16316,10 +14856,6 @@ snapshots:
   negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
-
-  new-github-release-url@2.0.0:
-    dependencies:
-      type-fest: 2.19.0
 
   next-themes@0.4.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
@@ -16361,7 +14897,7 @@ snapshots:
   no-case@3.0.4:
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   node-abi@3.75.0:
     dependencies:
@@ -16408,13 +14944,6 @@ snapshots:
       '@types/sarif': 2.1.7
       fs-extra: 10.1.0
 
-  normalize-package-data@3.0.3:
-    dependencies:
-      hosted-git-info: 4.1.0
-      is-core-module: 2.14.0
-      semver: 7.7.3
-      validate-npm-package-license: 3.0.4
-
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
@@ -16423,83 +14952,13 @@ snapshots:
 
   normalize-url@6.1.0: {}
 
-  normalize-url@8.0.1: {}
-
-  np@8.0.4(typescript@5.4.3):
-    dependencies:
-      chalk: 5.3.0
-      cosmiconfig: 8.3.6(typescript@5.4.3)
-      del: 7.1.0
-      escape-goat: 4.0.0
-      escape-string-regexp: 5.0.0
-      execa: 7.2.0
-      exit-hook: 3.2.0
-      github-url-from-git: 1.5.0
-      has-yarn: 3.0.0
-      hosted-git-info: 6.1.1
-      ignore-walk: 6.0.5
-      import-local: 3.1.0
-      inquirer: 9.3.5
-      is-installed-globally: 0.4.0
-      is-interactive: 2.0.0
-      is-scoped: 3.0.0
-      issue-regex: 4.1.0
-      listr: 0.14.3
-      listr-input: 0.2.1
-      log-symbols: 5.1.0
-      meow: 12.1.1
-      new-github-release-url: 2.0.0
-      npm-name: 7.1.1
-      onetime: 6.0.0
-      open: 9.1.0
-      ow: 1.1.1
-      p-memoize: 7.1.1
-      p-timeout: 6.1.2
-      path-exists: 5.0.0
-      pkg-dir: 7.0.0
-      read-pkg-up: 9.1.0
-      rxjs: 7.8.1
-      semver: 7.6.0
-      symbol-observable: 4.0.0
-      terminal-link: 3.0.0
-      update-notifier: 6.0.2
-    transitivePeerDependencies:
-      - typescript
-      - zen-observable
-      - zenObservable
-
-  npm-name@7.1.1:
-    dependencies:
-      got: 11.8.6
-      is-name-taken: 2.0.0
-      is-scoped: 3.0.0
-      is-url-superb: 6.1.0
-      lodash.zip: 4.2.0
-      org-regex: 1.0.0
-      p-map: 5.5.0
-      registry-auth-token: 4.2.2
-      registry-url: 6.0.1
-      validate-npm-package-name: 3.0.0
-
-  npm-run-path@4.0.1:
-    dependencies:
-      path-key: 3.1.1
-
-  npm-run-path@5.3.0:
-    dependencies:
-      path-key: 4.0.0
-
   npm-to-yarn@3.0.1: {}
-
-  npm@9.7.1: {}
 
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
 
   nullthrows@1.1.1: {}
-
-  number-is-nan@1.0.1: {}
 
   nwsapi@2.2.16: {}
 
@@ -16527,17 +14986,9 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  onetime@2.0.1:
-    dependencies:
-      mimic-fn: 1.2.0
-
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
-
-  onetime@6.0.0:
-    dependencies:
-      mimic-fn: 4.0.0
 
   oniguruma-parser@0.12.1: {}
 
@@ -16553,13 +15004,6 @@ snapshots:
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       is-wsl: 3.1.0
-
-  open@9.1.0:
-    dependencies:
-      default-browser: 4.0.0
-      define-lazy-prop: 3.0.0
-      is-inside-container: 1.0.0
-      is-wsl: 2.2.0
 
   ora@5.4.1:
     dependencies:
@@ -16577,17 +15021,7 @@ snapshots:
 
   ordered-binary@1.5.3: {}
 
-  org-regex@1.0.0: {}
-
   os-tmpdir@1.0.2: {}
-
-  ow@1.1.1:
-    dependencies:
-      '@sindresorhus/is': 5.6.0
-      callsites: 4.2.0
-      dot-prop: 7.2.0
-      lodash.isequal: 4.5.0
-      vali-date: 1.0.0
 
   oxc-transform@0.51.0:
     optionalDependencies:
@@ -16600,39 +15034,15 @@ snapshots:
       '@oxc-transform/binding-win32-arm64-msvc': 0.51.0
       '@oxc-transform/binding-win32-x64-msvc': 0.51.0
 
-  p-cancelable@2.1.1: {}
-
-  p-cancelable@3.0.0: {}
-
   p-finally@1.0.0: {}
-
-  p-limit@2.3.0:
-    dependencies:
-      p-try: 2.2.0
 
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
 
-  p-limit@4.0.0:
-    dependencies:
-      yocto-queue: 1.1.1
-
-  p-locate@4.1.0:
-    dependencies:
-      p-limit: 2.3.0
-
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
-
-  p-locate@6.0.0:
-    dependencies:
-      p-limit: 4.0.0
-
-  p-lock@2.1.0: {}
-
-  p-map@2.1.0: {}
 
   p-map@3.0.0:
     dependencies:
@@ -16641,15 +15051,6 @@ snapshots:
   p-map@4.0.0:
     dependencies:
       aggregate-error: 3.1.0
-
-  p-map@5.5.0:
-    dependencies:
-      aggregate-error: 4.0.1
-
-  p-memoize@7.1.1:
-    dependencies:
-      mimic-fn: 4.0.0
-      type-fest: 3.13.1
 
   p-queue@6.6.2:
     dependencies:
@@ -16660,20 +15061,7 @@ snapshots:
     dependencies:
       p-finally: 1.0.0
 
-  p-timeout@6.1.2: {}
-
-  p-try@2.2.0: {}
-
   package-json-from-dist@1.0.0: {}
-
-  package-json@8.1.1:
-    dependencies:
-      got: 12.6.1
-      registry-auth-token: 5.0.2
-      registry-url: 6.0.1
-      semver: 7.7.3
-
-  package-name-conflict@1.0.3: {}
 
   pako@0.2.9: {}
 
@@ -16723,14 +15111,6 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
-  parse-json-object@1.1.0:
-    dependencies:
-      types-json: 1.2.2
-
-  parse-json-object@2.0.1:
-    dependencies:
-      types-json: 1.2.2
-
   parse-json@5.2.0:
     dependencies:
       '@babel/code-frame': 7.24.7
@@ -16776,13 +15156,9 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-exists@5.0.0: {}
-
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
-
-  path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
 
@@ -16821,14 +15197,6 @@ snapshots:
   pify@5.0.0: {}
 
   pirates@4.0.6: {}
-
-  pkg-dir@4.2.0:
-    dependencies:
-      find-up: 4.1.0
-
-  pkg-dir@7.0.0:
-    dependencies:
-      find-up: 6.3.0
 
   pluralize@2.0.0: {}
 
@@ -17123,8 +15491,6 @@ snapshots:
 
   process@0.11.10: {}
 
-  progress@2.0.3: {}
-
   promise.series@0.2.0: {}
 
   prompts@2.4.2:
@@ -17134,8 +15500,6 @@ snapshots:
 
   property-information@7.0.0: {}
 
-  proto-list@1.2.4: {}
-
   psl@1.15.0:
     dependencies:
       punycode: 2.3.1
@@ -17144,14 +15508,11 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.4
       once: 1.4.0
+    optional: true
 
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
-
-  pupa@3.1.0:
-    dependencies:
-      escape-goat: 4.0.0
 
   qs@6.14.0:
     dependencies:
@@ -17160,8 +15521,6 @@ snapshots:
   querystringify@2.2.0: {}
 
   queue-microtask@1.2.3: {}
-
-  quick-lru@5.1.1: {}
 
   radix-ui@1.4.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
@@ -17281,7 +15640,7 @@ snapshots:
     dependencies:
       react: 19.2.1
       react-style-singleton: 2.2.3(@types/react@19.2.2)(react@19.2.1)
-      tslib: 2.6.3
+      tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.2
 
@@ -17290,7 +15649,7 @@ snapshots:
       react: 19.2.1
       react-remove-scroll-bar: 2.3.8(@types/react@19.2.2)(react@19.2.1)
       react-style-singleton: 2.2.3(@types/react@19.2.2)(react@19.2.1)
-      tslib: 2.6.3
+      tslib: 2.8.1
       use-callback-ref: 1.3.3(@types/react@19.2.2)(react@19.2.1)
       use-sidecar: 1.1.3(@types/react@19.2.2)(react@19.2.1)
     optionalDependencies:
@@ -17311,7 +15670,7 @@ snapshots:
     dependencies:
       get-nonce: 1.0.1
       react: 19.2.1
-      tslib: 2.6.3
+      tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.2
 
@@ -17320,26 +15679,6 @@ snapshots:
   read-cache@1.0.0:
     dependencies:
       pify: 2.3.0
-
-  read-file-safe@1.0.10: {}
-
-  read-json-safe@1.0.5:
-    dependencies:
-      parse-json-object: 1.1.0
-      read-file-safe: 1.0.10
-
-  read-pkg-up@9.1.0:
-    dependencies:
-      find-up: 6.3.0
-      read-pkg: 7.1.0
-      type-fest: 2.19.0
-
-  read-pkg@7.1.0:
-    dependencies:
-      '@types/normalize-package-data': 2.4.4
-      normalize-package-data: 3.0.3
-      parse-json: 5.2.0
-      type-fest: 2.19.0
 
   read-pkg@8.1.0:
     dependencies:
@@ -17440,19 +15779,7 @@ snapshots:
       rc: 1.2.8
       safe-buffer: 5.2.1
 
-  registry-auth-token@4.2.2:
-    dependencies:
-      rc: 1.2.8
-
-  registry-auth-token@5.0.2:
-    dependencies:
-      '@pnpm/npm-conf': 2.2.2
-
   registry-url@3.1.0:
-    dependencies:
-      rc: 1.2.8
-
-  registry-url@6.0.1:
     dependencies:
       rc: 1.2.8
 
@@ -17537,12 +15864,6 @@ snapshots:
 
   reselect@5.1.1: {}
 
-  resolve-alpn@1.2.1: {}
-
-  resolve-cwd@3.0.0:
-    dependencies:
-      resolve-from: 5.0.0
-
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
@@ -17552,19 +15873,6 @@ snapshots:
       is-core-module: 2.14.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-
-  responselike@2.0.1:
-    dependencies:
-      lowercase-keys: 2.0.0
-
-  responselike@3.0.0:
-    dependencies:
-      lowercase-keys: 3.0.0
-
-  restore-cursor@2.0.0:
-    dependencies:
-      onetime: 2.0.1
-      signal-exit: 3.0.7
 
   restore-cursor@3.1.0:
     dependencies:
@@ -17656,15 +15964,9 @@ snapshots:
 
   rrweb-cssom@0.8.0: {}
 
-  run-applescript@5.0.0:
-    dependencies:
-      execa: 5.1.1
-
   run-applescript@7.0.0: {}
 
   run-async@2.4.1: {}
-
-  run-async@3.0.0: {}
 
   run-parallel@1.2.0:
     dependencies:
@@ -17692,8 +15994,6 @@ snapshots:
 
   scheduler@0.27.0: {}
 
-  scoped-regex@3.0.0: {}
-
   scroll-into-view-if-needed@3.1.0:
     dependencies:
       compute-scroll-into-view: 3.1.1
@@ -17709,10 +16009,6 @@ snapshots:
       read-pkg: 8.1.0
     transitivePeerDependencies:
       - supports-color
-
-  semver-diff@4.0.0:
-    dependencies:
-      semver: 7.7.3
 
   semver@5.7.2: {}
 
@@ -17868,11 +16164,7 @@ snapshots:
 
   slash@3.0.0: {}
 
-  slash@4.0.0: {}
-
   slash@5.1.0: {}
-
-  slice-ansi@0.0.4: {}
 
   slice-ansi@4.0.0:
     dependencies:
@@ -17887,7 +16179,7 @@ snapshots:
   snake-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   sonner@2.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
@@ -17940,17 +16232,6 @@ snapshots:
 
   string-hash@1.1.3: {}
 
-  string-width@1.0.2:
-    dependencies:
-      code-point-at: 1.1.0
-      is-fullwidth-code-point: 1.0.0
-      strip-ansi: 3.0.1
-
-  string-width@2.1.1:
-    dependencies:
-      is-fullwidth-code-point: 2.0.0
-      strip-ansi: 4.0.0
-
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -17972,18 +16253,6 @@ snapshots:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
 
-  strip-ansi@3.0.1:
-    dependencies:
-      ansi-regex: 2.1.1
-
-  strip-ansi@4.0.0:
-    dependencies:
-      ansi-regex: 3.0.1
-
-  strip-ansi@5.2.0:
-    dependencies:
-      ansi-regex: 4.1.1
-
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -17991,10 +16260,6 @@ snapshots:
   strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.0.1
-
-  strip-final-newline@2.0.0: {}
-
-  strip-final-newline@3.0.0: {}
 
   strip-indent@3.0.0:
     dependencies:
@@ -18040,8 +16305,6 @@ snapshots:
       mz: 2.7.0
       pirates: 4.0.6
       ts-interface-checker: 0.1.13
-
-  supports-color@2.0.0: {}
 
   supports-color@5.5.0:
     dependencies:
@@ -18089,10 +16352,6 @@ snapshots:
       lower-case: 1.1.4
       upper-case: 1.1.3
 
-  symbol-observable@1.2.0: {}
-
-  symbol-observable@4.0.0: {}
-
   symbol-tree@3.2.4: {}
 
   table@6.9.0:
@@ -18130,11 +16389,6 @@ snapshots:
   terminal-link@2.1.1:
     dependencies:
       ansi-escapes: 4.3.2
-      supports-hyperlinks: 2.3.0
-
-  terminal-link@3.0.0:
-    dependencies:
-      ansi-escapes: 5.0.0
       supports-hyperlinks: 2.3.0
 
   terser@5.39.0:
@@ -18191,8 +16445,6 @@ snapshots:
     dependencies:
       no-case: 2.3.2
       upper-case: 1.1.3
-
-  titleize@3.0.0: {}
 
   tldts-core@6.1.86: {}
 
@@ -18335,10 +16587,6 @@ snapshots:
 
   type-fest@0.21.3: {}
 
-  type-fest@1.4.0: {}
-
-  type-fest@2.19.0: {}
-
   type-fest@3.13.1: {}
 
   type-fest@4.41.0: {}
@@ -18348,21 +16596,6 @@ snapshots:
       qs: 6.14.0
       tunnel: 0.0.6
       underscore: 1.13.7
-
-  typedarray-to-buffer@3.1.5:
-    dependencies:
-      is-typedarray: 1.0.0
-
-  types-eslintrc@1.0.3:
-    dependencies:
-      types-json: 1.2.2
-
-  types-json@1.2.2: {}
-
-  types-pkg-json@1.2.1:
-    dependencies:
-      types-eslintrc: 1.0.3
-      types-json: 1.2.2
 
   typescript-paths@1.5.1(typescript@5.4.3):
     dependencies:
@@ -18419,10 +16652,6 @@ snapshots:
       trough: 2.2.0
       vfile: 6.0.3
 
-  unique-string@3.0.0:
-    dependencies:
-      crypto-random-string: 4.0.0
-
   unist-util-is@6.0.0:
     dependencies:
       '@types/unist': 3.0.2
@@ -18459,8 +16688,6 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  untildify@4.0.0: {}
-
   update-browserslist-db@1.1.0(browserslist@4.23.2):
     dependencies:
       browserslist: 4.23.2
@@ -18478,23 +16705,6 @@ snapshots:
       registry-auth-token: 3.3.2
       registry-url: 3.1.0
 
-  update-notifier@6.0.2:
-    dependencies:
-      boxen: 7.1.1
-      chalk: 5.3.0
-      configstore: 6.0.0
-      has-yarn: 3.0.0
-      import-lazy: 4.0.0
-      is-ci: 3.0.1
-      is-installed-globally: 0.4.0
-      is-npm: 6.0.0
-      is-yarn-global: 0.4.1
-      latest-version: 7.0.0
-      pupa: 3.1.0
-      semver: 7.7.3
-      semver-diff: 4.0.0
-      xdg-basedir: 5.1.0
-
   upper-case-first@1.1.2:
     dependencies:
       upper-case: 1.1.3
@@ -18511,7 +16721,7 @@ snapshots:
   use-callback-ref@1.3.3(@types/react@19.2.2)(react@19.2.1):
     dependencies:
       react: 19.2.1
-      tslib: 2.6.3
+      tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.2
 
@@ -18523,7 +16733,7 @@ snapshots:
     dependencies:
       detect-node-es: 1.1.0
       react: 19.2.1
-      tslib: 2.6.3
+      tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.2
 
@@ -18539,16 +16749,10 @@ snapshots:
 
   v8-compile-cache-lib@3.0.1: {}
 
-  vali-date@1.0.0: {}
-
   validate-npm-package-license@3.0.4:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
-
-  validate-npm-package-name@3.0.0:
-    dependencies:
-      builtins: 1.0.3
 
   validate-npm-package-name@5.0.1: {}
 
@@ -18724,16 +16928,7 @@ snapshots:
     dependencies:
       string-width: 4.2.3
 
-  widest-line@4.0.1:
-    dependencies:
-      string-width: 5.1.2
-
   wordwrap@1.0.0: {}
-
-  wrap-ansi@3.0.1:
-    dependencies:
-      string-width: 2.1.1
-      strip-ansi: 4.0.0
 
   wrap-ansi@6.2.0:
     dependencies:
@@ -18755,16 +16950,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  write-file-atomic@3.0.3:
-    dependencies:
-      imurmurhash: 0.1.4
-      is-typedarray: 1.0.0
-      signal-exit: 3.0.7
-      typedarray-to-buffer: 3.1.5
-
   ws@8.18.0: {}
-
-  xdg-basedir@5.1.0: {}
 
   xml-name-validator@5.0.0: {}
 
@@ -18811,10 +16997,6 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
-
-  yocto-queue@1.1.1: {}
-
-  yoctocolors-cjs@2.1.2: {}
 
   zod-validation-error@3.5.3(zod@3.25.58):
     dependencies:


### PR DESCRIPTION
## Summary

A design-system-wide audit of the component library, consolidating the animation work and the broader interaction/craft pass into a single branch.

### What's covered

- **Motion** — shared easing/duration/scale tokens; interruptible, origin-anchored entrances for overlays (popover, menu, tooltip, select, combobox, preview-card); indeterminate Progress; drawer 1:1 swipe tracking; reduced-motion fallbacks throughout.
- **Interaction states** — hover / press / focus feedback for buttons, toggles, chips, and the text-field family (input, field, number-field, text-area, otp-field), with a unified invalid state.
- **Focus** — a consistent, tokenized `:focus-visible` ring across the library.
- **Accessibility** — reduced-motion and reduced-transparency fallbacks; a calendar day can no longer be selected by keyboard while the grid is loading; announcement-bar action-button states.
- **Data views** — selected / pressed row states, sort-icon direction, sticky-header hairlines that appear only once content scrolls under them, tabular figures.
- **Media** — image and avatar fade-in with a cached-image skip and a one-shot fallback guard.
- **Tokens & typography** — motion/interaction tokens consolidated into `styles/effects.css`; Inter body tracking and the h1–h4 type ramp retuned.

## Related issues

Closes #681 — consistent, tokenized `:focus-visible` ring applied across the library.
Closes #621 — Image error/loading handling: one-shot fallback guard plus load-state fade-in.
Closes #625 — Link's remaining items (focus-visible, reduced-motion) are now done.

Partially addresses:
- #642 — `TableRow` now uses CVA and gains row-state hooks. Cell truncation accessibility is still open.
- #596 — AnnouncementBar action-button interactive states added. Variants, dismissible support, and the `announementBar` typo are still open.

## Test plan

- [x] `pnpm build` passes.
- Component test suites pass. A pre-existing `@base-ui` module-resolution failure affects a handful of unrelated test files on `main` as well.
