### PR TITLE
feat: dataview timeline component

### DIFF
--- a/apps/www/src/app/examples/timeline/page.tsx
+++ b/apps/www/src/app/examples/timeline/page.tsx
@@ -84,6 +84,12 @@ const NAME_POOL = [
   'Order_9'
 ];
 
+/* Orders generated per month. Deliberately dense: enough cards for lane
+   packing to stack several deep inside every status band, which is what makes
+   the grouped swim-lane layout (and horizontal culling) worth looking at. */
+const ORDERS_PER_MONTH_MIN = 18;
+const ORDERS_PER_MONTH_MAX = 26;
+
 const STATUS_LABEL: Record<OrderStatus, string> = {
   scheduled: 'Scheduled',
   'in-progress': 'In progress',
@@ -116,7 +122,9 @@ function ordersForMonth(monthKey: string): Order[] {
   const monthStart = dayjs(`${monthKey}-01`);
   const rng = mulberry32(monthStart.year() * 100 + monthStart.month());
   const today = startOfToday();
-  const count = 5 + Math.floor(rng() * 4); // 5–8 orders per month
+  const count =
+    ORDERS_PER_MONTH_MIN +
+    Math.floor(rng() * (ORDERS_PER_MONTH_MAX - ORDERS_PER_MONTH_MIN + 1));
   return Array.from({ length: count }, (_, i) => {
     const start = monthStart.add(Math.floor(rng() * 27), 'day');
     const due = start.add(2 + Math.floor(rng() * 16), 'day');
@@ -187,6 +195,11 @@ const fields: DataViewField<Order>[] = [
     filterable: true,
     filterType: 'select',
     hideable: true,
+    // Groupable fields drive the Grouping control in Display settings. The
+    // timeline renders one swim-lane section per group; the list view renders
+    // the same groups as section headers.
+    groupable: true,
+    showGroupCount: true,
     filterOptions: ORG_LIST.map(org => ({ value: org, label: org }))
   },
   {
@@ -195,6 +208,10 @@ const fields: DataViewField<Order>[] = [
     filterable: true,
     filterType: 'select',
     hideable: true,
+    groupable: true,
+    showGroupCount: true,
+    // Bucket keys are the raw status values; the band shows these labels.
+    groupLabelsMap: STATUS_LABEL,
     filterOptions: (Object.keys(STATUS_LABEL) as OrderStatus[]).map(status => ({
       value: status,
       label: STATUS_LABEL[status]
@@ -707,6 +724,10 @@ const Page = () => {
           isLoading={isLoading}
           loadingRowCount={3}
           defaultSort={{ name: 'dueDate', order: 'asc' }}
+          /* Opens grouped by status — one swim-lane band per status in the
+             timeline, the same buckets as the list view's group headers.
+             Switch it in Display settings → Grouping. */
+          query={{ group_by: ['status'] }}
           getRowId={(row: Order) => row.id}
           onRowClick={order => orderDialog.openWithPayload(order)}
           views={[
@@ -770,7 +791,12 @@ const Page = () => {
                 <OrderCard order={row.original} context={context} />
               )}
             />
-            <DataView.List name='list' variant='table' columns={orderColumns} />
+            <DataView.List
+              name='list'
+              variant='table'
+              columns={orderColumns}
+              stickyGroupHeader
+            />
             <DataView.EmptyState>
               <EmptyState
                 icon={<FilterIcon />}

--- a/apps/www/src/app/examples/timeline/page.tsx
+++ b/apps/www/src/app/examples/timeline/page.tsx
@@ -1,0 +1,788 @@
+/** biome-ignore-all lint/suspicious/noShadowRestrictedNames: public component name intentionally matches the package export */
+'use client';
+
+import {
+  Badge,
+  Button,
+  DataView,
+  type DataViewField,
+  type DataViewListColumn,
+  Dialog,
+  EmptyState,
+  Flex,
+  IconButton,
+  Navbar,
+  Sidebar,
+  Text,
+  type TimelineActions,
+  type TimelineCardContext
+} from '@raystack/apsara';
+import { BellIcon, FilterIcon, SidebarIcon } from '@raystack/apsara/icons';
+import dayjs from 'dayjs';
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState
+} from 'react';
+
+type OrderStatus = 'scheduled' | 'in-progress' | 'partial' | 'completed';
+
+type Order = {
+  id: string;
+  name: string;
+  org: string;
+  priority: number;
+  status: OrderStatus;
+  startDate: string;
+  dueDate: string;
+};
+
+/* Dates are generated relative to today so the today-line and the
+   "Due in N days" danger states are always live in the example. Pinned to
+   midnight so server- and client-rendered output match (no hydration drift). */
+const DAY_MS = 86_400_000;
+const startOfToday = () => {
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  return now.getTime();
+};
+const daysFromNow = (days: number) =>
+  new Date(startOfToday() + days * DAY_MS).toISOString();
+
+/* ── Programmatic scroll domain (min/max of the timeline) ─────────────────
+   The explorable window is fixed to ±6 months around today. An explicit
+   `range` keeps the coordinate space stable while data streams in — the
+   scrollbar never jumps as new rows load. */
+const RANGE: [string, string] = [daysFromNow(-183), daysFromNow(183)];
+
+/* How far beyond the visible window to prefetch on each scroll event. */
+const PREFETCH_MS = 14 * DAY_MS;
+/* Minimum spacing between range fetches while scrolling. */
+const FETCH_THROTTLE_MS = 200;
+/* Simulated network latency for the fake orders API. */
+const API_LATENCY_MS = 500;
+
+const ORG_LIST = [
+  'Company A',
+  'Company B',
+  'Company C',
+  'Company D',
+  'Company E'
+];
+
+const NAME_POOL = [
+  'Order_1',
+  'Order_2',
+  'Order_3',
+  'Order_4',
+  'Order_5',
+  'Order_6',
+  'Order_7',
+  'Order_8',
+  'Order_9'
+];
+
+const STATUS_LABEL: Record<OrderStatus, string> = {
+  scheduled: 'Scheduled',
+  'in-progress': 'In progress',
+  partial: 'Partially delivered',
+  completed: 'Completed'
+};
+
+/* ── Simulated orders backend ──────────────────────────────────────────────
+   The full dataset is generated once up front (the "database table"), then
+   `fetchOrdersApi` answers range queries against it with the interval-overlap
+   predicate — the same shape a real RQL backend would run:
+
+     start_time <= to AND end_time >= from
+
+   i.e. a card is returned iff it has at least one visible pixel in the
+   window. A containment filter (`start >= from AND end <= to`) would drop
+   cards that straddle either window edge. */
+function mulberry32(seed: number) {
+  let a = seed;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function ordersForMonth(monthKey: string): Order[] {
+  const monthStart = dayjs(`${monthKey}-01`);
+  const rng = mulberry32(monthStart.year() * 100 + monthStart.month());
+  const today = startOfToday();
+  const count = 5 + Math.floor(rng() * 4); // 5–8 orders per month
+  return Array.from({ length: count }, (_, i) => {
+    const start = monthStart.add(Math.floor(rng() * 27), 'day');
+    const due = start.add(2 + Math.floor(rng() * 16), 'day');
+    let status: OrderStatus;
+    if (due.valueOf() < today) {
+      status = rng() < 0.75 ? 'completed' : 'partial';
+    } else if (start.valueOf() > today) {
+      status = 'scheduled';
+    } else {
+      status = rng() < 0.5 ? 'in-progress' : 'partial';
+    }
+    return {
+      id: `${monthKey}-${i}`,
+      name: NAME_POOL[Math.floor(rng() * NAME_POOL.length)],
+      org: ORG_LIST[Math.floor(rng() * ORG_LIST.length)],
+      priority: 1 + Math.floor(rng() * 10),
+      status,
+      startDate: start.toISOString(),
+      dueDate: due.toISOString()
+    };
+  });
+}
+
+function monthKeysBetween(fromMs: number, toMs: number): string[] {
+  const keys: string[] = [];
+  let cursor = dayjs(fromMs).startOf('month');
+  const end = dayjs(toMs);
+  while (cursor.isBefore(end)) {
+    keys.push(cursor.format('YYYY-MM'));
+    cursor = cursor.add(1, 'month');
+  }
+  return keys;
+}
+
+/* The whole "table", generated once at module load. Seeded per month, so the
+   data is stable across renders and reloads within a day. */
+const ALL_ORDERS: Order[] = monthKeysBetween(
+  Date.parse(RANGE[0]),
+  Date.parse(RANGE[1])
+).flatMap(ordersForMonth);
+
+function fetchOrdersApi(fromMs: number, toMs: number): Promise<Order[]> {
+  // Interval-overlap predicate: starts before the window closes AND ends
+  // after it opens — catches fully-inside cards and edge-spanners alike.
+  const rows = ALL_ORDERS.filter(
+    order =>
+      Date.parse(order.startDate) <= toMs && Date.parse(order.dueDate) >= fromMs
+  ).sort((a, b) => Date.parse(a.startDate) - Date.parse(b.startDate));
+  return new Promise(resolve =>
+    setTimeout(() => resolve(rows), API_LATENCY_MS)
+  );
+}
+
+// Renderer-agnostic metadata — drives search, filters, and the Display
+// Properties toggles that the card composes via <DataView.DisplayAccess>.
+const fields: DataViewField<Order>[] = [
+  {
+    accessorKey: 'name',
+    label: 'Order',
+    filterable: true,
+    filterType: 'string',
+    sortable: true,
+    hideable: false
+  },
+  {
+    accessorKey: 'org',
+    label: 'Organization',
+    filterable: true,
+    filterType: 'select',
+    hideable: true,
+    filterOptions: ORG_LIST.map(org => ({ value: org, label: org }))
+  },
+  {
+    accessorKey: 'status',
+    label: 'Status',
+    filterable: true,
+    filterType: 'select',
+    hideable: true,
+    filterOptions: (Object.keys(STATUS_LABEL) as OrderStatus[]).map(status => ({
+      value: status,
+      label: STATUS_LABEL[status]
+    }))
+  },
+  { accessorKey: 'priority', label: 'Priority', hideable: true },
+  {
+    accessorKey: 'startDate',
+    label: 'Start date',
+    filterable: true,
+    filterType: 'date',
+    sortable: true,
+    hideable: true
+  },
+  {
+    accessorKey: 'dueDate',
+    label: 'Due date',
+    filterable: true,
+    filterType: 'date',
+    sortable: true,
+    hideable: true
+  }
+];
+
+/* Status icons matching the Figma card anatomy: outlined circle (scheduled),
+   pie (in progress), half-filled circle (partially delivered), check circle
+   (completed). */
+function StatusIcon({ status }: { status: OrderStatus }) {
+  const accent = 'var(--rs-color-foreground-accent-primary)';
+  const success = 'var(--rs-color-foreground-success-primary)';
+  const shared = {
+    width: 16,
+    height: 16,
+    viewBox: '0 0 16 16',
+    'aria-label': STATUS_LABEL[status],
+    role: 'img',
+    style: { flexShrink: 0 }
+  } as const;
+  switch (status) {
+    case 'completed':
+      return (
+        <svg {...shared}>
+          <circle cx='8' cy='8' r='6.5' fill={success} />
+          <path
+            d='M5 8.2 7.1 10.3 11 6.2'
+            stroke='white'
+            strokeWidth='1.5'
+            fill='none'
+            strokeLinecap='round'
+            strokeLinejoin='round'
+          />
+        </svg>
+      );
+    case 'partial':
+      return (
+        <svg {...shared}>
+          <circle
+            cx='8'
+            cy='8'
+            r='6'
+            stroke={success}
+            strokeWidth='1.5'
+            fill='none'
+          />
+          <path d='M8 2 A6 6 0 0 1 8 14 Z' fill={success} />
+        </svg>
+      );
+    case 'in-progress':
+      return (
+        <svg {...shared}>
+          <circle
+            cx='8'
+            cy='8'
+            r='6'
+            stroke={accent}
+            strokeWidth='1.5'
+            fill='none'
+          />
+          <path d='M8 8 L8 3.5 A4.5 4.5 0 1 1 3.5 8 Z' fill={accent} />
+        </svg>
+      );
+    case 'scheduled':
+      return (
+        <svg {...shared}>
+          <circle
+            cx='8'
+            cy='8'
+            r='6'
+            stroke={accent}
+            strokeWidth='1.5'
+            fill='none'
+          />
+        </svg>
+      );
+  }
+}
+
+/* ── Shared order-details dialog ──────────────────────────────────────────
+   One detached Dialog instance serves every card. Cards don't render their
+   own <Dialog.Trigger>; clicking a card opens this instance imperatively via
+   the handle, passing the clicked order as the payload. */
+const orderDialog = Dialog.createHandle<Order>();
+
+const ellipsis: React.CSSProperties = {
+  minWidth: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap'
+};
+
+function formatDue(date: Date) {
+  return date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
+}
+
+const STATUS_BADGE_VARIANT: Record<
+  OrderStatus,
+  'accent' | 'success' | 'warning' | 'neutral'
+> = {
+  scheduled: 'neutral',
+  'in-progress': 'accent',
+  partial: 'warning',
+  completed: 'success'
+};
+
+/* Due-date urgency shared by the timeline card, the list view, and the
+   details dialog. */
+function dueState(order: Order) {
+  const due = new Date(order.dueDate);
+  const daysLeft = Math.ceil((due.getTime() - Date.now()) / DAY_MS);
+  return {
+    due,
+    daysLeft,
+    urgent: daysLeft >= 0 && daysLeft <= 5 && order.status !== 'completed'
+  };
+}
+
+function DueBadge({ order }: { order: Order }) {
+  const { due, daysLeft, urgent } = dueState(order);
+  return (
+    <Badge
+      size='micro'
+      variant={urgent ? 'danger' : 'neutral'}
+      style={{ flexShrink: 0 }}
+    >
+      {urgent
+        ? `Due in ${daysLeft} day${daysLeft === 1 ? '' : 's'}`
+        : `Due on ${formatDue(due)}`}
+    </Badge>
+  );
+}
+
+/* ── List view (table variant of DataView.List) ───────────────────────────
+   Same row model, columnar presentation — switched with the view tabs in
+   the Display settings popover. Columns reference the same accessorKeys as
+   `fields`, so visibility toggles, filters, and sort apply to both views. */
+type OrderCell = { row: { original: Order } };
+
+const orderColumns: DataViewListColumn<Order>[] = [
+  {
+    accessorKey: 'name',
+    width: 'minmax(220px, 1.5fr)',
+    cell: ({ row }: OrderCell) => (
+      <Flex align='center' gap={3} style={{ minWidth: 0 }}>
+        <StatusIcon status={row.original.status} />
+        <Text size='small' weight='medium' style={ellipsis}>
+          {row.original.name}
+        </Text>
+      </Flex>
+    )
+  },
+  {
+    accessorKey: 'status',
+    width: '150px',
+    cell: ({ row }: OrderCell) => (
+      <Badge size='micro' variant={STATUS_BADGE_VARIANT[row.original.status]}>
+        {STATUS_LABEL[row.original.status]}
+      </Badge>
+    )
+  },
+  {
+    accessorKey: 'priority',
+    width: '90px',
+    cell: ({ row }: OrderCell) => (
+      <Text size='small' variant='secondary'>
+        P{row.original.priority}
+      </Text>
+    )
+  },
+  {
+    accessorKey: 'startDate',
+    width: '120px',
+    cell: ({ row }: OrderCell) => (
+      <Text size='small'>{formatDue(new Date(row.original.startDate))}</Text>
+    )
+  },
+  {
+    accessorKey: 'dueDate',
+    width: '150px',
+    cell: ({ row }: OrderCell) => <DueBadge order={row.original} />
+  },
+  {
+    accessorKey: 'org',
+    width: 'minmax(180px, 1fr)',
+    cell: ({ row }: OrderCell) => (
+      <Text size='small' variant='secondary' style={ellipsis}>
+        {row.original.org}
+      </Text>
+    )
+  }
+];
+
+/* The card is entirely consumer-owned — the Timeline only positions it.
+   Chrome, danger state, truncation, and the collapsed stub all live here. */
+function OrderCard({
+  order,
+  context
+}: {
+  order: Order;
+  context: TimelineCardContext;
+}) {
+  const { urgent } = dueState(order);
+
+  const chrome: React.CSSProperties = {
+    height: '100%',
+    boxSizing: 'border-box',
+    borderRadius: 'var(--rs-radius-3)',
+    border: `1px solid ${
+      urgent
+        ? 'var(--rs-color-border-danger-emphasis)'
+        : 'var(--rs-color-border-base-primary)'
+    }`,
+    background: urgent
+      ? 'var(--rs-color-background-danger-primary)'
+      : 'var(--rs-color-background-base-primary)',
+    overflow: 'hidden'
+  };
+
+  // Narrow spans (context.collapsed) render as a compact priority stub, like
+  // the tiny "P10" card in the design.
+  if (context.collapsed) {
+    return (
+      <Flex align='center' justify='center' style={chrome}>
+        <Text
+          size='micro'
+          weight='medium'
+          variant={urgent ? 'danger' : 'secondary'}
+        >
+          P{order.priority}
+        </Text>
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex
+      direction='column'
+      justify='between'
+      style={{ ...chrome, padding: 'var(--rs-space-3)' }}
+    >
+      <Flex align='center' gap={3} style={{ minWidth: 0 }}>
+        <StatusIcon status={order.status} />
+        <Text size='small' weight='medium' style={{ ...ellipsis, flex: 1 }}>
+          {order.name}
+        </Text>
+        <DataView.DisplayAccess accessorKey='priority'>
+          <Text size='micro' variant='secondary'>
+            P{order.priority}
+          </Text>
+        </DataView.DisplayAccess>
+      </Flex>
+      <Flex align='center' gap={3} style={{ minWidth: 0 }}>
+        <DataView.DisplayAccess accessorKey='dueDate'>
+          <DueBadge order={order} />
+        </DataView.DisplayAccess>
+        <DataView.DisplayAccess accessorKey='org'>
+          <Text size='micro' variant='secondary' style={ellipsis}>
+            {order.org}
+          </Text>
+        </DataView.DisplayAccess>
+      </Flex>
+    </Flex>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <Flex justify='between' align='center' gap={5}>
+      <Text size='small' variant='secondary'>
+        {label}
+      </Text>
+      <Text size='small' weight='medium' style={{ textAlign: 'right' }}>
+        {value}
+      </Text>
+    </Flex>
+  );
+}
+
+/* The dialog body renders from the handle's payload — the order of whichever
+   card was clicked last. */
+function OrderDetailsDialog() {
+  return (
+    <Dialog handle={orderDialog}>
+      {({ payload: order }) =>
+        order ? (
+          <Dialog.Content style={{ maxWidth: 400 }}>
+            {/* Dialog.Header is a row flex by default — stack title over
+                description, and keep clear of the top-right close button. */}
+            <Dialog.Header
+              direction='column'
+              align='start'
+              gap={2}
+              style={{ paddingRight: 'var(--rs-space-13)' }}
+            >
+              <Flex align='center' gap={3}>
+                <StatusIcon status={order.status} />
+                <Dialog.Title>{order.name}</Dialog.Title>
+              </Flex>
+              <Dialog.Description>
+                {STATUS_LABEL[order.status]} · {order.org}
+              </Dialog.Description>
+            </Dialog.Header>
+            <Dialog.Body>
+              <Flex direction='column' gap={4}>
+                <DetailRow label='Order ID' value={order.id} />
+                <DetailRow
+                  label='Status'
+                  value={
+                    <Badge
+                      size='micro'
+                      variant={STATUS_BADGE_VARIANT[order.status]}
+                    >
+                      {STATUS_LABEL[order.status]}
+                    </Badge>
+                  }
+                />
+                <DetailRow label='Priority' value={`P${order.priority}`} />
+                <DetailRow
+                  label='Start date'
+                  value={formatDue(new Date(order.startDate))}
+                />
+                <DetailRow
+                  label='Due date'
+                  value={formatDue(new Date(order.dueDate))}
+                />
+                <DetailRow label='Organization' value={order.org} />
+              </Flex>
+            </Dialog.Body>
+          </Dialog.Content>
+        ) : null
+      }
+    </Dialog>
+  );
+}
+
+const Page = () => {
+  /* ── Range-window infinite loading ──────────────────────────────────────
+     The timeline reports its visible [from, to] via onVisibleRangeChange.
+     We widen that window by a prefetch pad and query the API with it. Month
+     buckets exist only as client-side bookkeeping of what's already been
+     requested — contiguous missing buckets coalesce into one query. Because
+     the API returns everything *overlapping* the window, a card straddling a
+     window edge comes back from both adjacent fetches, so merging dedupes by
+     row id. */
+  const [orders, setOrders] = useState<Order[]>([]);
+  /* Imperative navigation handle — drives the "Today" button in the toolbar.
+     Null while the timeline view is inactive (methods no-op with a warning). */
+  const timelineActions = useRef<TimelineActions | null>(null);
+  // Starts true: the first window is fetched on mount, and `isLoading` keeps
+  // the timeline shell (axis + skeletons) rendered while it's empty.
+  const [isLoading, setIsLoading] = useState(true);
+  const requestedRef = useRef<Set<string>>(new Set());
+  const inflightRef = useRef(0);
+  const lastFetchRef = useRef(0);
+  const trailingRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const loadWindow = useCallback((fromMs: number, toMs: number) => {
+    const clampedFrom = Math.max(fromMs, Date.parse(RANGE[0]));
+    const clampedTo = Math.min(toMs, Date.parse(RANGE[1]));
+    if (clampedFrom >= clampedTo) return;
+    const missing = monthKeysBetween(clampedFrom, clampedTo).filter(
+      key => !requestedRef.current.has(key)
+    );
+    if (missing.length === 0) return;
+    for (const key of missing) requestedRef.current.add(key);
+    // Coalesce consecutive missing months into contiguous [first, last] runs
+    // (jump-scrolling can leave already-fetched holes between them).
+    const runs: [string, string][] = [];
+    for (const key of missing) {
+      const last = runs[runs.length - 1];
+      if (
+        last &&
+        dayjs(`${last[1]}-01`).add(1, 'month').format('YYYY-MM') === key
+      ) {
+        last[1] = key;
+      } else {
+        runs.push([key, key]);
+      }
+    }
+    inflightRef.current += runs.length;
+    setIsLoading(true);
+    for (const [firstKey, lastKey] of runs) {
+      fetchOrdersApi(
+        dayjs(`${firstKey}-01`).valueOf(),
+        dayjs(`${lastKey}-01`).endOf('month').valueOf()
+      ).then(rows => {
+        setOrders(prev => {
+          const seen = new Set(prev.map(order => order.id));
+          const fresh = rows.filter(order => !seen.has(order.id));
+          return fresh.length > 0 ? [...prev, ...fresh] : prev;
+        });
+        inflightRef.current -= 1;
+        if (inflightRef.current === 0) setIsLoading(false);
+      });
+    }
+  }, []);
+
+  // Throttled (leading + trailing), NOT debounced: a debounce would wait for
+  // scrolling to stop, leaving a gap of missing cards during a long drag.
+  // Throttling fetches while the scroll is still in flight, and the trailing
+  // call covers the final resting position. Dedup in loadWindow keeps the
+  // extra invocations free.
+  const handleVisibleRangeChange = useCallback(
+    ([from, to]: [Date, Date]) => {
+      const fetchWindow = () => {
+        lastFetchRef.current = Date.now();
+        loadWindow(from.getTime() - PREFETCH_MS, to.getTime() + PREFETCH_MS);
+      };
+      if (trailingRef.current) clearTimeout(trailingRef.current);
+      const elapsed = Date.now() - lastFetchRef.current;
+      if (elapsed >= FETCH_THROTTLE_MS) {
+        fetchWindow();
+      } else {
+        trailingRef.current = setTimeout(
+          fetchWindow,
+          FETCH_THROTTLE_MS - elapsed
+        );
+      }
+    },
+    [loadWindow]
+  );
+
+  // Initial fetch around today — the timeline starts centered on it, and
+  // subsequent windows load through onVisibleRangeChange as the user scrolls.
+  useEffect(() => {
+    const today = startOfToday();
+    loadWindow(today - 2 * PREFETCH_MS, today + 2 * PREFETCH_MS);
+  }, [loadWindow]);
+
+  useEffect(
+    () => () => {
+      if (trailingRef.current) clearTimeout(trailingRef.current);
+    },
+    []
+  );
+
+  return (
+    <Flex
+      style={{
+        height: '100vh',
+        backgroundColor: 'var(--rs-color-background-base-primary)',
+        overflow: 'hidden'
+      }}
+    >
+      <Sidebar defaultOpen>
+        <Sidebar.Header>
+          <Flex align='center' gap={3}>
+            <IconButton size={4} aria-label='Logo'>
+              <BellIcon width={24} height={24} />
+            </IconButton>
+            <Text size='regular' weight='medium'>
+              Apsara
+            </Text>
+          </Flex>
+        </Sidebar.Header>
+        <Sidebar.Main>
+          <Sidebar.Item
+            href='/examples/timeline'
+            leadingIcon={<SidebarIcon />}
+            active
+          >
+            Timeline
+          </Sidebar.Item>
+        </Sidebar.Main>
+        <Sidebar.Footer>
+          <Sidebar.Item href='#'>Help & Support</Sidebar.Item>
+          <Sidebar.Item href='#'>Preferences</Sidebar.Item>
+        </Sidebar.Footer>
+      </Sidebar>
+
+      <Flex
+        direction='column'
+        style={{ flex: 1, overflow: 'hidden', minWidth: 0 }}
+      >
+        <DataView<Order>
+          data={orders}
+          fields={fields}
+          mode='client'
+          isLoading={isLoading}
+          loadingRowCount={3}
+          defaultSort={{ name: 'dueDate', order: 'asc' }}
+          getRowId={(row: Order) => row.id}
+          onRowClick={order => orderDialog.openWithPayload(order)}
+          views={[
+            { value: 'timeline', label: 'Timeline' },
+            { value: 'list', label: 'List' }
+          ]}
+          defaultView='timeline'
+        >
+          <Navbar>
+            <Navbar.Start>
+              <Text size='regular' weight='medium'>
+                Order management · Timeline
+              </Text>
+            </Navbar.Start>
+            <Navbar.End>
+              <DataView.Search placeholder='Search orders' width={300} />
+              <Button
+                size='small'
+                color='neutral'
+                variant='outline'
+                onClick={() =>
+                  timelineActions.current?.scrollTo('today', {
+                    align: 'center',
+                    behavior: 'smooth'
+                  })
+                }
+              >
+                Today
+              </Button>
+              <Text size='mini' variant='secondary'>
+                Orders load as you scroll · {orders.length} loaded
+              </Text>
+            </Navbar.End>
+          </Navbar>
+          <DataView.Toolbar>
+            <DataView.Filters />
+            <DataView.DisplayControls />
+          </DataView.Toolbar>
+
+          {/* Empty/zero states live inside the same flex-1 pane as the
+              timeline: when the timeline renders null they center in the
+              pane instead of being pushed below an empty spacer. */}
+          <Flex
+            direction='column'
+            justify='center'
+            style={{ flex: 1, overflow: 'hidden', minWidth: 0 }}
+          >
+            <DataView.Timeline<Order>
+              name='timeline'
+              startField='startDate'
+              endField='dueDate'
+              scale='day'
+              unitWidth={20}
+              tickInterval={2}
+              gridlineInterval={2}
+              range={RANGE}
+              virtualized
+              actionsRef={timelineActions}
+              onVisibleRangeChange={handleVisibleRangeChange}
+              renderCard={(row, context) => (
+                <OrderCard order={row.original} context={context} />
+              )}
+            />
+            <DataView.List name='list' variant='table' columns={orderColumns} />
+            <DataView.EmptyState>
+              <EmptyState
+                icon={<FilterIcon />}
+                heading='No matching orders'
+                variant='empty1'
+                subHeading='Try adjusting your filters or search.'
+              />
+            </DataView.EmptyState>
+            <DataView.ZeroState>
+              <EmptyState
+                icon={<FilterIcon />}
+                heading='No orders yet'
+                variant='empty1'
+                subHeading='Orders will show up here once they are scheduled.'
+              />
+            </DataView.ZeroState>
+          </Flex>
+
+          <DataView.ClearFilters />
+        </DataView>
+      </Flex>
+      <OrderDetailsDialog />
+    </Flex>
+  );
+};
+
+export default Page;

--- a/apps/www/src/app/examples/timeline/page.tsx
+++ b/apps/www/src/app/examples/timeline/page.tsx
@@ -417,8 +417,10 @@ function OrderCard({
 }) {
   const { urgent } = dueState(order);
 
+  // Card height is content-driven (the wrapper auto-measures, like
+  // DataView.List rows) — fix it here so collapsed stubs match full cards.
   const chrome: React.CSSProperties = {
-    height: '100%',
+    height: 64,
     boxSizing: 'border-box',
     borderRadius: 'var(--rs-radius-3)',
     border: `1px solid ${
@@ -596,18 +598,28 @@ const Page = () => {
     inflightRef.current += runs.length;
     setIsLoading(true);
     for (const [firstKey, lastKey] of runs) {
-      fetchOrdersApi(
-        dayjs(`${firstKey}-01`).valueOf(),
-        dayjs(`${lastKey}-01`).endOf('month').valueOf()
-      ).then(rows => {
-        setOrders(prev => {
-          const seen = new Set(prev.map(order => order.id));
-          const fresh = rows.filter(order => !seen.has(order.id));
-          return fresh.length > 0 ? [...prev, ...fresh] : prev;
+      const runFrom = dayjs(`${firstKey}-01`).valueOf();
+      const runTo = dayjs(`${lastKey}-01`).endOf('month').valueOf();
+      fetchOrdersApi(runFrom, runTo)
+        .then(rows => {
+          setOrders(prev => {
+            const seen = new Set(prev.map(order => order.id));
+            const fresh = rows.filter(order => !seen.has(order.id));
+            return fresh.length > 0 ? [...prev, ...fresh] : prev;
+          });
+        })
+        .catch(error => {
+          // Un-mark the failed months so scrolling back retries them —
+          // otherwise a transient failure leaves a permanent hole.
+          for (const key of monthKeysBetween(runFrom, runTo)) {
+            requestedRef.current.delete(key);
+          }
+          console.error('Failed to load orders', error);
+        })
+        .finally(() => {
+          inflightRef.current -= 1;
+          if (inflightRef.current === 0) setIsLoading(false);
         });
-        inflightRef.current -= 1;
-        if (inflightRef.current === 0) setIsLoading(false);
-      });
     }
   }, []);
 

--- a/apps/www/src/components/dataview-demo.tsx
+++ b/apps/www/src/components/dataview-demo.tsx
@@ -10,9 +10,11 @@ import {
   DataViewField,
   DataViewListColumn,
   Flex,
-  Text
+  Text,
+  type TimelineActions,
+  type TimelineCardContext
 } from '@raystack/apsara';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 
 type Person = {
   id: string;
@@ -601,6 +603,312 @@ export function DataViewPerViewFieldsDemo() {
           />
         </DataView>
       </div>
+    </Flex>
+  );
+}
+
+/* ── Timeline demo ─────────────────────────────────────────────────────── */
+
+type Task = {
+  id: string;
+  title: string;
+  team: 'Eng' | 'Design' | 'Ops';
+  status: 'todo' | 'active' | 'done';
+  start: string;
+  end: string;
+};
+
+const TASK_DAY_MS = 86_400_000;
+
+/* Dates relative to today, pinned to midnight so the today line is always
+   live and SSR/client renders match (no hydration drift). */
+const taskDate = (days: number) => {
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  return new Date(now.getTime() + days * TASK_DAY_MS).toISOString();
+};
+
+const taskSpec: Array<
+  [string, string, Task['team'], Task['status'], number, number]
+> = [
+  ['t1', 'Design audit', 'Design', 'done', -16, -9],
+  ['t2', 'API contracts', 'Eng', 'done', -13, -6],
+  ['t3', 'Billing revamp', 'Eng', 'active', -7, 2],
+  ['t4', 'Docs sprint', 'Design', 'active', -4, 4],
+  ['t5', 'Bug bash', 'Ops', 'todo', 1, 2],
+  ['t6', 'Load testing', 'Ops', 'todo', 3, 9],
+  ['t7', 'Beta rollout', 'Eng', 'todo', 6, 14],
+  ['t8', 'Launch comms', 'Design', 'todo', 10, 16]
+];
+
+const tasks: Task[] = taskSpec.map(([id, title, team, status, from, to]) => ({
+  id,
+  title,
+  team,
+  status,
+  start: taskDate(from),
+  end: taskDate(to)
+}));
+
+const taskFields: DataViewField<Task>[] = [
+  {
+    accessorKey: 'title',
+    label: 'Task',
+    filterable: true,
+    filterType: 'string',
+    hideable: false
+  },
+  {
+    accessorKey: 'team',
+    label: 'Team',
+    filterable: true,
+    filterType: 'select',
+    hideable: true,
+    filterOptions: [
+      { label: 'Eng', value: 'Eng' },
+      { label: 'Design', value: 'Design' },
+      { label: 'Ops', value: 'Ops' }
+    ]
+  },
+  {
+    accessorKey: 'status',
+    label: 'Status',
+    filterable: true,
+    filterType: 'select',
+    hideable: true,
+    filterOptions: [
+      { label: 'To do', value: 'todo' },
+      { label: 'Active', value: 'active' },
+      { label: 'Done', value: 'done' }
+    ]
+  },
+  {
+    accessorKey: 'start',
+    label: 'Start',
+    filterable: true,
+    filterType: 'date',
+    sortable: true,
+    hideable: true
+  },
+  {
+    accessorKey: 'end',
+    label: 'End',
+    filterable: true,
+    filterType: 'date',
+    sortable: true,
+    hideable: true
+  }
+];
+
+const TASK_STATUS_BADGE: Record<
+  Task['status'],
+  'neutral' | 'accent' | 'success'
+> = {
+  todo: 'neutral',
+  active: 'accent',
+  done: 'success'
+};
+
+/* The card interior is entirely consumer-owned — the Timeline only positions
+   the wrapper. `context.collapsed` flags spans narrower than `minCardWidth`. */
+function TaskCard({
+  task,
+  context
+}: {
+  task: Task;
+  context: TimelineCardContext;
+}) {
+  const chrome: React.CSSProperties = {
+    height: '100%',
+    boxSizing: 'border-box',
+    borderRadius: 'var(--rs-radius-3)',
+    border: '1px solid var(--rs-color-border-base-primary)',
+    background: 'var(--rs-color-background-base-primary)',
+    overflow: 'hidden'
+  };
+  if (context.collapsed) {
+    return (
+      <Flex align='center' justify='center' style={chrome}>
+        <Text size='micro' weight='medium' variant='secondary'>
+          {task.title.charAt(0)}
+        </Text>
+      </Flex>
+    );
+  }
+  return (
+    <Flex
+      direction='column'
+      justify='between'
+      style={{ ...chrome, padding: 'var(--rs-space-3)' }}
+    >
+      <Text
+        size='small'
+        weight='medium'
+        style={{
+          minWidth: 0,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap'
+        }}
+      >
+        {task.title}
+      </Text>
+      <Flex align='center' gap={2}>
+        <Badge size='micro' variant={TASK_STATUS_BADGE[task.status]}>
+          {task.status}
+        </Badge>
+        <DataView.DisplayAccess accessorKey='team'>
+          <Badge size='micro' variant='neutral'>
+            {task.team}
+          </Badge>
+        </DataView.DisplayAccess>
+      </Flex>
+    </Flex>
+  );
+}
+
+/* ── Timeline point-marker demo (no endField) ──────────────────────────── */
+
+type Release = {
+  id: string;
+  version: string;
+  channel: 'stable' | 'beta';
+  date: string;
+};
+
+const releases: Release[] = [
+  { id: 'r1', version: 'v1.8', channel: 'stable', date: taskDate(-14) },
+  { id: 'r2', version: 'v1.9', channel: 'stable', date: taskDate(-9) },
+  { id: 'r3', version: 'v2.0-b1', channel: 'beta', date: taskDate(-4) },
+  { id: 'r4', version: 'v2.0-b2', channel: 'beta', date: taskDate(1) },
+  { id: 'r5', version: 'v2.0', channel: 'stable', date: taskDate(6) },
+  { id: 'r6', version: 'v2.1-b1', channel: 'beta', date: taskDate(11) }
+];
+
+const releaseFields: DataViewField<Release>[] = [
+  {
+    accessorKey: 'version',
+    label: 'Version',
+    filterable: true,
+    filterType: 'string',
+    hideable: false
+  },
+  {
+    accessorKey: 'channel',
+    label: 'Channel',
+    filterable: true,
+    filterType: 'select',
+    hideable: true,
+    filterOptions: [
+      { label: 'Stable', value: 'stable' },
+      { label: 'Beta', value: 'beta' }
+    ]
+  },
+  {
+    accessorKey: 'date',
+    label: 'Date',
+    filterable: true,
+    filterType: 'date',
+    sortable: true,
+    hideable: true
+  }
+];
+
+export function DataViewTimelinePointDemo() {
+  return (
+    <Flex
+      direction='column'
+      style={{ width: '100%', height: 320, overflow: 'hidden' }}
+    >
+      <DataView<Release>
+        data={releases}
+        fields={releaseFields}
+        defaultSort={{ name: 'date', order: 'asc' }}
+        getRowId={release => release.id}
+      >
+        <DataView.Toolbar>
+          <DataView.Filters />
+          <DataView.DisplayControls hideOrdering hideGrouping />
+        </DataView.Toolbar>
+        <Flex
+          direction='column'
+          justify='center'
+          style={{ flex: 1, overflow: 'hidden', minWidth: 0 }}
+        >
+          {/* No endField → point markers: the wrapper sizes to its content. */}
+          <DataView.Timeline<Release>
+            startField='date'
+            estimatedRowHeight={28}
+            renderCard={row => (
+              <Badge
+                variant={
+                  row.original.channel === 'stable' ? 'accent' : 'neutral'
+                }
+              >
+                {row.original.version}
+              </Badge>
+            )}
+          />
+          <DataView.EmptyState>
+            <Text>No releases match your filters.</Text>
+          </DataView.EmptyState>
+        </Flex>
+      </DataView>
+    </Flex>
+  );
+}
+
+export function DataViewTimelineDemo() {
+  const timelineActions = useRef<TimelineActions | null>(null);
+  return (
+    <Flex
+      direction='column'
+      style={{ width: '100%', height: 420, overflow: 'hidden' }}
+    >
+      <DataView<Task>
+        data={tasks}
+        fields={taskFields}
+        defaultSort={{ name: 'start', order: 'asc' }}
+        getRowId={task => task.id}
+      >
+        <DataView.Toolbar>
+          <DataView.Filters />
+          <Flex gap={3} align='center'>
+            <Button
+              size='small'
+              variant='outline'
+              color='neutral'
+              onClick={() => timelineActions.current?.scrollTo('today')}
+            >
+              Today
+            </Button>
+            {/* Sorting/grouping don't affect time-positioned cards — hide them. */}
+            <DataView.DisplayControls hideOrdering hideGrouping />
+          </Flex>
+        </DataView.Toolbar>
+        {/* Empty state lives inside the flex-1 pane so it centers when the
+            timeline renders null. */}
+        <Flex
+          direction='column'
+          justify='center'
+          style={{ flex: 1, overflow: 'hidden', minWidth: 0 }}
+        >
+          <DataView.Timeline<Task>
+            startField='start'
+            endField='end'
+            actionsRef={timelineActions}
+            markers={[
+              { date: taskDate(12), label: 'Release', variant: 'accent' }
+            ]}
+            renderCard={(row, context) => (
+              <TaskCard task={row.original} context={context} />
+            )}
+          />
+          <DataView.EmptyState>
+            <Text>No tasks match your filters.</Text>
+          </DataView.EmptyState>
+        </Flex>
+      </DataView>
     </Flex>
   );
 }

--- a/apps/www/src/components/dataview-demo.tsx
+++ b/apps/www/src/components/dataview-demo.tsx
@@ -638,7 +638,19 @@ const taskSpec: Array<
   ['t5', 'Bug bash', 'Ops', 'todo', 1, 2],
   ['t6', 'Load testing', 'Ops', 'todo', 3, 9],
   ['t7', 'Beta rollout', 'Eng', 'todo', 6, 14],
-  ['t8', 'Launch comms', 'Design', 'todo', 10, 16]
+  ['t8', 'Launch comms', 'Design', 'todo', 10, 16],
+  // Overlapping work per team, so packing stacks a few lanes deep inside each
+  // group section rather than every band being a single row.
+  ['t9', 'Schema migration', 'Eng', 'done', -15, -10],
+  ['t10', 'Icon refresh', 'Design', 'done', -12, -5],
+  ['t11', 'On-call rotation', 'Ops', 'active', -11, -2],
+  ['t12', 'Runbook cleanup', 'Ops', 'done', -14, -8],
+  ['t13', 'Search indexing', 'Eng', 'active', -3, 6],
+  ['t14', 'Motion pass', 'Design', 'active', -2, 5],
+  ['t15', 'Cost review', 'Ops', 'todo', 4, 12],
+  ['t16', 'SSO hardening', 'Eng', 'todo', 8, 15],
+  ['t17', 'Empty states', 'Design', 'todo', 7, 13],
+  ['t18', 'Chaos drill', 'Ops', 'todo', 11, 15]
 ];
 
 const tasks: Task[] = taskSpec.map(([id, title, team, status, from, to]) => ({
@@ -664,6 +676,9 @@ const taskFields: DataViewField<Task>[] = [
     filterable: true,
     filterType: 'select',
     hideable: true,
+    // Groupable → the timeline renders one swim-lane section per team.
+    groupable: true,
+    showGroupCount: true,
     filterOptions: [
       { label: 'Eng', value: 'Eng' },
       { label: 'Design', value: 'Design' },
@@ -676,6 +691,9 @@ const taskFields: DataViewField<Task>[] = [
     filterable: true,
     filterType: 'select',
     hideable: true,
+    groupable: true,
+    showGroupCount: true,
+    groupLabelsMap: { todo: 'To do', active: 'Active', done: 'Done' },
     filterOptions: [
       { label: 'To do', value: 'todo' },
       { label: 'Active', value: 'active' },
@@ -884,8 +902,10 @@ export function DataViewTimelineDemo() {
             >
               Today
             </Button>
-            {/* Sorting/grouping don't affect time-positioned cards — hide them. */}
-            <DataView.DisplayControls hideOrdering hideGrouping />
+            {/* Sort can't move a card horizontally (x is time) and `auto`
+                packing is chronological, so Ordering is hidden. Grouping is
+                left in: it renders swim-lane sections — try Team or Status. */}
+            <DataView.DisplayControls hideOrdering />
           </Flex>
         </DataView.Toolbar>
         {/* Empty state lives inside the flex-1 pane so it centers when the
@@ -902,6 +922,50 @@ export function DataViewTimelineDemo() {
             markers={[
               { date: taskDate(12), label: 'Release', variant: 'accent' }
             ]}
+            renderCard={(row, context) => (
+              <TaskCard task={row.original} context={context} />
+            )}
+          />
+          <DataView.EmptyState>
+            <Text>No tasks match your filters.</Text>
+          </DataView.EmptyState>
+        </Flex>
+      </DataView>
+    </Flex>
+  );
+}
+
+/* ── Grouped timeline demo (swim-lane sections) ────────────────────────────
+   `group_by` in the query is the only wiring grouping needs — the timeline
+   consumes the same group rows `DataView.List` renders as section headers, so
+   labels, order, and counts match between the two views. Packing runs per
+   section, and each band pins under the axis while its section is in view. */
+
+export function DataViewTimelineGroupingDemo() {
+  return (
+    <Flex
+      direction='column'
+      style={{ width: '100%', height: 460, overflow: 'hidden' }}
+    >
+      <DataView<Task>
+        data={tasks}
+        fields={taskFields}
+        defaultSort={{ name: 'start', order: 'asc' }}
+        query={{ group_by: ['team'] }}
+        getRowId={task => task.id}
+      >
+        <DataView.Toolbar>
+          <DataView.Filters />
+          <DataView.DisplayControls hideOrdering />
+        </DataView.Toolbar>
+        <Flex
+          direction='column'
+          justify='center'
+          style={{ flex: 1, overflow: 'hidden', minWidth: 0 }}
+        >
+          <DataView.Timeline<Task>
+            startField='start'
+            endField='end'
             renderCard={(row, context) => (
               <TaskCard task={row.original} context={context} />
             )}

--- a/apps/www/src/components/dataview-demo.tsx
+++ b/apps/www/src/components/dataview-demo.tsx
@@ -718,8 +718,10 @@ function TaskCard({
   task: Task;
   context: TimelineCardContext;
 }) {
+  // Card height is content-driven (the wrapper auto-measures, like
+  // DataView.List rows) — fix it here so collapsed stubs match full cards.
   const chrome: React.CSSProperties = {
-    height: '100%',
+    height: 64,
     boxSizing: 'border-box',
     borderRadius: 'var(--rs-radius-3)',
     border: '1px solid var(--rs-color-border-base-primary)',

--- a/apps/www/src/components/demo/demo.tsx
+++ b/apps/www/src/components/demo/demo.tsx
@@ -52,6 +52,8 @@ import {
   DataViewPerViewFieldsDemo,
   DataViewSearchDemo,
   DataViewTableDemo,
+  DataViewTimelineDemo,
+  DataViewTimelinePointDemo,
   DataViewVirtualizedDemo,
   DataViewVirtualizedGroupingDemo
 } from '../dataview-demo';
@@ -87,6 +89,8 @@ export default function Demo(props: DemoProps) {
       DataViewLoadingDemo,
       DataViewPerViewFieldsDemo,
       DataViewSearchDemo,
+      DataViewTimelineDemo,
+      DataViewTimelinePointDemo,
       ChipInputDemo,
       DataTableSelectionDemo,
       LinearMenuDemo,

--- a/apps/www/src/components/demo/demo.tsx
+++ b/apps/www/src/components/demo/demo.tsx
@@ -53,6 +53,7 @@ import {
   DataViewSearchDemo,
   DataViewTableDemo,
   DataViewTimelineDemo,
+  DataViewTimelineGroupingDemo,
   DataViewTimelinePointDemo,
   DataViewVirtualizedDemo,
   DataViewVirtualizedGroupingDemo
@@ -90,6 +91,7 @@ export default function Demo(props: DemoProps) {
       DataViewPerViewFieldsDemo,
       DataViewSearchDemo,
       DataViewTimelineDemo,
+      DataViewTimelineGroupingDemo,
       DataViewTimelinePointDemo,
       ChipInputDemo,
       DataTableSelectionDemo,

--- a/apps/www/src/content/docs/components/dataview/demo.ts
+++ b/apps/www/src/content/docs/components/dataview/demo.ts
@@ -331,3 +331,79 @@ export const searchPreview = {
     }
   ]
 };
+
+export const timelinePreview = {
+  type: 'code',
+  style: { padding: 0 },
+  previewCode: false,
+  code: `<DataViewTimelineDemo />`,
+  codePreview: [
+    {
+      label: 'index.tsx',
+      code: `
+      /* The Timeline owns positioning: date → x, span → width, lane packing,
+         the sticky two-tier axis, and native x/y scrolling. The card interior
+         is entirely yours via renderCard. */
+      const timelineActions = useRef<TimelineActions | null>(null);
+
+      <DataView data={tasks} fields={fields} defaultSort={{ name: "start", order: "asc" }} getRowId={(t) => t.id}>
+        <DataView.Toolbar>
+          <DataView.Filters />
+          <Flex gap={3} align="center">
+            <Button size="small" variant="outline" color="neutral"
+              onClick={() => timelineActions.current?.scrollTo("today")}>
+              Today
+            </Button>
+            {/* Sorting/grouping don't affect time-positioned cards — hide them. */}
+            <DataView.DisplayControls hideOrdering hideGrouping />
+          </Flex>
+        </DataView.Toolbar>
+
+        <DataView.Timeline
+          startField="start"
+          endField="end"
+          actionsRef={timelineActions}
+          markers={[{ date: releaseDate, label: "Release", variant: "accent" }]}
+          renderCard={(row, context) =>
+            context.collapsed
+              ? <CompactStub task={row.original} />
+              : <TaskCard task={row.original} />
+          }
+        />
+        <DataView.EmptyState>
+          <Text>No tasks match your filters.</Text>
+        </DataView.EmptyState>
+      </DataView>`
+    }
+  ]
+};
+
+export const timelinePointPreview = {
+  type: 'code',
+  style: { padding: 0 },
+  previewCode: false,
+  code: `<DataViewTimelinePointDemo />`,
+  codePreview: [
+    {
+      label: 'index.tsx',
+      code: `
+      /* Omit endField → point markers. The wrapper sizes to its content
+         instead of a time span, and context.end is null. */
+      <DataView data={releases} fields={fields} defaultSort={{ name: "date", order: "asc" }} getRowId={(r) => r.id}>
+        <DataView.Toolbar>
+          <DataView.Filters />
+          <DataView.DisplayControls hideOrdering hideGrouping />
+        </DataView.Toolbar>
+        <DataView.Timeline
+          startField="date"
+          estimatedRowHeight={28}
+          renderCard={(row) => (
+            <Badge variant={row.original.channel === "stable" ? "accent" : "neutral"}>
+              {row.original.version}
+            </Badge>
+          )}
+        />
+      </DataView>`
+    }
+  ]
+};

--- a/apps/www/src/content/docs/components/dataview/demo.ts
+++ b/apps/www/src/content/docs/components/dataview/demo.ts
@@ -354,8 +354,9 @@ export const timelinePreview = {
               onClick={() => timelineActions.current?.scrollTo("today")}>
               Today
             </Button>
-            {/* Sorting/grouping don't affect time-positioned cards — hide them. */}
-            <DataView.DisplayControls hideOrdering hideGrouping />
+            {/* Sort can't move a time-positioned card — hide Ordering.
+                Grouping is left in: it renders swim-lane sections. */}
+            <DataView.DisplayControls hideOrdering />
           </Flex>
         </DataView.Toolbar>
 
@@ -373,6 +374,45 @@ export const timelinePreview = {
         <DataView.EmptyState>
           <Text>No tasks match your filters.</Text>
         </DataView.EmptyState>
+      </DataView>`
+    }
+  ]
+};
+
+export const timelineGroupingPreview = {
+  type: 'code',
+  style: { padding: 0 },
+  previewCode: false,
+  code: `<DataViewTimelineGroupingDemo />`,
+  codePreview: [
+    {
+      label: 'index.tsx',
+      code: `
+      /* group_by in the query is the whole wiring. The timeline consumes the
+         same group rows DataView.List renders as section headers, so section
+         order, labels, and counts match between the two views. Each band pins
+         under the axis while its section is in view; packing runs per section.
+         Mark the field groupable (and showGroupCount for the badge):
+
+           { accessorKey: "team", label: "Team", groupable: true, showGroupCount: true } */
+
+      <DataView
+        data={tasks}
+        fields={fields}
+        defaultSort={{ name: "start", order: "asc" }}
+        query={{ group_by: ["team"] }}
+        getRowId={(t) => t.id}>
+        <DataView.Toolbar>
+          <DataView.Filters />
+          <DataView.DisplayControls hideOrdering />
+        </DataView.Toolbar>
+
+        <DataView.Timeline
+          startField="start"
+          endField="end"
+          // showGroupHeaders={false} hides the bands, keeps the sections
+          renderCard={(row, context) => <TaskCard task={row.original} context={context} />}
+        />
       </DataView>`
     }
   ]

--- a/apps/www/src/content/docs/components/dataview/index.mdx
+++ b/apps/www/src/content/docs/components/dataview/index.mdx
@@ -328,7 +328,9 @@ The Timeline owns **positioning** — the time scale (date → x, span → width
 />
 ```
 
-`context.collapsed` flips when the span is narrower than `minCardWidth` (default 60px) — render a compact stub instead of letting the full card clip. Wrap card fields in `DataView.DisplayAccess` so the toolbar's Display Properties toggles reach them.
+`context.collapsed` flips when the span is narrower than `minCardWidth` (default 60px) — render a compact stub instead of letting the full card clip (point cards never collapse; they size to their content). Wrap card fields in `DataView.DisplayAccess` so the toolbar's Display Properties toggles reach them.
+
+Card height is content-driven, the same contract as `DataView.List` rows: cards auto-measure after paint, each lane sizes to its tallest card, and `estimatedRowHeight` (default 66) is only a layout hint until real heights arrive. Give your card an explicit height if you want uniform cards. Keep `renderCard` referentially stable (define it outside the component or wrap it in `useCallback`) — cards are memoized against it, and an inline closure forces every visible card to re-render on each scroll frame.
 
 ### Point markers
 
@@ -377,13 +379,15 @@ const timelineActions = useRef<TimelineActions | null>(null);
 
 `scrollTo(target, { align = "center", behavior = "smooth" })` accepts the same target vocabulary as `defaultScrollTo`. Out-of-domain dates clamp to the nearest domain edge; while the timeline is hidden (inactive view, no data) calls no-op with a dev warning. `getVisibleRange()` returns the visible `[Date, Date]` window (or `null` while hidden) — useful for showing the Today button only when today is off-screen.
 
+Filtering navigates too: when a filter or search change leaves no matching card in the viewport, the timeline scrolls the earliest match into view instead of leaving you parked on empty canvas (a change whose results are already on screen doesn't move the view). Opt out with `scrollToResults={false}`.
+
 ### Loading data by visible range
 
 Offset pagination doesn't fit a 2-D time canvas — the natural unit of fetching is the **visible window**. The recommended pattern is client mode + `onVisibleRangeChange`:
 
 1. Fix the coordinate space with an explicit `range` so the scrollbar stays stable while rows stream in.
 2. On `onVisibleRangeChange`, widen the window by a prefetch pad and fetch rows **overlapping** it (`start <= to AND end >= from` — a containment filter drops cards straddling the window edges).
-3. Track requested buckets (e.g. months) in a `Set` so re-entering a window is free, and dedupe merged rows by id — edge-straddling rows come back from both adjacent fetches.
+3. Track requested buckets (e.g. months) in a `Set` so re-entering a window is free, and dedupe merged rows by id — edge-straddling rows come back from both adjacent fetches. On a failed fetch, delete the affected buckets from the `Set` so scrolling back retries them instead of leaving a permanent hole.
 4. Throttle, don't debounce: a debounce waits for scrolling to stop, leaving a gap of missing cards mid-drag.
 
 ```tsx
@@ -415,4 +419,4 @@ Start with `isLoading={true}` and fire an initial fetch on mount: with no data a
 
 - **Grouping and sorting are bypassed** — cards are positioned by time, so group buckets and sort order have no geometric meaning. Hide both controls while a timeline view is active (`<DataView.DisplayControls hideOrdering hideGrouping />`), or pass the timeline a per-view `fields` override without `sortable`/`groupable`.
 - **`virtualized`** enables horizontal culling: only cards and gridlines near the viewport render. Recommended whenever the domain is long or rows are numerous.
-- **Interaction** — cards receive row clicks via the root's `onRowClick`; the background supports mouse drag-to-pan with a momentum glide; scrolling past the domain edge won't trigger browser back-swipe.
+- **Interaction** — cards receive row clicks via the root's `onRowClick`; the background supports mouse drag-to-pan with a momentum glide; scrolling past the domain edge won't trigger browser back-swipe. The pane is a focusable, labelled region (`aria-label`, default "Timeline"), so keyboard users can Tab to it and scroll with the arrow keys.

--- a/apps/www/src/content/docs/components/dataview/index.mdx
+++ b/apps/www/src/content/docs/components/dataview/index.mdx
@@ -17,6 +17,7 @@ import {
   loadingPreview,
   perViewFieldsPreview,
   timelinePreview,
+  timelineGroupingPreview,
   timelinePointPreview,
 } from "./demo.ts";
 
@@ -306,7 +307,7 @@ In server mode, `onTableQueryChange` fires whenever the query changes. The `Data
 
 ## Timeline
 
-`DataView.Timeline` positions the same row model as cards on a continuous, horizontally scrollable time axis — orders on a delivery schedule, tasks on a Gantt-style plan, releases on a strip. It shares the root's entire data layer: search, filters, and Display Properties apply to cards exactly as they do to list rows, and it participates in multi-view switching via `name`.
+`DataView.Timeline` positions the same row model as cards on a continuous, horizontally scrollable time axis — orders on a delivery schedule, tasks on a Gantt-style plan, releases on a strip. It shares the root's entire data layer: search, filters, grouping, and Display Properties apply to cards exactly as they do to list rows, and it participates in multi-view switching via `name`.
 
 In the demo below: drag the background to pan (with a momentum glide), hover for the snapped date cursor, and use the Today button — wired through `actionsRef` — to jump back. The narrow "B" stub is a span shorter than `minCardWidth`, rendered via `context.collapsed`.
 
@@ -337,6 +338,37 @@ Card height is content-driven, the same contract as `DataView.List` rows: cards 
 Omit `endField` and rows render as point markers at their date — releases, incidents, audit events. The wrapper sizes to the card's content instead of a time span, and `context.end` is `null`. Because the packer can't measure content, it assumes each point card is `estimatedPointWidth` wide (default 120px) when assigning lanes — set it to roughly your widest point card so nearby markers don't overlap in a lane.
 
 <Demo data={timelinePointPreview} />
+
+### Grouping
+
+Set `group_by` (from `DataView.DisplayControls` → Grouping, or on the initial `query`) and the timeline splits into **swim-lane sections** stacked under the single shared time axis: a full-width header band per group, that group's cards lane-packed beneath it. Horizontal position stays purely time — grouping reorganizes vertically only.
+
+<Demo data={timelineGroupingPreview} />
+
+```tsx
+// Mark the field groupable; showGroupCount adds the count badge to the band.
+const fields = [
+  { accessorKey: "team", label: "Team", groupable: true, showGroupCount: true },
+  …
+];
+
+<DataView data={tasks} fields={fields} query={{ group_by: ["team"] }} …>
+  <DataView.Timeline startField="start" endField="end" renderCard={renderCard} />
+</DataView>
+```
+
+The timeline consumes the **same group rows** `DataView.List` renders as section headers — the root's `groupData` output, in first-occurrence order — so section order, labels (`groupLabelsMap`), and counts (`groupCountMap`, or the bucket size) match between views, in client and server mode alike. There's no timeline-specific grouping path to keep in sync.
+
+- **Packing is per section.** A card only ever shares a lane with cards in its own group, and `context.laneIndex` is section-relative (every section starts at lane 0). `lanePacking="one-per-row"` applies within each section too.
+- **Bands pin while their section is in view.** The active band sticks directly under the time axis and is pushed off by the next section's band; its label sticks to the left edge so it stays readable while you pan to a distant month. Always on — pure CSS, no prop.
+- **Empty sections disappear.** A group whose cards all fall outside an explicit `range` (or that has no valid `startField` values) renders nothing — no band, no empty strip. A band that *does* render shows the full group count, even when some of its cards are culled, matching List.
+- **`showGroupHeaders={false}`** hides the bands but keeps the sections — same semantics as the prop on `DataView.List`. Style a band with `classNames.groupHeader`.
+
+Bands are labels only in this release: no chevron, no collapsing.
+
+### Ordering
+
+Sort can't move a card horizontally — x is locked to the start date — so it surfaces in exactly one place: `lanePacking="one-per-row"`, where vertical row order follows the active sort (within each section when grouped). With the default `auto` packing, lanes are assigned by dense chronological first-fit and the sort has no visible effect, so hide the Ordering control (`<DataView.DisplayControls hideOrdering />`) or leave `sortable` off the timeline's per-view `fields` unless you use `one-per-row`.
 
 ### Scale and axis
 
@@ -417,6 +449,7 @@ Start with `isLoading={true}` and fire an initial fetch on mount: with no data a
 
 ### Notes
 
-- **Grouping and sorting are bypassed** — cards are positioned by time, so group buckets and sort order have no geometric meaning. Hide both controls while a timeline view is active (`<DataView.DisplayControls hideOrdering hideGrouping />`), or pass the timeline a per-view `fields` override without `sortable`/`groupable`.
+- **Grouping** renders as swim-lane sections and **sorting** only reaches `lanePacking="one-per-row"` — see [Grouping](#grouping) and [Ordering](#ordering). Hide a control that has no meaning for your configuration (`<DataView.DisplayControls hideOrdering />`), or pass the timeline a per-view `fields` override without `sortable`/`groupable`.
+- **Vertical space is not virtualized.** `virtualized` culls horizontally only, so a grouped timeline renders every section's cards that fall in the visible time window. Deep grouping over thousands of rows will render a tall canvas.
 - **`virtualized`** enables horizontal culling: only cards and gridlines near the viewport render. Recommended whenever the domain is long or rows are numerous.
 - **Interaction** — cards receive row clicks via the root's `onRowClick`; the background supports mouse drag-to-pan with a momentum glide; scrolling past the domain edge won't trigger browser back-swipe. The pane is a focusable, labelled region (`aria-label`, default "Timeline"), so keyboard users can Tab to it and scroll with the arrow keys.

--- a/apps/www/src/content/docs/components/dataview/index.mdx
+++ b/apps/www/src/content/docs/components/dataview/index.mdx
@@ -16,6 +16,8 @@ import {
   virtualizedGroupingPreview,
   loadingPreview,
   perViewFieldsPreview,
+  timelinePreview,
+  timelinePointPreview,
 } from "./demo.ts";
 
 <Demo data={tablePreview} />
@@ -24,7 +26,7 @@ import {
 
 `DataView` owns the data layer — query state (filters, sort, group, search), client/server mode, row model derivation — and lets you pick the renderer that draws it. The same `<DataView>` can host a table, a list, or a free-form view, switchable at runtime without losing query state.
 
-In scope today: `DataView.List` (table + list presentations) and `DataView.Custom` (escape hatch for cards, kanban, gallery, etc.).
+In scope today: `DataView.List` (table + list presentations), `DataView.Timeline` (cards positioned on a continuous time axis — full guide in [Timeline](#timeline)), and `DataView.Custom` (escape hatch for cards, kanban, gallery, etc.).
 
 ## Anatomy
 
@@ -152,6 +154,26 @@ Visibility is a **single global map** on context. `DataView.List` honours it for
 #### Column
 
 <auto-type-table path="./props.ts" name="DataViewListColumn" />
+
+### DataView.Timeline
+
+<auto-type-table path="./props.ts" name="DataViewTimelineProps" />
+
+#### Card context
+
+Passed as the second argument to `renderCard`.
+
+<auto-type-table path="./props.ts" name="TimelineCardContext" />
+
+#### Marker
+
+<auto-type-table path="./props.ts" name="TimelineMarker" />
+
+#### Actions
+
+The imperative handle received through `actionsRef`.
+
+<auto-type-table path="./props.ts" name="TimelineActions" />
 
 ### DataView.Custom
 
@@ -281,3 +303,116 @@ The wire format keeps `group_by: string[]`. To group by something that isn't a r
 ```
 
 In server mode, `onTableQueryChange` fires whenever the query changes. The `DataView.List` shows skeleton loader rows when `isLoading` is true. Filter predicates and sort run on the server — the local TanStack table is manual.
+
+## Timeline
+
+`DataView.Timeline` positions the same row model as cards on a continuous, horizontally scrollable time axis — orders on a delivery schedule, tasks on a Gantt-style plan, releases on a strip. It shares the root's entire data layer: search, filters, and Display Properties apply to cards exactly as they do to list rows, and it participates in multi-view switching via `name`.
+
+In the demo below: drag the background to pan (with a momentum glide), hover for the snapped date cursor, and use the Today button — wired through `actionsRef` — to jump back. The narrow "B" stub is a span shorter than `minCardWidth`, rendered via `context.collapsed`.
+
+<Demo data={timelinePreview} />
+
+### Cards
+
+The Timeline owns **positioning** — the time scale (date → x, span → width, using real timestamps so variable-length months don't distort placement), lane packing (non-overlapping cards share a lane; `lanePacking="one-per-row"` opts out), the sticky two-tier axis, and scrolling. You own the **card**: `renderCard(row, context)` draws everything visual, the same split as `DataView.List`'s `columns[].cell`.
+
+```tsx
+<DataView.Timeline
+  startField="start"
+  endField="end"
+  renderCard={(row, context) => {
+    // context: { width, collapsed, laneIndex, start, end }
+    if (context.collapsed) return <CompactStub task={row.original} />;
+    return <TaskCard task={row.original} />;
+  }}
+/>
+```
+
+`context.collapsed` flips when the span is narrower than `minCardWidth` (default 60px) — render a compact stub instead of letting the full card clip. Wrap card fields in `DataView.DisplayAccess` so the toolbar's Display Properties toggles reach them.
+
+### Point markers
+
+Omit `endField` and rows render as point markers at their date — releases, incidents, audit events. The wrapper sizes to the card's content instead of a time span, and `context.end` is `null`. Because the packer can't measure content, it assumes each point card is `estimatedPointWidth` wide (default 120px) when assigning lanes — set it to roughly your widest point card so nearby markers don't overlap in a lane.
+
+<Demo data={timelinePointPreview} />
+
+### Scale and axis
+
+Four props control the axis, and they compose rather than overlap:
+
+- `scale` — the tick unit: `day` (default), `week`, `month`, or `quarter`.
+- `unitWidth` — pixels per unit (defaults: day 20, week 56, month 96, quarter 140). This is the zoom knob.
+- `tickInterval` — label every Nth unit. Labels never render closer than a collision floor, so a too-dense value degrades gracefully instead of overlapping.
+- `gridlineInterval` — draw a gridline every Nth unit. Purely visual: cards, the today line, and cursor snapping still land on every unit.
+
+The domain defaults to the data extent (plus today and markers) with padding. Pass an explicit `range` to fix the coordinate space — essential for range-window loading below, since the scrollbar then never jumps as data streams in. Rows entirely outside an explicit `range` are culled.
+
+### Today and markers
+
+`today` (default `true`) draws a vertical line with a date badge pinned to the axis, at day precision so server and client renders agree. Pin it to a fixed date with `today={date}` or hide it with `today={false}`. `markers` adds more full-height lines for milestones and deadlines:
+
+```tsx
+<DataView.Timeline
+  markers={[
+    { date: "2026-08-01", label: "Code freeze" },
+    { date: "2026-08-15", label: "Release", variant: "accent" },
+    { date: "2026-08-20", label: "EOL", variant: "danger" },
+  ]}
+/>
+```
+
+### Navigation
+
+`defaultScrollTo` (default `'today'`) sets the initial scroll position: a date, `'today'`, `'start'`, or `'end'`. After mount, navigate imperatively through `actionsRef`:
+
+```tsx
+const timelineActions = useRef<TimelineActions | null>(null);
+
+<DataView.Timeline actionsRef={timelineActions} … />
+
+<Button onClick={() => timelineActions.current?.scrollTo("today")}>
+  Today
+</Button>
+```
+
+`scrollTo(target, { align = "center", behavior = "smooth" })` accepts the same target vocabulary as `defaultScrollTo`. Out-of-domain dates clamp to the nearest domain edge; while the timeline is hidden (inactive view, no data) calls no-op with a dev warning. `getVisibleRange()` returns the visible `[Date, Date]` window (or `null` while hidden) — useful for showing the Today button only when today is off-screen.
+
+### Loading data by visible range
+
+Offset pagination doesn't fit a 2-D time canvas — the natural unit of fetching is the **visible window**. The recommended pattern is client mode + `onVisibleRangeChange`:
+
+1. Fix the coordinate space with an explicit `range` so the scrollbar stays stable while rows stream in.
+2. On `onVisibleRangeChange`, widen the window by a prefetch pad and fetch rows **overlapping** it (`start <= to AND end >= from` — a containment filter drops cards straddling the window edges).
+3. Track requested buckets (e.g. months) in a `Set` so re-entering a window is free, and dedupe merged rows by id — edge-straddling rows come back from both adjacent fetches.
+4. Throttle, don't debounce: a debounce waits for scrolling to stop, leaving a gap of missing cards mid-drag.
+
+```tsx
+const [orders, setOrders] = useState<Order[]>([]);
+const [isLoading, setIsLoading] = useState(true); // initial fetch in flight
+
+<DataView
+  data={orders}
+  fields={fields}
+  mode="client" // filters/search run locally against loaded rows
+  isLoading={isLoading}
+  defaultSort={{ name: "start", order: "asc" }}
+  getRowId={(o) => o.id}
+>
+  <DataView.Timeline
+    startField="start"
+    endField="end"
+    range={FIXED_RANGE}
+    virtualized
+    onVisibleRangeChange={([from, to]) => throttledLoadWindow(from, to)}
+    renderCard={renderOrderCard}
+  />
+</DataView>
+```
+
+Start with `isLoading={true}` and fire an initial fetch on mount: with no data and no loading flag the timeline renders `null` (the zero state takes over), so `onVisibleRangeChange` would never fire to bootstrap the first window. Keep the row model **cumulative** — the domain is stable, so previously fetched cards stay mounted and scrolling back is instant. Scroll position is anchored by *time*, not pixels: if the domain shifts (a `range` extension, rows prepended by a fetch), the date under the viewport's left edge stays put instead of the content jumping.
+
+### Notes
+
+- **Grouping and sorting are bypassed** — cards are positioned by time, so group buckets and sort order have no geometric meaning. Hide both controls while a timeline view is active (`<DataView.DisplayControls hideOrdering hideGrouping />`), or pass the timeline a per-view `fields` override without `sortable`/`groupable`.
+- **`virtualized`** enables horizontal culling: only cards and gridlines near the viewport render. Recommended whenever the domain is long or rows are numerous.
+- **Interaction** — cards receive row clicks via the root's `onRowClick`; the background supports mouse drag-to-pan with a momentum glide; scrolling past the domain edge won't trigger browser back-swipe.

--- a/apps/www/src/content/docs/components/dataview/props.ts
+++ b/apps/www/src/content/docs/components/dataview/props.ts
@@ -179,6 +179,13 @@ export interface DataViewTimelineProps {
   /** Multi-view name. When set, the renderer gates itself on the active view. */
   name?: string;
 
+  /**
+   * Accessible name of the scroll region. The pane is keyboard-focusable (arrow keys
+   * scroll it natively), so screen readers announce this label on focus.
+   * @defaultValue "Timeline"
+   */
+  'aria-label'?: string;
+
   /** Optional view-scoped field override (full replacement). */
   fields?: DataViewField[];
 
@@ -191,8 +198,10 @@ export interface DataViewTimelineProps {
   /**
    * Renders the card interior. The Timeline owns positioning (x from start,
    * width from span, lane from packing, scroll); the consumer owns the card
-   * visual entirely. Compose `DataView.DisplayAccess` inside for Display
-   * Properties support. (Required)
+   * visual entirely. The first argument is the TanStack `Row` wrapper — the
+   * row data is on `row.original`. Keep the reference stable (`useCallback`):
+   * cards are memoized against it. Compose `DataView.DisplayAccess` inside
+   * for Display Properties support. (Required)
    */
   renderCard: (row: T, context: TimelineCardContext) => ReactNode;
 
@@ -241,11 +250,23 @@ export interface DataViewTimelineProps {
    */
   showCursorLine?: boolean;
 
+  // The literals are named in the description because the rendered type
+  // column can't show them — TS collapses them into TimelineDateInput's
+  // `string` when the union resolves. Same for scrollTo's target below.
   /**
-   * Initial horizontal scroll target.
+   * Initial horizontal scroll target: a date, or one of `'today'` | `'start'` | `'end'`
+   * (the domain edges).
    * @defaultValue "today"
    */
   defaultScrollTo?: TimelineDateInput | 'today' | 'start' | 'end';
+
+  /**
+   * After a filter or search change, scroll the earliest matching card into view when
+   * no match is visible in the current viewport. A query change that keeps a card on
+   * screen doesn't move the view.
+   * @defaultValue true
+   */
+  scrollToResults?: boolean;
 
   /** Fires (rAF-throttled) with the visible time range as the user scrolls or resizes. */
   onVisibleRangeChange?: (range: [Date, Date]) => void;
@@ -260,7 +281,9 @@ export interface DataViewTimelineProps {
   lanePacking?: 'auto' | 'one-per-row';
 
   /**
-   * Card height in px (cards render at exactly this height; named to match `DataView.List`).
+   * Estimated card height in px, same contract as `DataView.List`: cards render at their
+   * natural content height and auto-measure after paint; the estimate seeds lane layout
+   * until real heights arrive. Each lane sizes to its tallest card.
    * @defaultValue 66
    */
   estimatedRowHeight?: number;
@@ -324,8 +347,11 @@ export interface TimelineMarker {
 
 export interface TimelineActions {
   /**
-   * Scroll the viewport so the target lands at `align`. Out-of-domain dates
-   * clamp to the nearest edge; no-ops (dev warning) while the renderer is hidden.
+   * Scroll the viewport so the target lands at `align`. The target is a date, or
+   * one of `'today'` | `'start'` | `'end'` (the domain edges) — same vocabulary as
+   * `defaultScrollTo`. Edge alignments keep a small inset so the target doesn't sit
+   * flush against the viewport edge (yields at the domain edges). Out-of-domain
+   * dates clamp to the nearest edge; no-ops (dev warning) while the renderer is hidden.
    */
   scrollTo: (
     target: TimelineDateInput | 'today' | 'start' | 'end',

--- a/apps/www/src/content/docs/components/dataview/props.ts
+++ b/apps/www/src/content/docs/components/dataview/props.ts
@@ -275,7 +275,9 @@ export interface DataViewTimelineProps {
   actionsRef?: RefObject<TimelineActions | null>;
 
   /**
-   * `auto` packs non-overlapping cards into shared lanes; `one-per-row` gives every row its own lane.
+   * `auto` packs non-overlapping cards into shared lanes; `one-per-row` gives every row
+   * its own lane, in row-model (sorted) order. Both apply per group section while
+   * `group_by` is active — cards never share a lane across sections.
    * @defaultValue "auto"
    */
   lanePacking?: 'auto' | 'one-per-row';
@@ -310,7 +312,15 @@ export interface DataViewTimelineProps {
   /** When true, only cards/gridlines near the visible viewport are rendered (horizontal culling). */
   virtualized?: boolean;
 
-  /** Class overrides per part: root, axis, band, tick, marker, gridline, cursor, canvas, card. */
+  /**
+   * Render the group header band above each swim-lane section while `group_by`
+   * is active. False hides the bands only — rows stay grouped into sections
+   * (same contract as `DataViewListProps.showGroupHeaders`).
+   * @defaultValue true
+   */
+  showGroupHeaders?: boolean;
+
+  /** Class overrides per part: root, axis, band, tick, marker, gridline, cursor, canvas, card, groupHeader. */
   classNames?: Record<string, string>;
 }
 
@@ -321,7 +331,10 @@ export interface TimelineCardContext {
   /** True when the span is narrower than `minCardWidth`. */
   collapsed: boolean;
 
-  /** Lane (row) index assigned by packing. */
+  /**
+   * Lane (row) index assigned by packing. Relative to the card's own group
+   * section when `group_by` is active — every section's first lane is 0.
+   */
   laneIndex: number;
 
   /** Resolved start date. */

--- a/apps/www/src/content/docs/components/dataview/props.ts
+++ b/apps/www/src/content/docs/components/dataview/props.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, RefObject } from 'react';
 
 // Documentation-only placeholders so `auto-type-table` can render the public
 // API without surfacing real generics (TData is shown as `T` for readability).
@@ -159,10 +159,10 @@ export interface DataViewListColumn {
   accessorKey: string;
 
   /** TanStack-style cell renderer. */
-  cell?: (ctx) => ReactNode;
+  cell?: (ctx: T) => ReactNode;
 
   /** TanStack-style header renderer. Overrides the field `label`. */
-  header?: (ctx) => ReactNode;
+  header?: (ctx: T) => ReactNode;
 
   /**
    * CSS grid track width.
@@ -170,6 +170,175 @@ export interface DataViewListColumn {
    * @defaultValue "1fr"
    */
   width?: string | number;
+}
+
+/** Date inputs accepted by Timeline props and row fields. */
+type TimelineDateInput = Date | number | string;
+
+export interface DataViewTimelineProps {
+  /** Multi-view name. When set, the renderer gates itself on the active view. */
+  name?: string;
+
+  /** Optional view-scoped field override (full replacement). */
+  fields?: DataViewField[];
+
+  /** Accessor key on the row yielding the start date. Rows with a missing/invalid value are skipped. (Required) */
+  startField: string;
+
+  /** Accessor key for the end date. Omitted → point markers; present → variable-width span cards. */
+  endField?: string;
+
+  /**
+   * Renders the card interior. The Timeline owns positioning (x from start,
+   * width from span, lane from packing, scroll); the consumer owns the card
+   * visual entirely. Compose `DataView.DisplayAccess` inside for Display
+   * Properties support. (Required)
+   */
+  renderCard: (row: T, context: TimelineCardContext) => ReactNode;
+
+  /**
+   * Tick granularity of the time axis.
+   * @defaultValue "day"
+   */
+  scale?: 'day' | 'week' | 'month' | 'quarter';
+
+  /** Pixel width of one `scale` unit — density/zoom override. Defaults per scale (day 20, week 56, month 96, quarter 140). */
+  unitWidth?: number;
+
+  /**
+   * Explicit time domain. Defaults to the data extent (plus today/markers) with padding.
+   * A domain narrower than the container is extended at the end so the axis and gridlines fill the visible width.
+   */
+  range?: [TimelineDateInput, TimelineDateInput];
+
+  /**
+   * Vertical "today" line + axis badge. `true` uses the current date; a date pins it; `false` hides it.
+   * @defaultValue true
+   */
+  today?: boolean | TimelineDateInput;
+
+  /** Additional full-height marker lines with axis badges (milestones, deadlines). */
+  markers?: TimelineMarker[];
+
+  /**
+   * Vertical gridlines at axis ticks.
+   * @defaultValue true
+   */
+  showGridlines?: boolean;
+
+  /** Label every Nth `scale` unit on the axis. Labels never render closer than the collision floor. Default: densest interval that fits. */
+  tickInterval?: number;
+
+  /**
+   * Draw a gridline every Nth `scale` unit. Purely visual — positioning stays at full unit granularity.
+   * @defaultValue 1
+   */
+  gridlineInterval?: number;
+
+  /**
+   * Hover crosshair snapped to the unit under the pointer, with a date badge on the axis.
+   * @defaultValue true
+   */
+  showCursorLine?: boolean;
+
+  /**
+   * Initial horizontal scroll target.
+   * @defaultValue "today"
+   */
+  defaultScrollTo?: TimelineDateInput | 'today' | 'start' | 'end';
+
+  /** Fires (rAF-throttled) with the visible time range as the user scrolls or resizes. */
+  onVisibleRangeChange?: (range: [Date, Date]) => void;
+
+  /** Receives the imperative navigation handle (`scrollTo`, `getVisibleRange`). */
+  actionsRef?: RefObject<TimelineActions | null>;
+
+  /**
+   * `auto` packs non-overlapping cards into shared lanes; `one-per-row` gives every row its own lane.
+   * @defaultValue "auto"
+   */
+  lanePacking?: 'auto' | 'one-per-row';
+
+  /**
+   * Card height in px (cards render at exactly this height; named to match `DataView.List`).
+   * @defaultValue 66
+   */
+  estimatedRowHeight?: number;
+
+  /**
+   * Vertical gap between lanes in px.
+   * @defaultValue 16
+   */
+  laneGap?: number;
+
+  /**
+   * Spans narrower than this (px) flip `context.collapsed` for `renderCard`.
+   * @defaultValue 60
+   */
+  minCardWidth?: number;
+
+  /**
+   * Assumed width (px) of point-marker cards (rows without `endField`) for lane packing.
+   * Set to roughly the widest point card to prevent horizontal overlap within a lane.
+   * @defaultValue 120
+   */
+  estimatedPointWidth?: number;
+
+  /** When true, only cards/gridlines near the visible viewport are rendered (horizontal culling). */
+  virtualized?: boolean;
+
+  /** Class overrides per part: root, axis, band, tick, marker, gridline, cursor, canvas, card. */
+  classNames?: Record<string, string>;
+}
+
+export interface TimelineCardContext {
+  /** Pixel width of the time span (0 when `endField` is omitted). */
+  width: number;
+
+  /** True when the span is narrower than `minCardWidth`. */
+  collapsed: boolean;
+
+  /** Lane (row) index assigned by packing. */
+  laneIndex: number;
+
+  /** Resolved start date. */
+  start: Date;
+
+  /** Resolved end date. Null when `endField` is omitted (point marker). */
+  end: Date | null;
+}
+
+export interface TimelineMarker {
+  /** Marker position. (Required) */
+  date: TimelineDateInput;
+
+  /** Badge content. Defaults to the marker date formatted as "17 Jan". */
+  label?: ReactNode;
+
+  /**
+   * Badge/line color.
+   * @defaultValue "default"
+   */
+  variant?: 'default' | 'accent' | 'danger';
+}
+
+export interface TimelineActions {
+  /**
+   * Scroll the viewport so the target lands at `align`. Out-of-domain dates
+   * clamp to the nearest edge; no-ops (dev warning) while the renderer is hidden.
+   */
+  scrollTo: (
+    target: TimelineDateInput | 'today' | 'start' | 'end',
+    options?: {
+      /** @defaultValue "center" */
+      align?: 'start' | 'center' | 'end';
+      /** @defaultValue "smooth" */
+      behavior?: 'auto' | 'smooth';
+    }
+  ) => void;
+
+  /** The visible time window, or null while the renderer is hidden. */
+  getVisibleRange: () => [Date, Date] | null;
 }
 
 export interface DataViewCustomProps {

--- a/packages/raystack/components/data-view/__tests__/timeline.test.tsx
+++ b/packages/raystack/components/data-view/__tests__/timeline.test.tsx
@@ -15,8 +15,10 @@ import { DataView } from '../data-view';
 import type {
   DataViewField,
   DataViewTimelineProps,
+  InternalFilter,
   TimelineActions
 } from '../data-view.types';
+import { useDataView } from '../hooks/useDataView';
 import { packLanes } from '../utils/pack-lanes';
 import { buildAxis, createTimeScale, toTimestamp } from '../utils/time-scale';
 
@@ -182,6 +184,32 @@ describe('createTimeScale', () => {
     // Domain = Jan 1 → Feb 1 = 31 days.
     expect(ts.totalWidth).toBe(31 * 20);
   });
+
+  it('clamps a zero or negative unitWidth to 1px instead of hanging', () => {
+    // 0 → pxPerMs 0 (NaN geometry); negative → inverted scale whose
+    // viewport-fill loop never terminates. Both clamp to a 1px unit.
+    const zero = createTimeScale({
+      minTime: dayjs('2025-01-01').valueOf(),
+      maxTime: dayjs('2025-01-31').valueOf(),
+      scale: 'day',
+      unitWidth: 0,
+      padUnits: 0,
+      minWidth: 500
+    });
+    expect(Number.isFinite(zero.totalWidth)).toBe(true);
+    expect(zero.totalWidth).toBeGreaterThanOrEqual(500);
+    const negative = createTimeScale({
+      minTime: dayjs('2025-01-01').valueOf(),
+      maxTime: dayjs('2025-01-31').valueOf(),
+      scale: 'day',
+      unitWidth: -20,
+      padUnits: 0,
+      minWidth: 500
+    });
+    expect(negative.pxPerMs).toBeGreaterThan(0);
+    expect(Number.isFinite(negative.totalWidth)).toBe(true);
+    expect(negative.totalWidth).toBeGreaterThanOrEqual(500);
+  });
 });
 
 describe('buildAxis', () => {
@@ -283,6 +311,39 @@ describe('buildAxis', () => {
     expect(bands.map(b => b.label)).toEqual(['2024', '2025']);
     expect(ticks[0].label).toBe('Nov');
   });
+
+  it('builds quarter ticks and year bands (hand-rolled, non-dayjs path)', () => {
+    // Quarter snapping/stepping is hand-rolled (dayjs has no quarter unit
+    // without a plugin): startOfUnit subtracts month % 3, addUnits steps by
+    // 3 months, and tick labels derive Q1–Q4 from the month index.
+    const quarterly = createTimeScale({
+      minTime: dayjs('2024-11-15').valueOf(),
+      maxTime: dayjs('2025-05-10').valueOf(),
+      scale: 'quarter',
+      unitWidth: 140,
+      padUnits: 0
+    });
+    // Nov 15 snaps back to Q4's start; May 10 is in Q2, +1 unit → Jul 1.
+    expect(dayjs(quarterly.t0).format('YYYY-MM-DD')).toBe('2024-10-01');
+    expect(dayjs(quarterly.t1).format('YYYY-MM-DD')).toBe('2025-07-01');
+    const { ticks, bands } = buildAxis(quarterly, 'quarter', 140);
+    expect(ticks.map(t => t.label)).toEqual(['Q4', 'Q1', 'Q2', 'Q3']);
+    expect(ticks[0].x).toBe(0);
+    expect(bands.map(b => b.label)).toEqual(['2024', '2025']);
+  });
+
+  it('builds week ticks snapped to week starts, with month bands', () => {
+    const weekly = createTimeScale({
+      minTime: dayjs('2025-01-05').valueOf(), // a Sunday (dayjs week start)
+      maxTime: dayjs('2025-01-20').valueOf(),
+      scale: 'week',
+      unitWidth: 56,
+      padUnits: 0
+    });
+    const { ticks, bands } = buildAxis(weekly, 'week', 56);
+    expect(ticks.map(t => t.label)).toEqual(['5', '12', '19', '26']);
+    expect(bands.map(b => b.label)).toEqual(['Jan 2025']);
+  });
 });
 
 /* ─────────────────────────── renderer ────────────────────────── */
@@ -304,6 +365,20 @@ const orders: Order[] = [
   { id: 'o2', title: 'Beta', start: '2025-01-12', end: '2025-01-15' },
   { id: 'o3', title: 'Gamma', start: '2025-01-06', end: '2025-01-09' }
 ];
+
+/** Applies a filter through the same context path as the Filters toolbar. */
+function ApplyFilterButton({ filters }: { filters: InternalFilter[] }) {
+  const { updateTableQuery } = useDataView();
+  return (
+    <button
+      type='button'
+      data-testid='apply-filter'
+      onClick={() => updateTableQuery(prev => ({ ...prev, filters }))}
+    >
+      apply
+    </button>
+  );
+}
 
 function renderTimeline(
   props: Partial<DataViewTimelineProps<Order>> = {},
@@ -358,6 +433,48 @@ describe('DataView.Timeline', () => {
     expect(screen.getByTestId('card-o3').dataset.lane).toBe('1');
     // o2 starts at 220 ≥ o1's end + gap → back onto lane 0.
     expect(screen.getByTestId('card-o2').dataset.lane).toBe('0');
+  });
+
+  it('exposes the scroll region as a focusable, labelled region', () => {
+    renderTimeline();
+    const region = screen.getByRole('region', { name: 'Timeline' });
+    // Focusable so keyboard users can scroll the pane with arrow keys —
+    // drag-to-pan is pointer-only.
+    expect(region.tabIndex).toBe(0);
+  });
+
+  it('lets the consumer override the region label via aria-label', () => {
+    renderTimeline({ 'aria-label': 'Order schedule' });
+    expect(
+      screen.getByRole('region', { name: 'Order schedule' })
+    ).toBeInTheDocument();
+  });
+
+  it('stacks lanes from estimatedRowHeight while cards are unmeasured', () => {
+    renderTimeline();
+    // jsdom reports offsetHeight 0 → the estimate (66) drives lane tops:
+    // lane 0 at laneGap 16, lane 1 at 16 + 66 + 16.
+    expect(screen.getByTestId('card-o1').parentElement!.style.top).toBe('16px');
+    expect(screen.getByTestId('card-o3').parentElement!.style.top).toBe('98px');
+    // Height is content-driven — the wrapper never hard-sizes the card.
+    expect(screen.getByTestId('card-o1').parentElement!.style.height).toBe('');
+  });
+
+  it('re-stacks lanes to the tallest measured card height', () => {
+    // Cards auto-measure after paint (List semantics). Simulate layout by
+    // reporting 90px for card wrappers.
+    const spy = vi
+      .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+      .mockImplementation(function (this: HTMLElement) {
+        return this.getAttribute('role') === 'listitem' ? 90 : 0;
+      });
+    renderTimeline();
+    // Lane 0 measured at 90px → lane 1 starts at 16 + 90 + 16.
+    expect(screen.getByTestId('card-o1').parentElement!.style.top).toBe('16px');
+    expect(screen.getByTestId('card-o3').parentElement!.style.top).toBe(
+      '122px'
+    );
+    spy.mockRestore();
   });
 
   it('gives every row its own lane with lanePacking="one-per-row"', () => {
@@ -777,6 +894,118 @@ describe('DataView.Timeline', () => {
     const calls = onVisibleRangeChange.mock.calls;
     const [from] = calls[calls.length - 1][0];
     expect(from.getTime()).toBe(dayjs('2025-01-06').valueOf());
+
+    // Sub-pixel drift (scroll anchoring's float round-trip, device-pixel
+    // quantization of scrollLeft) is noise, not a scroll — no re-fire.
+    root.scrollLeft = 100.4;
+    await act(async () => {
+      fireEvent.scroll(root);
+      await new Promise(resolve => setTimeout(resolve, 30)); // flush rAF
+    });
+    expect(onVisibleRangeChange.mock.calls.length).toBe(callsAfterMount + 1);
+
+    // A whole-pixel move is a real scroll again.
+    root.scrollLeft = 101;
+    await act(async () => {
+      fireEvent.scroll(root);
+      await new Promise(resolve => setTimeout(resolve, 30)); // flush rAF
+    });
+    expect(onVisibleRangeChange.mock.calls.length).toBe(callsAfterMount + 2);
+  });
+
+  it('scrolls the earliest match into view when a filter leaves the viewport empty', () => {
+    const { container } = render(
+      <DataView<Order>
+        data={orders}
+        fields={fields}
+        mode='client'
+        defaultSort={{ name: 'title', order: 'asc' }}
+        getRowId={(row: Order) => row.id}
+      >
+        <DataView.Timeline<Order>
+          startField='start'
+          endField='end'
+          range={['2025-01-01', '2025-01-31']}
+          scale='day'
+          unitWidth={20}
+          today={false}
+          defaultScrollTo='start'
+          renderCard={row => <div>{row.original.title}</div>}
+        />
+        <ApplyFilterButton
+          filters={[{ name: 'title', operator: 'eq', value: 'Beta' }]}
+        />
+      </DataView>
+    );
+    const root = container.firstElementChild as HTMLElement;
+    // Parked far past every card (jsdom viewport is 0-wide).
+    root.scrollLeft = 500;
+    fireEvent.click(screen.getByTestId('apply-filter'));
+    // Beta = Jan 12 → 11 days × 20px = 220, landing 24px (the edge inset)
+    // inside the viewport's left edge.
+    expect(root.scrollLeft).toBe(196);
+  });
+
+  it('does not move the view when a filter match is already visible', () => {
+    const { container } = render(
+      <DataView<Order>
+        data={orders}
+        fields={fields}
+        mode='client'
+        defaultSort={{ name: 'title', order: 'asc' }}
+        getRowId={(row: Order) => row.id}
+      >
+        <DataView.Timeline<Order>
+          startField='start'
+          endField='end'
+          range={['2025-01-01', '2025-01-31']}
+          scale='day'
+          unitWidth={20}
+          today={false}
+          defaultScrollTo='start'
+          renderCard={row => <div>{row.original.title}</div>}
+        />
+        <ApplyFilterButton
+          filters={[{ name: 'title', operator: 'eq', value: 'Alpha' }]}
+        />
+      </DataView>
+    );
+    const root = container.firstElementChild as HTMLElement;
+    // Alpha spans x 80–180; a viewport at 100 already shows it.
+    root.scrollLeft = 100;
+    fireEvent.click(screen.getByTestId('apply-filter'));
+    expect(root.scrollLeft).toBe(100);
+  });
+
+  it('keeps the scroll position on filter change when scrollToResults is false', () => {
+    const { container } = render(
+      <DataView<Order>
+        data={orders}
+        fields={fields}
+        mode='client'
+        defaultSort={{ name: 'title', order: 'asc' }}
+        getRowId={(row: Order) => row.id}
+      >
+        <DataView.Timeline<Order>
+          startField='start'
+          endField='end'
+          range={['2025-01-01', '2025-01-31']}
+          scale='day'
+          unitWidth={20}
+          today={false}
+          defaultScrollTo='start'
+          scrollToResults={false}
+          renderCard={row => <div>{row.original.title}</div>}
+        />
+        <ApplyFilterButton
+          filters={[{ name: 'title', operator: 'eq', value: 'Beta' }]}
+        />
+      </DataView>
+    );
+    const root = container.firstElementChild as HTMLElement;
+    root.scrollLeft = 500;
+    fireEvent.click(screen.getByTestId('apply-filter'));
+    expect(root.scrollLeft).toBe(500);
   });
 
   it('restores the scroll position when a gated view is re-activated', () => {
@@ -886,7 +1115,8 @@ describe('DataView.Timeline', () => {
 /* ─────────────────────── actionsRef (imperative handle) ─────────────────
    Domain: explicit range Jan 1 → Jan 31 2025, day scale, 20px/unit.
    t0 = Jan 1, t1 = Feb 1, totalWidth = 620px. jsdom clientWidth is 0, so
-   'center'/'end' alignment offsets collapse to the target's own x. */
+   'center' collapses to the target's own x, while 'start'/'end' offset by
+   the 24px edge inset (clamped at the domain edges). */
 
 describe('DataView.Timeline actionsRef', () => {
   const makeActionsRef = () => ({ current: null as TimelineActions | null });
@@ -896,12 +1126,12 @@ describe('DataView.Timeline actionsRef', () => {
     const { container } = renderTimeline({ actionsRef });
     const root = container.firstElementChild as HTMLElement;
     expect(actionsRef.current).not.toBeNull();
-    // Jan 11 = 10 days after Jan 1 → 10 × 20px.
+    // Jan 11 = 10 days after Jan 1 → 10 × 20px, minus the 24px edge inset.
     actionsRef.current!.scrollTo('2025-01-11', {
       align: 'start',
       behavior: 'auto'
     });
-    expect(root.scrollLeft).toBe(200);
+    expect(root.scrollLeft).toBe(176);
   });
 
   it("resolves 'start' and 'end' to the domain edges", () => {
@@ -918,11 +1148,13 @@ describe('DataView.Timeline actionsRef', () => {
     const actionsRef = makeActionsRef();
     const { container } = renderTimeline({ actionsRef });
     const root = container.firstElementChild as HTMLElement;
+    // Clamped to t1 (x 620), then the 24px edge inset applies.
     actionsRef.current!.scrollTo('2030-06-01', {
       align: 'start',
       behavior: 'auto'
     });
-    expect(root.scrollLeft).toBe(620);
+    expect(root.scrollLeft).toBe(596);
+    // Clamped to t0 (x 0) — the inset yields to the scroll floor.
     actionsRef.current!.scrollTo('1999-01-01', {
       align: 'start',
       behavior: 'auto'
@@ -938,7 +1170,7 @@ describe('DataView.Timeline actionsRef', () => {
     // biome-ignore lint/suspicious/noExplicitAny: jsdom lacks Element.scrollTo
     (root as any).scrollTo = scrollToSpy;
     actionsRef.current!.scrollTo('2025-01-11', { align: 'start' });
-    expect(scrollToSpy).toHaveBeenCalledWith({ left: 200, behavior: 'smooth' });
+    expect(scrollToSpy).toHaveBeenCalledWith({ left: 176, behavior: 'smooth' });
   });
 
   it('warns and no-ops on an invalid date', () => {

--- a/packages/raystack/components/data-view/__tests__/timeline.test.tsx
+++ b/packages/raystack/components/data-view/__tests__/timeline.test.tsx
@@ -1,0 +1,976 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import dayjs from 'dayjs';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+// SVG icons are inlined via @svgr/rollup at build time. In Vitest they resolve
+// to undefined, so stub the `~/icons` module with no-op components.
+vi.mock('~/icons', () => ({
+  FilterIcon: () => null,
+  __esModule: true
+}));
+
+// biome-ignore lint/suspicious/noShadowRestrictedNames: legitimate export name
+import { DataView } from '../data-view';
+import type {
+  DataViewField,
+  DataViewTimelineProps,
+  TimelineActions
+} from '../data-view.types';
+import { packLanes } from '../utils/pack-lanes';
+import { buildAxis, createTimeScale, toTimestamp } from '../utils/time-scale';
+
+beforeAll(() => {
+  // jsdom doesn't implement ResizeObserver — the timeline observes its scroll
+  // container when viewport tracking is enabled.
+  // biome-ignore lint/suspicious/noExplicitAny: jsdom lacks ResizeObserver
+  (global as any).ResizeObserver =
+    // biome-ignore lint/suspicious/noExplicitAny: jsdom lacks ResizeObserver
+    (global as any).ResizeObserver ||
+    vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn()
+    }));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/* ─────────────────────────── utils: packLanes ────────────────────────── */
+
+describe('packLanes', () => {
+  it('returns no lanes for empty input', () => {
+    expect(packLanes([])).toEqual({ lanes: [], laneCount: 0 });
+  });
+
+  it('packs non-overlapping items into the same lane', () => {
+    const { lanes, laneCount } = packLanes([
+      { x: 0, width: 100 },
+      { x: 120, width: 50 }
+    ]);
+    expect(lanes).toEqual([0, 0]);
+    expect(laneCount).toBe(1);
+  });
+
+  it('opens a new lane for overlapping items', () => {
+    const { lanes, laneCount } = packLanes([
+      { x: 0, width: 100 },
+      { x: 50, width: 100 }
+    ]);
+    expect(lanes).toEqual([0, 1]);
+    expect(laneCount).toBe(2);
+  });
+
+  it('respects the gap: items closer than gapPx do not share a lane', () => {
+    // First ends at 100; second starts at 104 < 100 + 8 → new lane.
+    const tight = packLanes([
+      { x: 0, width: 100 },
+      { x: 104, width: 50 }
+    ]);
+    expect(tight.lanes).toEqual([0, 1]);
+    // Exactly at the gap boundary → same lane.
+    const exact = packLanes([
+      { x: 0, width: 100 },
+      { x: 108, width: 50 }
+    ]);
+    expect(exact.lanes).toEqual([0, 0]);
+  });
+
+  it('assigns lanes by ascending x regardless of input order', () => {
+    const { lanes, laneCount } = packLanes([
+      { x: 220, width: 60 }, // fits after the first item
+      { x: 0, width: 100 },
+      { x: 50, width: 100 } // overlaps the first → lane 1
+    ]);
+    expect(lanes).toEqual([0, 0, 1]);
+    expect(laneCount).toBe(2);
+  });
+});
+
+/* ─────────────────────────── utils: time scale ───────────────────────── */
+
+describe('toTimestamp', () => {
+  it('accepts Date, epoch ms, and parseable strings', () => {
+    const date = new Date('2025-01-05T00:00:00');
+    expect(toTimestamp(date)).toBe(date.getTime());
+    expect(toTimestamp(1736035200000)).toBe(1736035200000);
+    expect(toTimestamp('2025-01-05')).toBe(dayjs('2025-01-05').valueOf());
+  });
+
+  it('returns null for missing or invalid values', () => {
+    expect(toTimestamp(null)).toBeNull();
+    expect(toTimestamp(undefined)).toBeNull();
+    expect(toTimestamp('not-a-date')).toBeNull();
+    expect(toTimestamp(new Date('invalid'))).toBeNull();
+    expect(toTimestamp(Number.NaN)).toBeNull();
+    expect(toTimestamp({})).toBeNull();
+  });
+});
+
+describe('createTimeScale', () => {
+  it('snaps the domain to unit boundaries with padding', () => {
+    const ts = createTimeScale({
+      minTime: dayjs('2025-01-05T10:30:00').valueOf(),
+      maxTime: dayjs('2025-01-20T18:00:00').valueOf(),
+      scale: 'day',
+      unitWidth: 20,
+      padUnits: 2
+    });
+    expect(ts.t0).toBe(dayjs('2025-01-03').startOf('day').valueOf());
+    // startOf(max) + (pad + 1) days.
+    expect(ts.t1).toBe(dayjs('2025-01-23').startOf('day').valueOf());
+  });
+
+  it('extends the domain end to reach minWidth, in whole units', () => {
+    // Jan 1 → Feb 1 = 31 days × 20px = 620px; filling to 1000px needs 50 days.
+    const ts = createTimeScale({
+      minTime: dayjs('2025-01-01').valueOf(),
+      maxTime: dayjs('2025-01-31').valueOf(),
+      scale: 'day',
+      unitWidth: 20,
+      padUnits: 0,
+      minWidth: 1000
+    });
+    expect(ts.t0).toBe(dayjs('2025-01-01').valueOf());
+    expect(ts.t1).toBe(dayjs('2025-02-20').valueOf());
+    expect(ts.totalWidth).toBe(1000);
+  });
+
+  it('never shrinks a domain already wider than minWidth', () => {
+    const ts = createTimeScale({
+      minTime: dayjs('2025-01-01').valueOf(),
+      maxTime: dayjs('2025-01-31').valueOf(),
+      scale: 'day',
+      unitWidth: 20,
+      padUnits: 0,
+      minWidth: 100
+    });
+    expect(ts.t1).toBe(dayjs('2025-02-01').valueOf());
+    expect(ts.totalWidth).toBe(620);
+  });
+
+  it('reaches minWidth on calendar scales with uneven unit lengths', () => {
+    // Months render at (actual ms × pxPerMs), not exactly unitWidth — the
+    // fill must land at or past minWidth despite short months.
+    const ts = createTimeScale({
+      minTime: dayjs('2025-01-15').valueOf(),
+      maxTime: dayjs('2025-02-15').valueOf(),
+      scale: 'month',
+      unitWidth: 96,
+      padUnits: 0,
+      minWidth: 500
+    });
+    expect(ts.totalWidth).toBeGreaterThanOrEqual(500);
+    // Still snapped to a month boundary.
+    expect(dayjs(ts.t1).date()).toBe(1);
+  });
+
+  it('maps time to px linearly and inverts with timeAt', () => {
+    const ts = createTimeScale({
+      minTime: dayjs('2025-01-01').valueOf(),
+      maxTime: dayjs('2025-01-31').valueOf(),
+      scale: 'day',
+      unitWidth: 20,
+      padUnits: 0
+    });
+    expect(ts.x(ts.t0)).toBe(0);
+    expect(ts.x(dayjs('2025-01-05').valueOf())).toBe(80);
+    const time = dayjs('2025-01-11').valueOf();
+    expect(ts.timeAt(ts.x(time))).toBe(time);
+    // Domain = Jan 1 → Feb 1 = 31 days.
+    expect(ts.totalWidth).toBe(31 * 20);
+  });
+});
+
+describe('buildAxis', () => {
+  const januaryScale = createTimeScale({
+    minTime: dayjs('2025-01-01').valueOf(),
+    maxTime: dayjs('2025-01-31').valueOf(),
+    scale: 'day',
+    unitWidth: 20,
+    padUnits: 0
+  });
+
+  it('emits one tick per unit across the domain', () => {
+    const { ticks } = buildAxis(januaryScale, 'day', 20);
+    // Jan 1 … Feb 1 inclusive.
+    expect(ticks).toHaveLength(32);
+    expect(ticks[0].label).toBe('1');
+    expect(ticks[0].x).toBe(0);
+    expect(ticks[4].x).toBe(80);
+  });
+
+  it('thins tick labels below the minimum label spacing', () => {
+    // 20px per tick < 28px minimum → every 2nd label.
+    const thinned = buildAxis(januaryScale, 'day', 20).ticks;
+    expect(thinned[0].showLabel).toBe(true);
+    expect(thinned[1].showLabel).toBe(false);
+    expect(thinned[2].showLabel).toBe(true);
+    // 40px per tick → all labels show.
+    const roomy = buildAxis(
+      createTimeScale({
+        minTime: dayjs('2025-01-01').valueOf(),
+        maxTime: dayjs('2025-01-31').valueOf(),
+        scale: 'day',
+        unitWidth: 40,
+        padUnits: 0
+      }),
+      'day',
+      40
+    ).ticks;
+    expect(roomy.every(t => t.showLabel)).toBe(true);
+  });
+
+  it('labels every Nth unit when labelEvery is passed', () => {
+    const roomyScale = createTimeScale({
+      minTime: dayjs('2025-01-01').valueOf(),
+      maxTime: dayjs('2025-01-31').valueOf(),
+      scale: 'day',
+      unitWidth: 40,
+      padUnits: 0
+    });
+    // 40px fits every label; the override thins to every 2nd anyway.
+    const { ticks } = buildAxis(roomyScale, 'day', 40, 2);
+    expect(ticks.map(t => t.showLabel).slice(0, 4)).toEqual([
+      true,
+      false,
+      true,
+      false
+    ]);
+    expect(ticks[0].index).toBe(0);
+    expect(ticks[3].index).toBe(3);
+  });
+
+  it('collision floor wins over a too-dense labelEvery', () => {
+    // 10px per tick → auto floor is every 3rd; asking for every 2nd degrades.
+    const dense = createTimeScale({
+      minTime: dayjs('2025-01-01').valueOf(),
+      maxTime: dayjs('2025-01-31').valueOf(),
+      scale: 'day',
+      unitWidth: 10,
+      padUnits: 0
+    });
+    const { ticks } = buildAxis(dense, 'day', 10, 2);
+    expect(ticks[0].showLabel).toBe(true);
+    expect(ticks[1].showLabel).toBe(false);
+    expect(ticks[2].showLabel).toBe(false);
+    expect(ticks[3].showLabel).toBe(true);
+  });
+
+  it('emits month bands over day ticks, with the year on the first band', () => {
+    const wide = createTimeScale({
+      minTime: dayjs('2025-01-10').valueOf(),
+      maxTime: dayjs('2025-02-20').valueOf(),
+      scale: 'day',
+      unitWidth: 20,
+      padUnits: 0
+    });
+    const { bands } = buildAxis(wide, 'day', 20);
+    expect(bands.map(b => b.label)).toEqual(['Jan 2025', 'Feb']);
+  });
+
+  it('emits year bands over month ticks', () => {
+    const yearly = createTimeScale({
+      minTime: dayjs('2024-11-01').valueOf(),
+      maxTime: dayjs('2025-03-01').valueOf(),
+      scale: 'month',
+      unitWidth: 96,
+      padUnits: 0
+    });
+    const { bands, ticks } = buildAxis(yearly, 'month', 96);
+    expect(bands.map(b => b.label)).toEqual(['2024', '2025']);
+    expect(ticks[0].label).toBe('Nov');
+  });
+});
+
+/* ─────────────────────────── renderer ────────────────────────── */
+
+type Order = {
+  id: string;
+  title: string;
+  start: string | null;
+  end: string | null;
+};
+
+const fields: DataViewField<Order>[] = [
+  { accessorKey: 'title', label: 'Title', sortable: true }
+];
+
+// x at unitWidth 20 over a Jan 2025 domain: Jan 5 → 80px, Jan 12 → 220px, …
+const orders: Order[] = [
+  { id: 'o1', title: 'Alpha', start: '2025-01-05', end: '2025-01-10' },
+  { id: 'o2', title: 'Beta', start: '2025-01-12', end: '2025-01-15' },
+  { id: 'o3', title: 'Gamma', start: '2025-01-06', end: '2025-01-09' }
+];
+
+function renderTimeline(
+  props: Partial<DataViewTimelineProps<Order>> = {},
+  data: Order[] = orders
+) {
+  return render(
+    <DataView<Order>
+      data={data}
+      fields={fields}
+      mode='client'
+      defaultSort={{ name: 'title', order: 'asc' }}
+      getRowId={(row: Order) => row.id}
+    >
+      <DataView.Timeline<Order>
+        startField='start'
+        endField='end'
+        range={['2025-01-01', '2025-01-31']}
+        scale='day'
+        unitWidth={20}
+        today={false}
+        defaultScrollTo='start'
+        renderCard={(row, context) => (
+          <div
+            data-testid={`card-${row.original.id}`}
+            data-collapsed={String(context.collapsed)}
+            data-lane={context.laneIndex}
+            data-point={String(context.end === null)}
+          >
+            {row.original.title}
+          </div>
+        )}
+        {...props}
+      />
+    </DataView>
+  );
+}
+
+describe('DataView.Timeline', () => {
+  it('positions cards from the time scale (left = start, width = span)', () => {
+    renderTimeline();
+    const wrapper = screen.getByTestId('card-o1').parentElement!;
+    // Jan 5 = 4 days after Jan 1 → 4 × 20px; Jan 5 → Jan 10 = 5 days → 100px.
+    expect(wrapper.style.left).toBe('80px');
+    expect(wrapper.style.width).toBe('100px');
+    expect(wrapper).toHaveAttribute('role', 'listitem');
+  });
+
+  it('packs overlapping cards into separate lanes and reuses free lanes', () => {
+    renderTimeline();
+    // o1 [80..180] and o3 [100..180] overlap → different lanes.
+    expect(screen.getByTestId('card-o1').dataset.lane).toBe('0');
+    expect(screen.getByTestId('card-o3').dataset.lane).toBe('1');
+    // o2 starts at 220 ≥ o1's end + gap → back onto lane 0.
+    expect(screen.getByTestId('card-o2').dataset.lane).toBe('0');
+  });
+
+  it('gives every row its own lane with lanePacking="one-per-row"', () => {
+    renderTimeline({ lanePacking: 'one-per-row' });
+    const lanes = ['o1', 'o2', 'o3'].map(
+      id => screen.getByTestId(`card-${id}`).dataset.lane
+    );
+    expect(new Set(lanes).size).toBe(3);
+  });
+
+  it('flags spans narrower than minCardWidth as collapsed', () => {
+    renderTimeline(undefined, [
+      { id: 'wide', title: 'Wide', start: '2025-01-05', end: '2025-01-10' },
+      { id: 'tiny', title: 'Tiny', start: '2025-01-12', end: '2025-01-14' }
+    ]);
+    // 5 days × 20px = 100px ≥ 60 → not collapsed.
+    expect(screen.getByTestId('card-wide').dataset.collapsed).toBe('false');
+    // 2 days × 20px = 40px < 60 → collapsed.
+    expect(screen.getByTestId('card-tiny').dataset.collapsed).toBe('true');
+  });
+
+  it('renders point markers with intrinsic width when endField is omitted', () => {
+    renderTimeline({ endField: undefined }, [
+      { id: 'p1', title: 'Point', start: '2025-01-05', end: null }
+    ]);
+    const card = screen.getByTestId('card-p1');
+    expect(card.dataset.point).toBe('true');
+    expect(card.parentElement!.style.width).toBe('');
+    expect(card.parentElement!.style.left).toBe('80px');
+  });
+
+  it('culls rows entirely outside an explicit range, keeps overlapping ones', () => {
+    renderTimeline(undefined, [
+      { id: 'in', title: 'Inside', start: '2025-01-05', end: '2025-01-10' },
+      // Crosses the range end (Jan 31) → kept, clipped visually by the canvas.
+      { id: 'edge', title: 'Edge', start: '2025-01-30', end: '2025-02-05' },
+      // Entirely past the range end → dropped (no lane, no card).
+      { id: 'after', title: 'After', start: '2025-02-10', end: '2025-02-15' },
+      // Entirely before the range start → dropped.
+      { id: 'before', title: 'Before', start: '2024-12-01', end: '2024-12-20' }
+    ]);
+    expect(screen.getByTestId('card-in')).toBeInTheDocument();
+    expect(screen.getByTestId('card-edge')).toBeInTheDocument();
+    expect(screen.queryByTestId('card-after')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('card-before')).not.toBeInTheDocument();
+  });
+
+  it('skips rows with a missing start value and warns in dev', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    renderTimeline(undefined, [
+      { id: 'ok', title: 'Ok', start: '2025-01-05', end: '2025-01-10' },
+      { id: 'bad', title: 'Bad', start: null, end: '2025-01-10' }
+    ]);
+    expect(screen.getByTestId('card-ok')).toBeInTheDocument();
+    expect(screen.queryByTestId('card-bad')).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Skipped 1 row(s)')
+    );
+  });
+
+  it('renders the today line badge and custom markers on the axis', () => {
+    renderTimeline({
+      today: '2025-01-17',
+      markers: [
+        { date: '2025-01-25' },
+        { date: '2025-01-28', label: 'Launch', variant: 'danger' }
+      ]
+    });
+    expect(screen.getByText('17 Jan')).toBeInTheDocument();
+    expect(screen.getByText('25 Jan')).toBeInTheDocument();
+    expect(screen.getByText('Launch')).toBeInTheDocument();
+  });
+
+  it('renders axis bands and tick labels', () => {
+    renderTimeline();
+    expect(screen.getByText('Jan 2025')).toBeInTheDocument();
+    // unitWidth 20 thins labels to every other day (odd days from Jan 1).
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('fires onRowClick with the row data when a card is clicked', async () => {
+    const onRowClick = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <DataView<Order>
+        data={orders}
+        fields={fields}
+        mode='client'
+        defaultSort={{ name: 'title', order: 'asc' }}
+        getRowId={(row: Order) => row.id}
+        onRowClick={onRowClick}
+      >
+        <DataView.Timeline<Order>
+          startField='start'
+          endField='end'
+          range={['2025-01-01', '2025-01-31']}
+          today={false}
+          defaultScrollTo='start'
+          renderCard={row => (
+            <div data-testid={`card-${row.original.id}`}>
+              {row.original.title}
+            </div>
+          )}
+        />
+      </DataView>
+    );
+    await user.click(screen.getByTestId('card-o1'));
+    expect(onRowClick).toHaveBeenCalledWith(orders[0]);
+  });
+
+  it('gates itself on the active view when `name` is set', () => {
+    const views = [
+      { value: 'gantt', label: 'Timeline' },
+      { value: 'other', label: 'Other' }
+    ];
+    const { unmount } = render(
+      <DataView<Order>
+        data={orders}
+        fields={fields}
+        mode='client'
+        defaultSort={{ name: 'title', order: 'asc' }}
+        views={views}
+        defaultView='other'
+      >
+        <DataView.Timeline<Order>
+          name='gantt'
+          startField='start'
+          endField='end'
+          today={false}
+          renderCard={row => <div data-testid={`card-${row.original.id}`} />}
+        />
+      </DataView>
+    );
+    expect(screen.queryByTestId('card-o1')).toBeNull();
+    unmount();
+
+    render(
+      <DataView<Order>
+        data={orders}
+        fields={fields}
+        mode='client'
+        defaultSort={{ name: 'title', order: 'asc' }}
+        views={views}
+        defaultView='gantt'
+      >
+        <DataView.Timeline<Order>
+          name='gantt'
+          startField='start'
+          endField='end'
+          today={false}
+          renderCard={row => <div data-testid={`card-${row.original.id}`} />}
+        />
+      </DataView>
+    );
+    expect(screen.getByTestId('card-o1')).toBeInTheDocument();
+  });
+
+  it('thins gridlines with gridlineInterval while the cursor snaps to every unit', async () => {
+    const { container } = renderTimeline({
+      gridlineInterval: 2,
+      classNames: { gridline: 'test-gridline' }
+    });
+    // 32 ticks (Jan 1 … Feb 1); every 2nd from the domain start → 16 lines.
+    expect(container.getElementsByClassName('test-gridline')).toHaveLength(16);
+
+    // Jan 6 (index 5) has no gridline, but the hover cursor still snaps to it.
+    const root = container.firstElementChild as HTMLElement;
+    await act(async () => {
+      fireEvent.mouseMove(root, { clientX: 100 });
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(screen.getByText('6 Jan')).toBeInTheDocument();
+  });
+
+  it('extends the domain so the grid fills a container wider than the data span', () => {
+    // jsdom's clientWidth is 0 by default — pretend the scroll container is
+    // 1000px wide. The explicit range renders 620px, so the domain end
+    // extends Feb 1 → Feb 20 and ticks run Jan 1 … Feb 20 = 51 gridlines.
+    vi.spyOn(Element.prototype, 'clientWidth', 'get').mockReturnValue(1000);
+    const { container } = renderTimeline({
+      classNames: { gridline: 'test-gridline' }
+    });
+    expect(container.getElementsByClassName('test-gridline')).toHaveLength(51);
+    const canvas = container.querySelector('[role="list"]') as HTMLElement;
+    expect(canvas.style.width).toBe('1000px');
+  });
+
+  it('renders nothing when there is no data and not loading', () => {
+    const { container } = renderTimeline(undefined, []);
+    expect(container.querySelector('[role="list"]')).toBeNull();
+  });
+
+  it('shows a cursor line snapped to the hovered sub-interval with a date badge', async () => {
+    const { container } = renderTimeline();
+    const root = container.firstElementChild as HTMLElement;
+    // jsdom rects are all-zero and scrollLeft is 0, so canvasX = clientX.
+    // x=100 at 20px/day from Jan 1 → snapped to Jan 6.
+    await act(async () => {
+      fireEvent.mouseMove(root, { clientX: 100 });
+      await new Promise(resolve => setTimeout(resolve, 30)); // flush rAF
+    });
+    expect(screen.getByText('6 Jan')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.mouseLeave(root);
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(screen.queryByText('6 Jan')).toBeNull();
+  });
+
+  it('does not track the cursor when showCursorLine is false', async () => {
+    const { container } = renderTimeline({ showCursorLine: false });
+    const root = container.firstElementChild as HTMLElement;
+    await act(async () => {
+      fireEvent.mouseMove(root, { clientX: 100 });
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(screen.queryByText('6 Jan')).toBeNull();
+  });
+
+  it('pans both axes when the background is dragged', async () => {
+    const { container } = renderTimeline();
+    const root = container.firstElementChild as HTMLElement;
+    fireEvent.pointerDown(root, {
+      pointerType: 'mouse',
+      button: 0,
+      pointerId: 1,
+      clientX: 300,
+      clientY: 100
+    });
+    // Pointer moves 50px left / 20px up → content scrolls 50px right / 20px down.
+    fireEvent.pointerMove(root, { pointerId: 1, clientX: 250, clientY: 80 });
+    expect(root.scrollLeft).toBe(50);
+    expect(root.scrollTop).toBe(20);
+    expect(root.dataset.dragging).toBe('true');
+
+    // Hold still past the stale window, then release — no glide.
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 100));
+    });
+    fireEvent.pointerUp(root, { pointerId: 1 });
+    expect(root.dataset.dragging).toBeUndefined();
+    // Released — further movement no longer pans.
+    fireEvent.pointerMove(root, { pointerId: 1, clientX: 100, clientY: 0 });
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    expect(root.scrollLeft).toBe(50);
+  });
+
+  it('glides with momentum after a fling release', async () => {
+    const { container } = renderTimeline();
+    const root = container.firstElementChild as HTMLElement;
+    fireEvent.pointerDown(root, {
+      pointerType: 'mouse',
+      button: 0,
+      pointerId: 1,
+      clientX: 300,
+      clientY: 100
+    });
+    fireEvent.pointerMove(root, { pointerId: 1, clientX: 250, clientY: 100 });
+    // Release mid-motion — the pan keeps scrolling and decays.
+    fireEvent.pointerUp(root, { pointerId: 1 });
+    expect(root.scrollLeft).toBe(50);
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 100));
+    });
+    const glided = root.scrollLeft;
+    expect(glided).toBeGreaterThan(50);
+
+    // Wheel input cancels the glide.
+    fireEvent.wheel(root);
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    expect(root.scrollLeft).toBe(glided);
+  });
+
+  it('does not start a pan from a card or from touch pointers', () => {
+    const { container } = renderTimeline();
+    const root = container.firstElementChild as HTMLElement;
+    // Press on a card (row-click territory) — no pan.
+    fireEvent.pointerDown(screen.getByTestId('card-o1'), {
+      pointerType: 'mouse',
+      button: 0,
+      pointerId: 1,
+      clientX: 300,
+      clientY: 100
+    });
+    fireEvent.pointerMove(root, { pointerId: 1, clientX: 200, clientY: 100 });
+    expect(root.scrollLeft).toBe(0);
+
+    // Touch pans natively — the drag handler must not hijack it.
+    fireEvent.pointerDown(root, {
+      pointerType: 'touch',
+      button: 0,
+      pointerId: 2,
+      clientX: 300,
+      clientY: 100
+    });
+    fireEvent.pointerMove(root, { pointerId: 2, clientX: 200, clientY: 100 });
+    expect(root.scrollLeft).toBe(0);
+  });
+
+  it('keeps the left-edge time anchored when the domain is extended', async () => {
+    const { container, rerender } = render(
+      <DataView<Order>
+        data={orders}
+        fields={fields}
+        mode='client'
+        defaultSort={{ name: 'title', order: 'asc' }}
+        getRowId={(row: Order) => row.id}
+      >
+        <DataView.Timeline<Order>
+          startField='start'
+          endField='end'
+          range={['2025-01-01', '2025-01-31']}
+          scale='day'
+          unitWidth={20}
+          today={false}
+          defaultScrollTo='start'
+          renderCard={row => <div>{row.original.title}</div>}
+        />
+      </DataView>
+    );
+    const root = container.firstElementChild as HTMLElement;
+    // Viewport's left edge sits at Jan 11 (200px / 20px-per-day from Jan 1).
+    root.scrollLeft = 200;
+
+    // Extend the range a month to the left — t0 moves to Dec 1.
+    rerender(
+      <DataView<Order>
+        data={orders}
+        fields={fields}
+        mode='client'
+        defaultSort={{ name: 'title', order: 'asc' }}
+        getRowId={(row: Order) => row.id}
+      >
+        <DataView.Timeline<Order>
+          startField='start'
+          endField='end'
+          range={['2024-12-01', '2025-01-31']}
+          scale='day'
+          unitWidth={20}
+          today={false}
+          defaultScrollTo='start'
+          renderCard={row => <div>{row.original.title}</div>}
+        />
+      </DataView>
+    );
+    // Dec 1 → Jan 11 = 41 days × 20px: the same time stays at the left edge.
+    expect(root.scrollLeft).toBe(820);
+  });
+
+  it('fires onVisibleRangeChange with the visible time window', async () => {
+    const onVisibleRangeChange = vi.fn();
+    renderTimeline({ onVisibleRangeChange });
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+    expect(onVisibleRangeChange).toHaveBeenCalled();
+    const calls = onVisibleRangeChange.mock.calls;
+    const [from, to] = calls[calls.length - 1][0];
+    expect(from).toBeInstanceOf(Date);
+    expect(to).toBeInstanceOf(Date);
+    // jsdom viewport is 0-wide at scrollLeft 0 → both edges sit at t0 (Jan 1).
+    expect(from.getTime()).toBe(dayjs('2025-01-01').valueOf());
+  });
+
+  it('does not re-fire onVisibleRangeChange when the window is unchanged', async () => {
+    const onVisibleRangeChange = vi.fn();
+    // Fresh `markers` array each render → domain/timeScale identity churn
+    // without any change to the actual window.
+    const makeUI = () => (
+      <DataView<Order>
+        data={orders}
+        fields={fields}
+        mode='client'
+        defaultSort={{ name: 'title', order: 'asc' }}
+        getRowId={(row: Order) => row.id}
+      >
+        <DataView.Timeline<Order>
+          startField='start'
+          endField='end'
+          range={['2025-01-01', '2025-01-31']}
+          scale='day'
+          unitWidth={20}
+          today={false}
+          defaultScrollTo='start'
+          markers={[{ date: '2025-01-20' }]}
+          onVisibleRangeChange={onVisibleRangeChange}
+          renderCard={row => <div>{row.original.title}</div>}
+        />
+      </DataView>
+    );
+    const { container, rerender } = render(makeUI());
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+    const callsAfterMount = onVisibleRangeChange.mock.calls.length;
+    expect(callsAfterMount).toBeGreaterThan(0);
+
+    rerender(makeUI());
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+    expect(onVisibleRangeChange.mock.calls.length).toBe(callsAfterMount);
+
+    // An actual scroll still fires with the new window.
+    const root = container.firstElementChild as HTMLElement;
+    root.scrollLeft = 100;
+    await act(async () => {
+      fireEvent.scroll(root);
+      await new Promise(resolve => setTimeout(resolve, 30)); // flush rAF
+    });
+    expect(onVisibleRangeChange.mock.calls.length).toBe(callsAfterMount + 1);
+    const calls = onVisibleRangeChange.mock.calls;
+    const [from] = calls[calls.length - 1][0];
+    expect(from.getTime()).toBe(dayjs('2025-01-06').valueOf());
+  });
+
+  it('restores the scroll position when a gated view is re-activated', () => {
+    const views = [
+      { value: 'gantt', label: 'Timeline' },
+      { value: 'other', label: 'Other' }
+    ];
+    const makeUI = (view: string) => (
+      <DataView<Order>
+        data={orders}
+        fields={fields}
+        mode='client'
+        defaultSort={{ name: 'title', order: 'asc' }}
+        getRowId={(row: Order) => row.id}
+        views={views}
+        view={view}
+      >
+        <DataView.Timeline<Order>
+          name='gantt'
+          startField='start'
+          endField='end'
+          range={['2025-01-01', '2025-01-31']}
+          scale='day'
+          unitWidth={20}
+          today={false}
+          defaultScrollTo='start'
+          renderCard={row => <div data-testid={`card-${row.original.id}`} />}
+        />
+      </DataView>
+    );
+    const { container, rerender } = render(makeUI('gantt'));
+    const root = container.firstElementChild as HTMLElement;
+    // User scrolls to Jan 11 (200px), then switches away and back.
+    root.scrollLeft = 200;
+    fireEvent.scroll(root);
+    rerender(makeUI('other'));
+    expect(screen.queryByTestId('card-o1')).toBeNull();
+
+    rerender(makeUI('gantt'));
+    // The DOM is recreated at scroll 0 — the stashed position must come back
+    // instead of stranding the user at the domain start.
+    const newRoot = container.firstElementChild as HTMLElement;
+    expect(screen.getByTestId('card-o1')).toBeInTheDocument();
+    expect(newRoot.scrollLeft).toBe(200);
+  });
+
+  it('packs point markers using estimatedPointWidth', () => {
+    const points: Order[] = [
+      { id: 'p1', title: 'P1', start: '2025-01-05', end: null }, // x = 80
+      { id: 'p2', title: 'P2', start: '2025-01-08', end: null } // x = 140
+    ];
+    // Default estimate (120px): p1 occupies [80, 200] → p2 at 140 overlaps
+    // → separate lanes, even though the old 24px floor would have packed them.
+    renderTimeline({ endField: undefined }, points);
+    expect(screen.getByTestId('card-p1').dataset.lane).not.toBe(
+      screen.getByTestId('card-p2').dataset.lane
+    );
+  });
+
+  it('shares a lane when estimatedPointWidth says the points fit', () => {
+    const points: Order[] = [
+      { id: 'p1', title: 'P1', start: '2025-01-05', end: null },
+      { id: 'p2', title: 'P2', start: '2025-01-08', end: null }
+    ];
+    // 40px estimate + 8px lane gap ≤ 60px separation → same lane.
+    renderTimeline({ endField: undefined, estimatedPointWidth: 40 }, points);
+    expect(screen.getByTestId('card-p1').dataset.lane).toBe(
+      screen.getByTestId('card-p2').dataset.lane
+    );
+  });
+
+  it('culls cards outside the overscanned viewport when virtualized', () => {
+    // jsdom viewport: left 0, width 0 → overscan 400 → cull window [-400, 400].
+    renderTimeline({ virtualized: true }, [
+      { id: 'near', title: 'Near', start: '2025-01-05', end: '2025-01-10' }, // x = 80
+      { id: 'far', title: 'Far', start: '2025-01-27', end: '2025-01-30' } // x = 520
+    ]);
+    expect(screen.getByTestId('card-near')).toBeInTheDocument();
+    expect(screen.queryByTestId('card-far')).toBeNull();
+  });
+
+  it('does not re-render cards on hover-cursor updates (memoized wrapper)', async () => {
+    const renderSpy = vi.fn();
+    const { container } = renderTimeline({
+      renderCard: row => {
+        renderSpy(row.original.id);
+        return (
+          <div data-testid={`card-${row.original.id}`}>
+            {row.original.title}
+          </div>
+        );
+      }
+    });
+    const callsAfterMount = renderSpy.mock.calls.length;
+    const root = container.firstElementChild as HTMLElement;
+    await act(async () => {
+      fireEvent.mouseMove(root, { clientX: 100 });
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    // The cursor badge proves a root re-render happened…
+    expect(screen.getByText('6 Jan')).toBeInTheDocument();
+    // …but no card interior re-rendered.
+    expect(renderSpy.mock.calls.length).toBe(callsAfterMount);
+  });
+});
+
+/* ─────────────────────── actionsRef (imperative handle) ─────────────────
+   Domain: explicit range Jan 1 → Jan 31 2025, day scale, 20px/unit.
+   t0 = Jan 1, t1 = Feb 1, totalWidth = 620px. jsdom clientWidth is 0, so
+   'center'/'end' alignment offsets collapse to the target's own x. */
+
+describe('DataView.Timeline actionsRef', () => {
+  const makeActionsRef = () => ({ current: null as TimelineActions | null });
+
+  it('scrolls to a date, aligned to the viewport edge requested', () => {
+    const actionsRef = makeActionsRef();
+    const { container } = renderTimeline({ actionsRef });
+    const root = container.firstElementChild as HTMLElement;
+    expect(actionsRef.current).not.toBeNull();
+    // Jan 11 = 10 days after Jan 1 → 10 × 20px.
+    actionsRef.current!.scrollTo('2025-01-11', {
+      align: 'start',
+      behavior: 'auto'
+    });
+    expect(root.scrollLeft).toBe(200);
+  });
+
+  it("resolves 'start' and 'end' to the domain edges", () => {
+    const actionsRef = makeActionsRef();
+    const { container } = renderTimeline({ actionsRef });
+    const root = container.firstElementChild as HTMLElement;
+    actionsRef.current!.scrollTo('end', { behavior: 'auto' });
+    expect(root.scrollLeft).toBe(620);
+    actionsRef.current!.scrollTo('start', { behavior: 'auto' });
+    expect(root.scrollLeft).toBe(0);
+  });
+
+  it('clamps out-of-domain dates to the nearest domain edge', () => {
+    const actionsRef = makeActionsRef();
+    const { container } = renderTimeline({ actionsRef });
+    const root = container.firstElementChild as HTMLElement;
+    actionsRef.current!.scrollTo('2030-06-01', {
+      align: 'start',
+      behavior: 'auto'
+    });
+    expect(root.scrollLeft).toBe(620);
+    actionsRef.current!.scrollTo('1999-01-01', {
+      align: 'start',
+      behavior: 'auto'
+    });
+    expect(root.scrollLeft).toBe(0);
+  });
+
+  it('defaults to smooth behavior via Element.scrollTo when available', () => {
+    const actionsRef = makeActionsRef();
+    const { container } = renderTimeline({ actionsRef });
+    const root = container.firstElementChild as HTMLElement;
+    const scrollToSpy = vi.fn();
+    // biome-ignore lint/suspicious/noExplicitAny: jsdom lacks Element.scrollTo
+    (root as any).scrollTo = scrollToSpy;
+    actionsRef.current!.scrollTo('2025-01-11', { align: 'start' });
+    expect(scrollToSpy).toHaveBeenCalledWith({ left: 200, behavior: 'smooth' });
+  });
+
+  it('warns and no-ops on an invalid date', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const actionsRef = makeActionsRef();
+    const { container } = renderTimeline({ actionsRef });
+    const root = container.firstElementChild as HTMLElement;
+    actionsRef.current!.scrollTo('not-a-date', { behavior: 'auto' });
+    expect(root.scrollLeft).toBe(0);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('invalid date'));
+  });
+
+  it('reports the visible time window from the live scroll position', () => {
+    const actionsRef = makeActionsRef();
+    const { container } = renderTimeline({ actionsRef });
+    const root = container.firstElementChild as HTMLElement;
+    root.scrollLeft = 200;
+    const range = actionsRef.current!.getVisibleRange();
+    expect(range).not.toBeNull();
+    const [from, to] = range!;
+    expect(from.getTime()).toBe(dayjs('2025-01-11').valueOf());
+    // 0-wide jsdom viewport → both edges coincide.
+    expect(to.getTime()).toBe(dayjs('2025-01-11').valueOf());
+  });
+
+  it('no-ops with a dev warning while hidden, and getVisibleRange is null', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const actionsRef = makeActionsRef();
+    renderTimeline({ actionsRef }, []); // no data + not loading → renders null
+    expect(actionsRef.current).not.toBeNull();
+    actionsRef.current!.scrollTo('today');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('not rendered'));
+    expect(actionsRef.current!.getVisibleRange()).toBeNull();
+  });
+});

--- a/packages/raystack/components/data-view/__tests__/timeline.test.tsx
+++ b/packages/raystack/components/data-view/__tests__/timeline.test.tsx
@@ -14,6 +14,7 @@ vi.mock('~/icons', () => ({
 import { DataView } from '../data-view';
 import type {
   DataViewField,
+  DataViewQuery,
   DataViewTimelineProps,
   InternalFilter,
   TimelineActions
@@ -353,6 +354,7 @@ type Order = {
   title: string;
   start: string | null;
   end: string | null;
+  team?: string;
 };
 
 const fields: DataViewField<Order>[] = [
@@ -382,14 +384,20 @@ function ApplyFilterButton({ filters }: { filters: InternalFilter[] }) {
 
 function renderTimeline(
   props: Partial<DataViewTimelineProps<Order>> = {},
-  data: Order[] = orders
+  data: Order[] = orders,
+  root: {
+    fields?: DataViewField<Order>[];
+    sort?: { name: string; order: 'asc' | 'desc' };
+    query?: DataViewQuery;
+  } = {}
 ) {
   return render(
     <DataView<Order>
       data={data}
-      fields={fields}
+      fields={root.fields ?? fields}
       mode='client'
-      defaultSort={{ name: 'title', order: 'asc' }}
+      defaultSort={root.sort ?? { name: 'title', order: 'asc' }}
+      query={root.query}
       getRowId={(row: Order) => row.id}
     >
       <DataView.Timeline<Order>
@@ -1109,6 +1117,292 @@ describe('DataView.Timeline', () => {
     expect(screen.getByText('6 Jan')).toBeInTheDocument();
     // …but no card interior re-rendered.
     expect(renderSpy.mock.calls.length).toBe(callsAfterMount);
+  });
+});
+
+/* ───────────────────────────── ordering contract ─────────────────────────
+   Sort can't move a card horizontally (x is locked to time), so it only shows
+   up where vertical order is free: `lanePacking="one-per-row"`. `auto` packing
+   stays purely chronological — these two tests are the regression guard. */
+
+describe('DataView.Timeline ordering', () => {
+  const laneOf = (id: string) =>
+    screen.getByTestId(`card-${id}`).dataset.lane as string;
+  const topOf = (id: string) =>
+    screen.getByTestId(`card-${id}`).parentElement!.style.top;
+
+  it('follows the active sort with lanePacking="one-per-row"', () => {
+    // Titles Alpha (o1), Beta (o2), Gamma (o3) → descending puts Gamma first.
+    const { unmount } = renderTimeline({ lanePacking: 'one-per-row' }, orders, {
+      sort: { name: 'title', order: 'desc' }
+    });
+    expect([laneOf('o3'), laneOf('o2'), laneOf('o1')]).toEqual(['0', '1', '2']);
+    unmount();
+
+    renderTimeline({ lanePacking: 'one-per-row' }, orders, {
+      sort: { name: 'title', order: 'asc' }
+    });
+    expect([laneOf('o1'), laneOf('o2'), laneOf('o3')]).toEqual(['0', '1', '2']);
+  });
+
+  it('leaves the packed layout untouched when the sort changes', () => {
+    const { unmount } = renderTimeline(undefined, orders, {
+      sort: { name: 'title', order: 'asc' }
+    });
+    const ascending = ['o1', 'o2', 'o3'].map(id => [laneOf(id), topOf(id)]);
+    unmount();
+
+    renderTimeline(undefined, orders, {
+      sort: { name: 'title', order: 'desc' }
+    });
+    const descending = ['o1', 'o2', 'o3'].map(id => [laneOf(id), topOf(id)]);
+    expect(descending).toEqual(ascending);
+  });
+});
+
+/* ────────────────────────── grouping (swim lanes) ───────────────────────
+   Grouped geometry over the same Jan 2025 domain. Cards are unmeasured in
+   jsdom, so every lane is estimatedRowHeight (66) tall with laneGap 16 and a
+   38px band (List's group-header box) per section:
+
+     Eng     band  0 →  38 | lane 0 top  54 | lane 1 top 136 | section ends 218
+     Design  band 218 → 256 | lane 0 top 272                 | canvas ends 354 */
+
+const groupedFields: DataViewField<Order>[] = [
+  { accessorKey: 'title', label: 'Title', sortable: true },
+  { accessorKey: 'team', label: 'Team', groupable: true, showGroupCount: true }
+];
+
+const groupedOrders: Order[] = [
+  // Eng: a1 [80..180] and a2 [100..180] overlap → two lanes.
+  {
+    id: 'a1',
+    title: 'A1',
+    team: 'Eng',
+    start: '2025-01-05',
+    end: '2025-01-10'
+  },
+  {
+    id: 'a2',
+    title: 'A2',
+    team: 'Eng',
+    start: '2025-01-06',
+    end: '2025-01-09'
+  },
+  // Design: b1 sits at the same x as a1 but packs in its own section → lane 0.
+  {
+    id: 'b1',
+    title: 'B1',
+    team: 'Design',
+    start: '2025-01-05',
+    end: '2025-01-10'
+  }
+];
+
+function renderGrouped(
+  props: Partial<DataViewTimelineProps<Order>> = {},
+  data: Order[] = groupedOrders
+) {
+  return renderTimeline(
+    { classNames: { groupHeader: 'band' }, ...props },
+    data,
+    {
+      fields: groupedFields,
+      query: { group_by: ['team'] }
+    }
+  );
+}
+
+const bands = (container: HTMLElement) =>
+  Array.from(container.getElementsByClassName('band'));
+
+describe('DataView.Timeline grouping', () => {
+  it('renders one band per group, in row-model order, with label and count', () => {
+    const { container } = renderGrouped();
+    // First-occurrence order from `groupData` — the same order List renders.
+    expect(bands(container).map(band => band.textContent)).toEqual([
+      'Eng2',
+      'Design1'
+    ]);
+  });
+
+  it('omits the count badge when the field does not opt in', () => {
+    const { container } = renderTimeline(
+      { classNames: { groupHeader: 'band' } },
+      groupedOrders,
+      {
+        fields: [
+          { accessorKey: 'title', label: 'Title', sortable: true },
+          { accessorKey: 'team', label: 'Team', groupable: true }
+        ],
+        query: { group_by: ['team'] }
+      }
+    );
+    expect(bands(container).map(band => band.textContent)).toEqual([
+      'Eng',
+      'Design'
+    ]);
+  });
+
+  it('packs each section independently and stacks sections vertically', () => {
+    renderGrouped();
+    // Lane indices reported to renderCard are section-relative.
+    expect(screen.getByTestId('card-a1').dataset.lane).toBe('0');
+    expect(screen.getByTestId('card-a2').dataset.lane).toBe('1');
+    expect(screen.getByTestId('card-b1').dataset.lane).toBe('0');
+    // …but the tops are global: Design's lane 0 sits below Eng's lanes.
+    expect(screen.getByTestId('card-a1').parentElement!.style.top).toBe('54px');
+    expect(screen.getByTestId('card-a2').parentElement!.style.top).toBe(
+      '136px'
+    );
+    expect(screen.getByTestId('card-b1').parentElement!.style.top).toBe(
+      '272px'
+    );
+  });
+
+  it('gives each band a slot spanning its whole section, contiguously', () => {
+    const { container } = renderGrouped();
+    // Contiguous slots are what makes a pinned band get pushed out by the
+    // next one exactly as that section arrives (CSS sticky, no JS).
+    const slots = Array.from(
+      container.querySelectorAll<HTMLElement>('[class*="timelineGroupSlot"]')
+    ).map(slot => [slot.style.top, slot.style.height]);
+    expect(slots).toEqual([
+      ['0px', '218px'],
+      ['218px', '136px']
+    ]);
+    const canvas = container.querySelector('[role="list"]') as HTMLElement;
+    expect(canvas.style.height).toBe('354px');
+  });
+
+  it('keeps a card in its own section when it starts under another group', () => {
+    renderGrouped();
+    // Same x as a1 (80px) — proves packing never leaks across sections.
+    expect(screen.getByTestId('card-b1').parentElement!.style.left).toBe(
+      '80px'
+    );
+    expect(screen.getByTestId('card-a1').parentElement!.style.left).toBe(
+      '80px'
+    );
+  });
+
+  it('hides the bands but keeps the sections with showGroupHeaders={false}', () => {
+    const { container } = renderGrouped({ showGroupHeaders: false });
+    expect(bands(container)).toHaveLength(0);
+    expect(container.querySelector('[class*="timelineGroupSlot"]')).toBeNull();
+    // Rows stay grouped (List semantics): the 38px bands are gone, so every
+    // section shifts up, but Design's lane still starts after Eng's two.
+    expect(screen.getByTestId('card-a1').parentElement!.style.top).toBe('16px');
+    expect(screen.getByTestId('card-a2').parentElement!.style.top).toBe('98px');
+    expect(screen.getByTestId('card-b1').parentElement!.style.top).toBe(
+      '196px'
+    );
+  });
+
+  it('drops a group whose cards are all outside the domain', () => {
+    const { container } = renderGrouped({}, [
+      ...groupedOrders,
+      // Entirely past the range end → the whole Ops section disappears.
+      {
+        id: 'c1',
+        title: 'C1',
+        team: 'Ops',
+        start: '2025-03-01',
+        end: '2025-03-05'
+      }
+    ]);
+    expect(bands(container).map(band => band.textContent)).toEqual([
+      'Eng2',
+      'Design1'
+    ]);
+    expect(screen.queryByTestId('card-c1')).toBeNull();
+  });
+
+  it('counts the whole group in the badge even when cards are culled', () => {
+    const { container } = renderGrouped({}, [
+      ...groupedOrders,
+      // A third Eng row outside the range: culled from the canvas, but the
+      // badge still reports `GroupedData.count` — same as List.
+      {
+        id: 'a3',
+        title: 'A3',
+        team: 'Eng',
+        start: '2025-03-01',
+        end: '2025-03-05'
+      }
+    ]);
+    expect(bands(container)[0].textContent).toBe('Eng3');
+    expect(screen.queryByTestId('card-a3')).toBeNull();
+    expect(screen.getByTestId('card-a1')).toBeInTheDocument();
+  });
+
+  it('renders no band layer when grouping is off', () => {
+    const { container } = renderTimeline({
+      classNames: { groupHeader: 'band' }
+    });
+    expect(bands(container)).toHaveLength(0);
+    expect(container.querySelector('[class*="timelineGroupLayer"]')).toBeNull();
+    // Degenerate single-section geometry is the ungrouped layout, unchanged.
+    expect(screen.getByTestId('card-o1').parentElement!.style.top).toBe('16px');
+  });
+
+  it('applies one-per-row packing within each section', () => {
+    renderGrouped({ lanePacking: 'one-per-row' });
+    expect(screen.getByTestId('card-a1').dataset.lane).toBe('0');
+    expect(screen.getByTestId('card-a2').dataset.lane).toBe('1');
+    // Design's single row restarts at lane 0 rather than continuing to 2.
+    expect(screen.getByTestId('card-b1').dataset.lane).toBe('0');
+  });
+
+  it('drops a whole section when its rows are filtered out', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <DataView<Order>
+        data={groupedOrders}
+        fields={[
+          { accessorKey: 'title', label: 'Title', sortable: true },
+          {
+            accessorKey: 'team',
+            label: 'Team',
+            groupable: true,
+            showGroupCount: true,
+            filterable: true,
+            filterType: 'select'
+          }
+        ]}
+        mode='client'
+        defaultSort={{ name: 'title', order: 'asc' }}
+        query={{ group_by: ['team'] }}
+        getRowId={(row: Order) => row.id}
+      >
+        <ApplyFilterButton
+          filters={[
+            { name: 'team', operator: 'eq', value: 'Design', _type: 'select' }
+          ]}
+        />
+        <DataView.Timeline<Order>
+          startField='start'
+          endField='end'
+          range={['2025-01-01', '2025-01-31']}
+          scale='day'
+          unitWidth={20}
+          today={false}
+          defaultScrollTo='start'
+          classNames={{ groupHeader: 'band' }}
+          renderCard={row => (
+            <div data-testid={`card-${row.original.id}`}>
+              {row.original.title}
+            </div>
+          )}
+        />
+      </DataView>
+    );
+    expect(bands(container)).toHaveLength(2);
+    await user.click(screen.getByTestId('apply-filter'));
+    // Only the matching group survives, and it moves to the top of the canvas.
+    expect(bands(container).map(band => band.textContent)).toEqual(['Design1']);
+    expect(screen.queryByTestId('card-a1')).toBeNull();
+    expect(screen.getByTestId('card-b1').parentElement!.style.top).toBe('54px');
   });
 });
 

--- a/packages/raystack/components/data-view/components/timeline.tsx
+++ b/packages/raystack/components/data-view/components/timeline.tsx
@@ -1,0 +1,1061 @@
+'use client';
+
+import type { Row } from '@tanstack/react-table';
+import { cx } from 'class-variance-authority';
+import dayjs from 'dayjs';
+import {
+  CSSProperties,
+  memo,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
+
+import { Badge } from '../../badge';
+import styles from '../data-view.module.css';
+import {
+  DataViewTimelineProps,
+  TimelineActions,
+  TimelineCardContext,
+  TimelineScale
+} from '../data-view.types';
+import { useDataView } from '../hooks/useDataView';
+import { packLanes } from '../utils/pack-lanes';
+import {
+  buildAxis,
+  createTimeScale,
+  startOfUnit,
+  TIMELINE_DEFAULT_UNIT_WIDTH,
+  TIMELINE_UNIT_MS,
+  toTimestamp
+} from '../utils/time-scale';
+import { FilterSummary } from './clear-filters';
+
+const DEFAULT_ROW_HEIGHT = 66;
+const DEFAULT_LANE_GAP = 16;
+const DEFAULT_MIN_CARD_WIDTH = 60;
+/** Assumed width of content-sized point cards for lane packing and culling. */
+const DEFAULT_POINT_WIDTH = 120;
+/** Floor for the rendered wrapper so near-zero spans stay visible and clickable. */
+const MIN_RENDER_WIDTH = 24;
+/** Units of padding around the data extent when no explicit `range` is given. */
+const DOMAIN_PAD_UNITS = 2;
+/** Half-window (in units) of the fallback domain used while loading with no data. */
+const FALLBACK_DOMAIN_UNITS = 15;
+/** Below this speed (px/ms) a release doesn't glide, and a glide stops. */
+const MOMENTUM_MIN_SPEED = 0.05;
+/** Speed cap (px/ms) so event-timing spikes can't launch a huge fling. */
+const MOMENTUM_MAX_SPEED = 4;
+/** Exponential decay constant (ms) of the post-release glide. */
+const MOMENTUM_DECAY_TAU = 325;
+/** Releasing this long (ms) after the last move means "held still" — no glide. */
+const MOMENTUM_STALE_MS = 80;
+
+const clampSpeed = (v: number) =>
+  Math.max(-MOMENTUM_MAX_SPEED, Math.min(v, MOMENTUM_MAX_SPEED));
+
+/** First index in `list` (ascending by `x`) with `x >= value`. */
+function lowerBoundByX(list: readonly { x: number }[], value: number): number {
+  let lo = 0;
+  let hi = list.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (list[mid].x < value) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+/** First index in `list` (ascending by `x`) with `x > value`. */
+function upperBoundByX(list: readonly { x: number }[], value: number): number {
+  let lo = 0;
+  let hi = list.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (list[mid].x <= value) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+interface TimelineCardViewProps<TData> {
+  row: Row<TData>;
+  x: number;
+  top: number;
+  height: number;
+  /** Null for point cards — the wrapper sizes to its content. */
+  renderWidth: number | null;
+  spanWidth: number;
+  collapsed: boolean;
+  laneIndex: number;
+  startTime: number;
+  /** Null when `endField` is omitted (point marker). */
+  endTime: number | null;
+  renderCard: DataViewTimelineProps<TData>['renderCard'];
+  onRowClick?: (row: TData) => void;
+  className?: string;
+}
+
+/**
+ * Memoized positioning wrapper for one card. Isolates `renderCard` from the
+ * root's per-frame re-renders (hover cursor, viewport tracking) — a card only
+ * re-renders when its own row or geometry changes. All props except `row`,
+ * `renderCard`, and `onRowClick` are primitives, so the default shallow
+ * compare holds as long as those identities are stable across renders.
+ */
+function TimelineCardViewInner<TData>({
+  row,
+  x,
+  top,
+  height,
+  renderWidth,
+  spanWidth,
+  collapsed,
+  laneIndex,
+  startTime,
+  endTime,
+  renderCard,
+  onRowClick,
+  className
+}: TimelineCardViewProps<TData>) {
+  const context: TimelineCardContext = {
+    width: spanWidth,
+    collapsed,
+    laneIndex,
+    start: new Date(startTime),
+    end: endTime !== null ? new Date(endTime) : null
+  };
+  const style: CSSProperties = {
+    left: x,
+    top,
+    height,
+    ...(renderWidth !== null ? { width: renderWidth } : null)
+  };
+  return (
+    <div
+      role='listitem'
+      className={className}
+      style={style}
+      data-collapsed={collapsed || undefined}
+      onClick={onRowClick ? () => onRowClick(row.original) : undefined}
+    >
+      {renderCard(row, context)}
+    </div>
+  );
+}
+
+const TimelineCardView = memo(
+  TimelineCardViewInner
+) as unknown as typeof TimelineCardViewInner & { displayName?: string };
+TimelineCardView.displayName = 'DataView.TimelineCard';
+
+interface ResolvedMarker {
+  key: string;
+  time: number;
+  x: number;
+  label: ReactNode;
+  variant: 'default' | 'accent' | 'danger';
+}
+
+const MARKER_BADGE_VARIANT: Record<
+  ResolvedMarker['variant'],
+  'accent' | 'danger' | 'neutral'
+> = {
+  accent: 'accent',
+  danger: 'danger',
+  default: 'neutral'
+};
+
+/** Axis-badge label for the hover cursor, formatted per scale granularity. */
+function cursorLabel(time: number, scale: TimelineScale): string {
+  const date = dayjs(time);
+  switch (scale) {
+    case 'day':
+    case 'week':
+      return date.format('D MMM');
+    case 'month':
+      return date.format('MMM YYYY');
+    case 'quarter':
+      return `Q${Math.floor(date.month() / 3) + 1} ${date.format('YYYY')}`;
+  }
+}
+
+/**
+ * Time-positioned card renderer. The Timeline owns the time scale (date → x,
+ * span → width), lane packing, the sticky two-tier axis (ticks, month/year
+ * bands, today + custom markers, gridlines), and native x/y scrolling. The
+ * card interior is entirely consumer-owned via `renderCard` — analogous to how
+ * `columns[].cell` owns cell interiors in `DataView.List`.
+ */
+export function DataViewTimeline<TData>({
+  name,
+  fields: fieldsOverride,
+  startField,
+  endField,
+  renderCard,
+  scale = 'day',
+  unitWidth,
+  range,
+  today = true,
+  markers,
+  showGridlines = true,
+  tickInterval,
+  gridlineInterval = 1,
+  showCursorLine = true,
+  defaultScrollTo = 'today',
+  onVisibleRangeChange,
+  actionsRef,
+  lanePacking = 'auto',
+  estimatedRowHeight = DEFAULT_ROW_HEIGHT,
+  laneGap = DEFAULT_LANE_GAP,
+  minCardWidth = DEFAULT_MIN_CARD_WIDTH,
+  estimatedPointWidth = DEFAULT_POINT_WIDTH,
+  virtualized = false,
+  classNames = {}
+}: DataViewTimelineProps<TData>) {
+  const { table, onRowClick, activeView, registerFieldsForView, hasData } =
+    useDataView<TData>();
+
+  // Register per-view field override so the toolbar's effectiveFields reflects
+  // this renderer's metadata while it's the active view.
+  useEffect(() => {
+    if (!name || !fieldsOverride) return;
+    return registerFieldsForView(name, fieldsOverride);
+  }, [name, fieldsOverride, registerFieldsForView]);
+
+  // Multi-view gate. When `name` is set, render only when this is the active
+  // view. When unset (single-renderer mode), always render.
+  const isActive = !name || activeView === undefined || activeView === name;
+
+  const effectiveUnitWidth = unitWidth ?? TIMELINE_DEFAULT_UNIT_WIDTH[scale];
+
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  // Viewport fill — when the domain renders narrower than the scroll
+  // container, the domain end extends so the axis/gridlines span the full
+  // visible width (see `minWidth` in createTimeScale). Extension only ever
+  // widens, so an explicit `range` wider than the container is untouched.
+  const [containerWidth, setContainerWidth] = useState(0);
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const measure = () => setContainerWidth(el.clientWidth);
+    measure();
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+    // Re-attach when the renderer mounts its DOM (ref is null while the view
+    // is gated or there's no data yet).
+  }, [isActive, hasData]);
+
+  // Quantized to whole units so sub-unit resizes (e.g. dragging a panel
+  // divider 1px at a time) don't rebuild the scale and re-run layout.
+  const fillWidth =
+    Math.ceil(containerWidth / effectiveUnitWidth) * effectiveUnitWidth;
+
+  const rowModel = table?.getRowModel();
+  const { rows = [] } = rowModel || {};
+
+  // Timeline bypasses group headers (RFC §Grouping) — position leaf rows only.
+  const leafRows = useMemo(
+    () => rows.filter(row => !(row.subRows && row.subRows.length > 0)),
+    [rows]
+  );
+
+  // Resolve each row's start/end timestamps. Rows without a valid start are
+  // skipped (dev warning); inverted ranges clamp to zero-length spans.
+  const timedItems = useMemo(() => {
+    const items: {
+      row: Row<TData>;
+      startTime: number;
+      endTime: number | null;
+    }[] = [];
+    let dropped = 0;
+    for (const row of leafRows) {
+      const original = row.original as Record<string, unknown>;
+      const startTime = toTimestamp(original?.[startField]);
+      if (startTime === null) {
+        dropped++;
+        continue;
+      }
+      let endTime: number | null = null;
+      if (endField) {
+        endTime = toTimestamp(original?.[endField]);
+        if (endTime !== null && endTime < startTime) endTime = startTime;
+      }
+      items.push({ row, startTime, endTime });
+    }
+    if (process.env.NODE_ENV !== 'production' && dropped > 0) {
+      console.warn(
+        `[DataView.Timeline] Skipped ${dropped} row(s) with a missing or invalid "${startField}" value.`
+      );
+    }
+    return items;
+  }, [leafRows, startField, endField]);
+
+  const todayTime = useMemo(() => {
+    if (today === false) return null;
+    if (today === true) {
+      // Day precision: aligns the line with its day tick and keeps SSR and
+      // client renders consistent (no per-ms Date.now() drift → no hydration
+      // mismatch).
+      const now = new Date();
+      now.setHours(0, 0, 0, 0);
+      return now.getTime();
+    }
+    return toTimestamp(today);
+  }, [today]);
+
+  const markerTimes = useMemo(
+    () =>
+      (markers ?? [])
+        .map(marker => toTimestamp(marker.date))
+        .filter((time): time is number => time !== null),
+    [markers]
+  );
+
+  // Domain: explicit `range` wins; otherwise the extent of data + today +
+  // markers. With nothing to show (e.g. initial server load), fall back to a
+  // window centered on today so the axis and skeletons still render.
+  const domain = useMemo(() => {
+    if (range) {
+      const a = toTimestamp(range[0]);
+      const b = toTimestamp(range[1]);
+      if (a !== null && b !== null) {
+        return { min: Math.min(a, b), max: Math.max(a, b), explicit: true };
+      }
+    }
+    let min = Infinity;
+    let max = -Infinity;
+    for (const item of timedItems) {
+      min = Math.min(min, item.startTime);
+      max = Math.max(max, item.endTime ?? item.startTime);
+    }
+    for (const time of [todayTime ?? Infinity, ...markerTimes]) {
+      if (!Number.isFinite(time)) continue;
+      min = Math.min(min, time);
+      max = Math.max(max, time);
+    }
+    if (!Number.isFinite(min)) {
+      const fallback = new Date();
+      fallback.setHours(0, 0, 0, 0);
+      const anchor = todayTime ?? fallback.getTime();
+      const pad = FALLBACK_DOMAIN_UNITS * TIMELINE_UNIT_MS[scale];
+      return { min: anchor - pad, max: anchor + pad, explicit: false };
+    }
+    return { min, max, explicit: false };
+  }, [range, timedItems, todayTime, markerTimes, scale]);
+
+  const timeScale = useMemo(
+    () =>
+      createTimeScale({
+        minTime: domain.min,
+        maxTime: domain.max,
+        scale,
+        unitWidth: effectiveUnitWidth,
+        padUnits: domain.explicit ? 0 : DOMAIN_PAD_UNITS,
+        minWidth: fillWidth
+      }),
+    [domain, scale, effectiveUnitWidth, fillWidth]
+  );
+
+  const { ticks, bands } = useMemo(
+    () => buildAxis(timeScale, scale, effectiveUnitWidth, tickInterval),
+    [timeScale, scale, effectiveUnitWidth, tickInterval]
+  );
+
+  // Gridline thinning is visual only — positioning (cards, today, cursor
+  // snapping) stays at full `scale`-unit granularity.
+  const gridlineEvery = Math.max(1, Math.floor(gridlineInterval));
+
+  // Card geometry. `renderWidth` is null for point markers (no endField) —
+  // the wrapper sizes to its content instead of the time span. Rows entirely
+  // outside the domain are dropped: with an explicit `range`, fetched data
+  // routinely extends past the window (e.g. whole-month API buckets), and
+  // those rows must not render beyond the axis or occupy lanes.
+  const positioned = useMemo(() => {
+    const items: (typeof timedItems)[number][] = [];
+    for (const item of timedItems) {
+      const effectiveEnd = item.endTime ?? item.startTime;
+      if (item.startTime > timeScale.t1 || effectiveEnd < timeScale.t0) {
+        continue;
+      }
+      items.push(item);
+    }
+    return items.map(item => {
+      const x = timeScale.x(item.startTime);
+      const spanWidth =
+        item.endTime !== null
+          ? (item.endTime - item.startTime) * timeScale.pxPerMs
+          : 0;
+      const renderWidth =
+        item.endTime !== null ? Math.max(spanWidth, MIN_RENDER_WIDTH) : null;
+      // Point cards (no endField) size to their content, so the packer can't
+      // know their width — `estimatedPointWidth` stands in for lane packing
+      // and culling so wide chips don't overlap within a lane.
+      const packWidth = renderWidth ?? estimatedPointWidth;
+      return { ...item, x, spanWidth, renderWidth, packWidth };
+    });
+  }, [timedItems, timeScale, estimatedPointWidth]);
+
+  const { lanes, laneCount } = useMemo(() => {
+    if (lanePacking === 'one-per-row') {
+      return {
+        lanes: positioned.map((_, i) => i),
+        laneCount: positioned.length
+      };
+    }
+    return packLanes(
+      positioned.map(item => ({ x: item.x, width: item.packWidth }))
+    );
+  }, [positioned, lanePacking]);
+
+  // Lane assignments zipped in and sorted ascending by x so per-frame culling
+  // can binary-search the visible slice instead of scanning every item. Lane
+  // semantics (packing order, one-per-row row order) are unaffected — lanes
+  // are assigned before the sort. DOM order becomes chronological.
+  const cards = useMemo(() => {
+    const list = positioned.map((item, index) => ({
+      ...item,
+      lane: lanes[index]
+    }));
+    list.sort((a, b) => a.x - b.x);
+    return list;
+  }, [positioned, lanes]);
+
+  // Widens the culling window's left bound: a card is visible when
+  // `x + width >= min`, and width isn't sorted — only x is.
+  const maxPackWidth = useMemo(
+    () => positioned.reduce((max, item) => Math.max(max, item.packWidth), 0),
+    [positioned]
+  );
+
+  const resolvedMarkers = useMemo(() => {
+    const list: ResolvedMarker[] = [];
+    if (
+      todayTime !== null &&
+      todayTime >= timeScale.t0 &&
+      todayTime <= timeScale.t1
+    ) {
+      list.push({
+        key: '__today',
+        time: todayTime,
+        x: timeScale.x(todayTime),
+        label: dayjs(todayTime).format('D MMM'),
+        variant: 'accent'
+      });
+    }
+    markers?.forEach((marker, index) => {
+      const time = toTimestamp(marker.date);
+      if (time === null || time < timeScale.t0 || time > timeScale.t1) return;
+      list.push({
+        key: `__marker-${index}`,
+        time,
+        x: timeScale.x(time),
+        label: marker.label ?? dayjs(time).format('D MMM'),
+        variant: marker.variant ?? 'default'
+      });
+    });
+    return list;
+  }, [todayTime, markers, timeScale]);
+
+  // Viewport tracking — drives horizontal culling (`virtualized`) and
+  // `onVisibleRangeChange`. rAF-throttled so the state update runs at most
+  // once per frame regardless of scroll event rate.
+  const needsViewport = virtualized || Boolean(onVisibleRangeChange);
+  const [viewport, setViewport] = useState<{
+    left: number;
+    width: number;
+  } | null>(null);
+  const rafIdRef = useRef<number | null>(null);
+
+  const readViewport = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setViewport(prev => {
+      const next = { left: el.scrollLeft, width: el.clientWidth };
+      if (prev && prev.left === next.left && prev.width === next.width) {
+        return prev;
+      }
+      return next;
+    });
+  }, []);
+
+  // Hover cursor — a crosshair line snapped to the sub-interval (tick unit)
+  // under the pointer, with a date badge pinned to the axis. Updates are
+  // rAF-throttled and recomputed on scroll too (the content moves under a
+  // stationary pointer).
+  const [cursorTime, setCursorTime] = useState<number | null>(null);
+  const pointerXRef = useRef<number | null>(null);
+  const cursorRafRef = useRef<number | null>(null);
+
+  const updateCursorFromPointer = useCallback(() => {
+    if (!showCursorLine) return;
+    const el = scrollRef.current;
+    const pointerX = pointerXRef.current;
+    if (!el || pointerX === null) return;
+    const rect = el.getBoundingClientRect();
+    const canvasX = pointerX - rect.left + el.scrollLeft;
+    const time = Math.max(
+      timeScale.t0,
+      Math.min(timeScale.timeAt(canvasX), timeScale.t1)
+    );
+    const snapped = startOfUnit(dayjs(time), scale).valueOf();
+    setCursorTime(prev => (prev === snapped ? prev : snapped));
+  }, [showCursorLine, timeScale, scale]);
+
+  const handlePointerMove = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (!showCursorLine) return;
+      pointerXRef.current = event.clientX;
+      if (cursorRafRef.current !== null) return;
+      cursorRafRef.current = requestAnimationFrame(() => {
+        cursorRafRef.current = null;
+        updateCursorFromPointer();
+      });
+    },
+    [showCursorLine, updateCursorFromPointer]
+  );
+
+  const handlePointerLeave = useCallback(() => {
+    pointerXRef.current = null;
+    if (cursorRafRef.current !== null) {
+      cancelAnimationFrame(cursorRafRef.current);
+      cursorRafRef.current = null;
+    }
+    setCursorTime(null);
+  }, []);
+
+  // Drag-to-pan — press the background and drag to scroll both axes. Mouse
+  // only: touch already pans via native scrolling, and starting only on the
+  // background keeps cards (row click) and footer controls interactive.
+  const dragRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    scrollLeft: number;
+    scrollTop: number;
+    lastX: number;
+    lastY: number;
+    lastTime: number;
+    vx: number;
+    vy: number;
+  } | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  // Post-release glide — the pan carries its release velocity and decays
+  // exponentially instead of stopping dead. Any new interaction cancels it.
+  const momentumRafRef = useRef<number | null>(null);
+
+  const stopMomentum = useCallback(() => {
+    if (momentumRafRef.current !== null) {
+      cancelAnimationFrame(momentumRafRef.current);
+      momentumRafRef.current = null;
+    }
+  }, []);
+
+  const startMomentum = useCallback(
+    (initialVx: number, initialVy: number) => {
+      stopMomentum();
+      let vx = initialVx;
+      let vy = initialVy;
+      let prevTime = performance.now();
+      const step = (now: number) => {
+        momentumRafRef.current = null;
+        const el = scrollRef.current;
+        if (!el) return;
+        const dt = Math.max(0, now - prevTime);
+        prevTime = now;
+        if (dt > 0) {
+          const beforeLeft = el.scrollLeft;
+          const beforeTop = el.scrollTop;
+          el.scrollLeft = beforeLeft + vx * dt;
+          el.scrollTop = beforeTop + vy * dt;
+          // Hitting a scroll bound kills that axis so the glide ends there
+          // instead of burning frames against the edge.
+          if (el.scrollLeft === beforeLeft) vx = 0;
+          if (el.scrollTop === beforeTop) vy = 0;
+          const decay = Math.exp(-dt / MOMENTUM_DECAY_TAU);
+          vx *= decay;
+          vy *= decay;
+        }
+        if (Math.hypot(vx, vy) >= MOMENTUM_MIN_SPEED) {
+          momentumRafRef.current = requestAnimationFrame(step);
+        }
+      };
+      momentumRafRef.current = requestAnimationFrame(step);
+    },
+    [stopMomentum]
+  );
+
+  const handleDragPointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      // Any press grabs the content — even ones that don't start a pan.
+      stopMomentum();
+      if (event.pointerType !== 'mouse' || event.button !== 0) return;
+      const el = scrollRef.current;
+      if (!el) return;
+      const target = event.target as Element;
+      if (
+        target.closest(
+          '[role="listitem"], a, button, input, textarea, select, [contenteditable]'
+        )
+      ) {
+        return;
+      }
+      dragRef.current = {
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        scrollLeft: el.scrollLeft,
+        scrollTop: el.scrollTop,
+        lastX: event.clientX,
+        lastY: event.clientY,
+        lastTime: performance.now(),
+        vx: 0,
+        vy: 0
+      };
+      // Capture so the pan keeps tracking when the pointer leaves the pane.
+      // Throws for pointers the browser isn't tracking (synthetic events).
+      try {
+        el.setPointerCapture?.(event.pointerId);
+      } catch {
+        /* noop */
+      }
+      // Panning, not selecting — suppress native text-selection drag.
+      event.preventDefault();
+    },
+    []
+  );
+
+  const handleDragPointerMove = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current;
+      const el = scrollRef.current;
+      if (!drag || !el || event.pointerId !== drag.pointerId) return;
+      const dx = event.clientX - drag.startX;
+      const dy = event.clientY - drag.startY;
+      el.scrollLeft = drag.scrollLeft - dx;
+      el.scrollTop = drag.scrollTop - dy;
+      // Release velocity, EMA-smoothed over a ~50ms window so one noisy
+      // inter-event gap doesn't set the fling speed.
+      const now = performance.now();
+      const dt = now - drag.lastTime;
+      if (dt > 0) {
+        const mix = Math.min(1, dt / 50);
+        drag.vx += ((event.clientX - drag.lastX) / dt - drag.vx) * mix;
+        drag.vy += ((event.clientY - drag.lastY) / dt - drag.vy) * mix;
+        drag.lastX = event.clientX;
+        drag.lastY = event.clientY;
+        drag.lastTime = now;
+      }
+      // Small threshold so a plain background click never flashes the
+      // grabbing cursor.
+      if (Math.abs(dx) > 2 || Math.abs(dy) > 2) setIsDragging(true);
+    },
+    []
+  );
+
+  const handleDragEnd = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current;
+      if (!drag || event.pointerId !== drag.pointerId) return;
+      dragRef.current = null;
+      setIsDragging(false);
+      // Fling: glide only when released mid-motion, not after holding still.
+      if (performance.now() - drag.lastTime > MOMENTUM_STALE_MS) return;
+      const vx = clampSpeed(drag.vx);
+      const vy = clampSpeed(drag.vy);
+      if (Math.hypot(vx, vy) < MOMENTUM_MIN_SPEED) return;
+      // Content scrolls opposite to the pointer's travel.
+      startMomentum(-vx, -vy);
+    },
+    [startMomentum]
+  );
+
+  // Last known scroll offsets — stashed on every scroll (and on programmatic
+  // scrolls) so the position survives the DOM being unmounted while hidden
+  // (inactive view / no data) and restored on re-activation, instead of the
+  // recreated DOM stranding the user at scroll 0 (the domain start).
+  const savedScrollRef = useRef<{ left: number; top: number } | null>(null);
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (el) {
+      savedScrollRef.current = { left: el.scrollLeft, top: el.scrollTop };
+    }
+    if (!needsViewport && !showCursorLine) return;
+    if (rafIdRef.current !== null) return;
+    rafIdRef.current = requestAnimationFrame(() => {
+      rafIdRef.current = null;
+      if (needsViewport) readViewport();
+      updateCursorFromPointer();
+    });
+  }, [needsViewport, showCursorLine, readViewport, updateCursorFromPointer]);
+
+  useEffect(
+    () => () => {
+      for (const ref of [rafIdRef, cursorRafRef, momentumRafRef]) {
+        if (ref.current !== null) {
+          cancelAnimationFrame(ref.current);
+          ref.current = null;
+        }
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!needsViewport || !isActive) return;
+    readViewport();
+    const el = scrollRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(readViewport);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [needsViewport, isActive, readViewport]);
+
+  // Deduped by ms values — `timeScale`/`viewport` identity churn (a resize, a
+  // domain rebuild from streamed-in rows) must not re-fire consumers with an
+  // unchanged window; each fire typically triggers a fetch check.
+  const lastNotifiedRangeRef = useRef<{ from: number; to: number } | null>(
+    null
+  );
+  useEffect(() => {
+    if (!onVisibleRangeChange || !viewport) return;
+    const from = timeScale.timeAt(viewport.left);
+    const to = timeScale.timeAt(viewport.left + viewport.width);
+    const prev = lastNotifiedRangeRef.current;
+    if (prev && prev.from === from && prev.to === to) return;
+    lastNotifiedRangeRef.current = { from, to };
+    onVisibleRangeChange([new Date(from), new Date(to)]);
+  }, [onVisibleRangeChange, viewport, timeScale]);
+
+  // Time-target resolution shared by `defaultScrollTo` and the imperative
+  // handle. 'today' resolves to the today-line when shown, else the actual
+  // current date — both get clamped into the domain by `scrollToTime`.
+  const resolveScrollTarget = useCallback(
+    (target: NonNullable<DataViewTimelineProps<TData>['defaultScrollTo']>) => {
+      if (target === 'start') return timeScale.t0;
+      if (target === 'end') return timeScale.t1;
+      if (target === 'today') {
+        if (todayTime !== null) return todayTime;
+        const now = new Date();
+        now.setHours(0, 0, 0, 0);
+        return now.getTime();
+      }
+      return toTimestamp(target);
+    },
+    [timeScale, todayTime]
+  );
+
+  // Programmatic scroll — clamps the target into the domain, aligns it in the
+  // viewport, and cancels any in-flight momentum glide. Direct scrollLeft
+  // assignment for 'auto' keeps jsdom (no Element.scrollTo) working.
+  const scrollToTime = useCallback(
+    (
+      time: number,
+      align: 'start' | 'center' | 'end',
+      behavior: 'auto' | 'smooth'
+    ) => {
+      const el = scrollRef.current;
+      if (!el) return;
+      stopMomentum();
+      const clamped = Math.max(timeScale.t0, Math.min(time, timeScale.t1));
+      let targetX = timeScale.x(clamped);
+      if (align === 'center') targetX -= el.clientWidth / 2;
+      else if (align === 'end') targetX -= el.clientWidth;
+      const left = Math.max(
+        0,
+        Math.min(targetX, timeScale.totalWidth - el.clientWidth)
+      );
+      // Stash eagerly — programmatic scrolls must survive a view switch even
+      // when no scroll event follows (e.g. the target equals the current
+      // position, or jsdom).
+      savedScrollRef.current = { left, top: el.scrollTop };
+      if (behavior === 'smooth' && typeof el.scrollTo === 'function') {
+        el.scrollTo({ left, behavior: 'smooth' });
+      } else {
+        el.scrollLeft = left;
+      }
+    },
+    [timeScale, stopMomentum]
+  );
+
+  useImperativeHandle(
+    actionsRef,
+    (): TimelineActions => ({
+      scrollTo: (target, options) => {
+        if (!scrollRef.current) {
+          if (process.env.NODE_ENV !== 'production') {
+            console.warn(
+              '[DataView.Timeline] scrollTo() ignored — the timeline is not rendered (inactive view or no data).'
+            );
+          }
+          return;
+        }
+        const time = resolveScrollTarget(target);
+        if (time === null) {
+          if (process.env.NODE_ENV !== 'production') {
+            console.warn(
+              `[DataView.Timeline] scrollTo() received an invalid date: ${String(target)}`
+            );
+          }
+          return;
+        }
+        scrollToTime(
+          time,
+          options?.align ?? 'center',
+          options?.behavior ?? 'smooth'
+        );
+      },
+      getVisibleRange: () => {
+        const el = scrollRef.current;
+        if (!el) return null;
+        return [
+          new Date(timeScale.timeAt(el.scrollLeft)),
+          new Date(timeScale.timeAt(el.scrollLeft + el.clientWidth))
+        ];
+      }
+    }),
+    [resolveScrollTarget, scrollToTime, timeScale]
+  );
+
+  // Initial scroll position — runs when the renderer (re)mounts its DOM. The
+  // first activation applies `defaultScrollTo`; re-activations restore the
+  // stashed position, because the recreated scroll container starts back at
+  // (0, 0) — without the restore a returning user would land at the domain
+  // start instead of where they left off.
+  const didInitScrollRef = useRef(false);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `isActive`/`hasData` re-run the attempt when the renderer (re)mounts its DOM (the ref is null while hidden).
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    if (!el) {
+      // Hidden (inactive view or no data): the DOM is gone — arm the next
+      // activation to restore or re-init.
+      didInitScrollRef.current = false;
+      return;
+    }
+    if (didInitScrollRef.current) return;
+    didInitScrollRef.current = true;
+    const saved = savedScrollRef.current;
+    if (saved) {
+      el.scrollLeft = saved.left;
+      el.scrollTop = saved.top;
+      return;
+    }
+    const time = resolveScrollTarget(defaultScrollTo) ?? timeScale.t0;
+    const align =
+      defaultScrollTo === 'start'
+        ? 'start'
+        : defaultScrollTo === 'end'
+          ? 'end'
+          : 'center';
+    scrollToTime(time, align, 'auto');
+  }, [
+    defaultScrollTo,
+    resolveScrollTarget,
+    scrollToTime,
+    timeScale,
+    isActive,
+    hasData
+  ]);
+
+  // Scroll anchoring — when the time domain shifts (rows prepended by
+  // range-window fetching, `range` extended, zoom change), keep the time under
+  // the viewport's left edge stable instead of letting content jump.
+  const scrollAnchorRef = useRef<{ t0: number; pxPerMs: number } | null>(null);
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    const prev = scrollAnchorRef.current;
+    if (
+      el &&
+      prev &&
+      (prev.t0 !== timeScale.t0 || prev.pxPerMs !== timeScale.pxPerMs)
+    ) {
+      const leftEdgeTime = prev.t0 + el.scrollLeft / prev.pxPerMs;
+      el.scrollLeft = Math.max(0, timeScale.x(leftEdgeTime));
+    }
+    scrollAnchorRef.current = {
+      t0: timeScale.t0,
+      pxPerMs: timeScale.pxPerMs
+    };
+  }, [timeScale]);
+
+  if (!isActive) return null;
+  // Render nothing when there's truly no data and no loading — sibling
+  // `<DataView.EmptyState>` / `<DataView.ZeroState>` handle messaging.
+  if (!hasData) return null;
+
+  const lanePitch = estimatedRowHeight + laneGap;
+  const canvasHeight = Math.max(laneCount, 1) * lanePitch + laneGap;
+
+  // Horizontal culling window — one extra viewport on each side as overscan.
+  const overscan = viewport ? Math.max(viewport.width, 400) : 0;
+  const cullRange =
+    virtualized && viewport
+      ? {
+          min: viewport.left - overscan,
+          max: viewport.left + viewport.width + overscan
+        }
+      : null;
+  // Visible slices via binary search — both lists are sorted ascending by x,
+  // so per-frame culling costs O(log n + visible) instead of scanning every
+  // item. The card slice widens its left bound by the widest card (x is
+  // sorted, width isn't), so each sliced card still gets a right-edge check.
+  const cardSlice = cullRange
+    ? cards.slice(
+        lowerBoundByX(cards, cullRange.min - maxPackWidth),
+        upperBoundByX(cards, cullRange.max)
+      )
+    : cards;
+  const gridTicks = cullRange
+    ? ticks.slice(
+        lowerBoundByX(ticks, cullRange.min),
+        upperBoundByX(ticks, cullRange.max)
+      )
+    : ticks;
+  const cardClassName = cx(
+    styles.timelineCard,
+    onRowClick && styles.clickable,
+    classNames.card
+  );
+
+  return (
+    <div
+      ref={scrollRef}
+      className={cx(styles.timelineRoot, classNames.root)}
+      data-dragging={isDragging || undefined}
+      onScroll={handleScroll}
+      onMouseMove={showCursorLine ? handlePointerMove : undefined}
+      onMouseLeave={showCursorLine ? handlePointerLeave : undefined}
+      onPointerDown={handleDragPointerDown}
+      onPointerMove={handleDragPointerMove}
+      onPointerUp={handleDragEnd}
+      onPointerCancel={handleDragEnd}
+      onLostPointerCapture={handleDragEnd}
+      onWheel={stopMomentum}
+    >
+      <div
+        className={cx(styles.timelineAxis, classNames.axis)}
+        style={{ width: timeScale.totalWidth }}
+      >
+        {bands.map(band => (
+          <div
+            key={band.time}
+            className={cx(styles.timelineAxisBand, classNames.band)}
+            style={{ left: band.x, width: band.width }}
+          >
+            {/* Sticky-left so the label stays visible while its band spans the viewport. */}
+            <span className={styles.timelineAxisBandLabel}>{band.label}</span>
+          </div>
+        ))}
+        {ticks.map(tick =>
+          tick.showLabel ? (
+            <div
+              key={tick.time}
+              className={cx(styles.timelineAxisTick, classNames.tick)}
+              style={{ left: tick.x }}
+            >
+              {tick.label}
+            </div>
+          ) : null
+        )}
+        {resolvedMarkers.map(marker => (
+          <div
+            key={marker.key}
+            className={styles.timelineAxisMarker}
+            style={{ left: marker.x }}
+          >
+            <Badge size='micro' variant={MARKER_BADGE_VARIANT[marker.variant]}>
+              {marker.label}
+            </Badge>
+          </div>
+        ))}
+        {cursorTime !== null ? (
+          <div
+            aria-hidden='true'
+            className={styles.timelineAxisCursor}
+            style={{ left: timeScale.x(cursorTime) }}
+          >
+            <Badge size='micro' variant='neutral'>
+              {cursorLabel(cursorTime, scale)}
+            </Badge>
+          </div>
+        ) : null}
+      </div>
+
+      <div
+        role='list'
+        className={cx(styles.timelineCanvas, classNames.canvas)}
+        style={{ width: timeScale.totalWidth, height: canvasHeight }}
+      >
+        {showGridlines
+          ? gridTicks.map(tick =>
+              tick.index % gridlineEvery === 0 ? (
+                <div
+                  key={tick.time}
+                  aria-hidden='true'
+                  className={cx(styles.timelineGridline, classNames.gridline)}
+                  style={{ left: tick.x }}
+                />
+              ) : null
+            )
+          : null}
+        {resolvedMarkers.map(marker => (
+          <div
+            key={marker.key}
+            aria-hidden='true'
+            className={cx(styles.timelineMarkerLine, classNames.marker)}
+            data-variant={marker.variant}
+            style={{ left: marker.x }}
+          />
+        ))}
+        {cursorTime !== null ? (
+          <div
+            aria-hidden='true'
+            className={cx(styles.timelineCursorLine, classNames.cursor)}
+            style={{ left: timeScale.x(cursorTime) }}
+          />
+        ) : null}
+        {cardSlice.map(item => {
+          // Right-edge check for the widened left bound of the slice.
+          if (cullRange && item.x + item.packWidth < cullRange.min) {
+            return null;
+          }
+          return (
+            <TimelineCardView
+              key={item.row.id}
+              row={item.row}
+              x={item.x}
+              top={laneGap + item.lane * lanePitch}
+              height={estimatedRowHeight}
+              renderWidth={item.renderWidth}
+              spanWidth={item.spanWidth}
+              collapsed={item.endTime !== null && item.spanWidth < minCardWidth}
+              laneIndex={item.lane}
+              startTime={item.startTime}
+              endTime={item.endTime}
+              renderCard={renderCard}
+              onRowClick={onRowClick}
+              className={cardClassName}
+            />
+          );
+        })}
+      </div>
+
+      {/* Sticky-left so the footer stays viewport-aligned under horizontal scroll. */}
+      <div className={styles.timelineFooter}>
+        <FilterSummary />
+      </div>
+    </div>
+  );
+}
+
+DataViewTimeline.displayName = 'DataView.Timeline';

--- a/packages/raystack/components/data-view/components/timeline.tsx
+++ b/packages/raystack/components/data-view/components/timeline.tsx
@@ -55,6 +55,13 @@ const MOMENTUM_MAX_SPEED = 4;
 const MOMENTUM_DECAY_TAU = 325;
 /** Releasing this long (ms) after the last move means "held still" — no glide. */
 const MOMENTUM_STALE_MS = 80;
+/**
+ * Breathing room between an edge-aligned scroll target ('start'/'end') and
+ * the viewport edge — a card flush against the edge reads as clipped. The
+ * domain clamp wins when there's no room, so targets at the domain edges
+ * still sit flush instead of revealing space past the domain.
+ */
+const SCROLL_EDGE_INSET_PX = 24;
 
 const clampSpeed = (v: number) =>
   Math.max(-MOMENTUM_MAX_SPEED, Math.min(v, MOMENTUM_MAX_SPEED));
@@ -87,7 +94,6 @@ interface TimelineCardViewProps<TData> {
   row: Row<TData>;
   x: number;
   top: number;
-  height: number;
   /** Null for point cards — the wrapper sizes to its content. */
   renderWidth: number | null;
   spanWidth: number;
@@ -97,6 +103,8 @@ interface TimelineCardViewProps<TData> {
   /** Null when `endField` is omitted (point marker). */
   endTime: number | null;
   renderCard: DataViewTimelineProps<TData>['renderCard'];
+  /** Reports the wrapper's rendered height so lanes can size to content. */
+  onMeasure: (rowId: string, height: number) => void;
   onRowClick?: (row: TData) => void;
   className?: string;
 }
@@ -105,14 +113,13 @@ interface TimelineCardViewProps<TData> {
  * Memoized positioning wrapper for one card. Isolates `renderCard` from the
  * root's per-frame re-renders (hover cursor, viewport tracking) — a card only
  * re-renders when its own row or geometry changes. All props except `row`,
- * `renderCard`, and `onRowClick` are primitives, so the default shallow
- * compare holds as long as those identities are stable across renders.
+ * `renderCard`, `onMeasure`, and `onRowClick` are primitives, so the default
+ * shallow compare holds as long as those identities are stable across renders.
  */
 function TimelineCardViewInner<TData>({
   row,
   x,
   top,
-  height,
   renderWidth,
   spanWidth,
   collapsed,
@@ -120,9 +127,27 @@ function TimelineCardViewInner<TData>({
   startTime,
   endTime,
   renderCard,
+  onMeasure,
   onRowClick,
   className
 }: TimelineCardViewProps<TData>) {
+  const elementRef = useRef<HTMLDivElement | null>(null);
+  const rowId = row.id;
+
+  // Height is content-driven (same contract as `DataView.List` rows):
+  // measure after paint and on resize, and report up so the lane layout can
+  // replace its `estimatedRowHeight` seed with the real value.
+  useEffect(() => {
+    const el = elementRef.current;
+    if (!el) return;
+    const report = () => onMeasure(rowId, el.offsetHeight);
+    report();
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(report);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [onMeasure, rowId]);
+
   const context: TimelineCardContext = {
     width: spanWidth,
     collapsed,
@@ -133,11 +158,11 @@ function TimelineCardViewInner<TData>({
   const style: CSSProperties = {
     left: x,
     top,
-    height,
     ...(renderWidth !== null ? { width: renderWidth } : null)
   };
   return (
     <div
+      ref={elementRef}
       role='listitem'
       className={className}
       style={style}
@@ -195,6 +220,7 @@ function cursorLabel(time: number, scale: TimelineScale): string {
 export function DataViewTimeline<TData>({
   name,
   fields: fieldsOverride,
+  'aria-label': ariaLabel,
   startField,
   endField,
   renderCard,
@@ -208,6 +234,7 @@ export function DataViewTimeline<TData>({
   gridlineInterval = 1,
   showCursorLine = true,
   defaultScrollTo = 'today',
+  scrollToResults = true,
   onVisibleRangeChange,
   actionsRef,
   lanePacking = 'auto',
@@ -218,8 +245,14 @@ export function DataViewTimeline<TData>({
   virtualized = false,
   classNames = {}
 }: DataViewTimelineProps<TData>) {
-  const { table, onRowClick, activeView, registerFieldsForView, hasData } =
-    useDataView<TData>();
+  const {
+    table,
+    onRowClick,
+    activeView,
+    registerFieldsForView,
+    hasData,
+    tableQuery
+  } = useDataView<TData>();
 
   // Register per-view field override so the toolbar's effectiveFields reflects
   // this renderer's metadata while it's the active view.
@@ -232,7 +265,12 @@ export function DataViewTimeline<TData>({
   // view. When unset (single-renderer mode), always render.
   const isActive = !name || activeView === undefined || activeView === name;
 
-  const effectiveUnitWidth = unitWidth ?? TIMELINE_DEFAULT_UNIT_WIDTH[scale];
+  // Clamped: a zero/negative width would zero out px density and hang the
+  // viewport-fill loop in createTimeScale (see the guard there).
+  const effectiveUnitWidth = Math.max(
+    1,
+    unitWidth ?? TIMELINE_DEFAULT_UNIT_WIDTH[scale]
+  );
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
@@ -416,6 +454,22 @@ export function DataViewTimeline<TData>({
     );
   }, [positioned, lanePacking]);
 
+  // Measured card heights by row id, `estimatedRowHeight` standing in until a
+  // card reports (same estimate-then-measure contract as `DataView.List`).
+  // Kept in a ref — measurements arrive per card per paint, and a version
+  // counter batches them into one lane-geometry recompute. Entries survive
+  // virtualization unmounts so scrolling back doesn't shift lanes.
+  const measuredHeightsRef = useRef<Map<string, number>>(new Map());
+  const [measureVersion, setMeasureVersion] = useState(0);
+  const handleCardMeasure = useCallback((rowId: string, height: number) => {
+    // 0/negative = not laid out (display:none, jsdom) — keep the estimate.
+    if (height <= 0) return;
+    const map = measuredHeightsRef.current;
+    if (map.get(rowId) === height) return;
+    map.set(rowId, height);
+    setMeasureVersion(version => version + 1);
+  }, []);
+
   // Lane assignments zipped in and sorted ascending by x so per-frame culling
   // can binary-search the visible slice instead of scanning every item. Lane
   // semantics (packing order, one-per-row row order) are unaffected — lanes
@@ -428,6 +482,44 @@ export function DataViewTimeline<TData>({
     list.sort((a, b) => a.x - b.x);
     return list;
   }, [positioned, lanes]);
+
+  // Drop measurements for rows that left the data set so a shrunk lane
+  // doesn't stay sized to a card that no longer exists.
+  useEffect(() => {
+    const ids = new Set(cards.map(item => item.row.id));
+    const map = measuredHeightsRef.current;
+    let changed = false;
+    for (const key of map.keys()) {
+      if (!ids.has(key)) {
+        map.delete(key);
+        changed = true;
+      }
+    }
+    if (changed) setMeasureVersion(version => version + 1);
+  }, [cards]);
+
+  // Vertical geometry. Each lane is as tall as its tallest card — measured
+  // height when known, `estimatedRowHeight` until then — so lane tops are
+  // cumulative rather than a fixed pitch.
+  const { laneTops, canvasHeight } = useMemo(() => {
+    // Reads measuredHeightsRef; measureVersion invalidates on new reports.
+    void measureVersion;
+    const measured = measuredHeightsRef.current;
+    const heights = new Array<number>(Math.max(laneCount, 1)).fill(0);
+    for (const item of cards) {
+      const height = measured.get(item.row.id) ?? estimatedRowHeight;
+      if (height > heights[item.lane]) heights[item.lane] = height;
+    }
+    const tops = new Array<number>(heights.length);
+    let y = laneGap;
+    for (let i = 0; i < heights.length; i++) {
+      // A lane with no cards (empty data) still reserves the estimate.
+      if (heights[i] === 0) heights[i] = estimatedRowHeight;
+      tops[i] = y;
+      y += heights[i] + laneGap;
+    }
+    return { laneTops: tops, canvasHeight: y };
+  }, [cards, laneCount, estimatedRowHeight, laneGap, measureVersion]);
 
   // Widens the culling window's left bound: a card is visible when
   // `x + width >= min`, and width isn't sorted — only x is.
@@ -631,7 +723,7 @@ export function DataViewTimeline<TData>({
       // Panning, not selecting — suppress native text-selection drag.
       event.preventDefault();
     },
-    []
+    [stopMomentum]
   );
 
   const handleDragPointerMove = useCallback(
@@ -721,9 +813,16 @@ export function DataViewTimeline<TData>({
     return () => observer.disconnect();
   }, [needsViewport, isActive, readViewport]);
 
-  // Deduped by ms values — `timeScale`/`viewport` identity churn (a resize, a
-  // domain rebuild from streamed-in rows) must not re-fire consumers with an
-  // unchanged window; each fire typically triggers a fetch check.
+  // Deduped within one pixel of time — `timeScale`/`viewport` identity churn
+  // (a resize, a domain rebuild from streamed-in rows) must not re-fire
+  // consumers with an unchanged window; each fire typically triggers a fetch
+  // check. Exact equality is too strict for "unchanged": the px→time→px
+  // round-trip of scroll anchoring isn't bit-exact in floats, and browsers
+  // quantize an anchored scrollLeft to device pixels — either can drift the
+  // recomputed edges without the window visibly moving. Anything under one
+  // pixel's worth of time is that noise, not a scroll (the baseline is the
+  // last *notified* window, so slow sub-pixel scrolling still accumulates
+  // past the threshold and fires).
   const lastNotifiedRangeRef = useRef<{ from: number; to: number } | null>(
     null
   );
@@ -732,7 +831,14 @@ export function DataViewTimeline<TData>({
     const from = timeScale.timeAt(viewport.left);
     const to = timeScale.timeAt(viewport.left + viewport.width);
     const prev = lastNotifiedRangeRef.current;
-    if (prev && prev.from === from && prev.to === to) return;
+    const pxOfTime = 1 / timeScale.pxPerMs;
+    if (
+      prev &&
+      Math.abs(prev.from - from) < pxOfTime &&
+      Math.abs(prev.to - to) < pxOfTime
+    ) {
+      return;
+    }
     lastNotifiedRangeRef.current = { from, to };
     onVisibleRangeChange([new Date(from), new Date(to)]);
   }, [onVisibleRangeChange, viewport, timeScale]);
@@ -769,8 +875,10 @@ export function DataViewTimeline<TData>({
       stopMomentum();
       const clamped = Math.max(timeScale.t0, Math.min(time, timeScale.t1));
       let targetX = timeScale.x(clamped);
-      if (align === 'center') targetX -= el.clientWidth / 2;
-      else if (align === 'end') targetX -= el.clientWidth;
+      if (align === 'start') targetX -= SCROLL_EDGE_INSET_PX;
+      else if (align === 'center') targetX -= el.clientWidth / 2;
+      else if (align === 'end')
+        targetX -= el.clientWidth - SCROLL_EDGE_INSET_PX;
       const left = Math.max(
         0,
         Math.min(targetX, timeScale.totalWidth - el.clientWidth)
@@ -787,6 +895,34 @@ export function DataViewTimeline<TData>({
     },
     [timeScale, stopMomentum]
   );
+
+  // Filter/search-driven auto-scroll (`scrollToResults`). Applying a filter
+  // while scrolled away from the matches would leave the user parked on empty
+  // canvas — when the query changes and no matching card intersects the
+  // viewport, bring the earliest match into view. A query change that keeps a
+  // card on screen doesn't move the view. Compared by value: `tableQuery`
+  // identity churns on unrelated updates (sort, grouping); the ref seeds with
+  // the mount-time key so the initial position stays `defaultScrollTo`'s job.
+  const queryKey = JSON.stringify({
+    filters: tableQuery?.filters ?? null,
+    search: tableQuery?.search ?? null
+  });
+  const lastQueryKeyRef = useRef(queryKey);
+  useEffect(() => {
+    if (queryKey === lastQueryKeyRef.current) return;
+    lastQueryKeyRef.current = queryKey;
+    if (!scrollToResults) return;
+    const el = scrollRef.current;
+    if (!el || cards.length === 0) return;
+    const left = el.scrollLeft;
+    const right = left + el.clientWidth;
+    const anyInView = cards.some(
+      item => item.x <= right && item.x + item.packWidth >= left
+    );
+    if (anyInView) return;
+    // `cards` is sorted ascending by x, so [0] is the earliest match.
+    scrollToTime(cards[0].startTime, 'start', 'smooth');
+  }, [queryKey, scrollToResults, cards, scrollToTime]);
 
   useImperativeHandle(
     actionsRef,
@@ -893,9 +1029,6 @@ export function DataViewTimeline<TData>({
   // `<DataView.EmptyState>` / `<DataView.ZeroState>` handle messaging.
   if (!hasData) return null;
 
-  const lanePitch = estimatedRowHeight + laneGap;
-  const canvasHeight = Math.max(laneCount, 1) * lanePitch + laneGap;
-
   // Horizontal culling window — one extra viewport on each side as overscan.
   const overscan = viewport ? Math.max(viewport.width, 400) : 0;
   const cullRange =
@@ -930,6 +1063,12 @@ export function DataViewTimeline<TData>({
   return (
     <div
       ref={scrollRef}
+      // Keyboard access to the pan surface: focusable so arrow/page keys
+      // scroll natively (drag-to-pan is pointer-only), and a labelled region
+      // so screen readers announce what the scrollable area is.
+      role='region'
+      aria-label={ariaLabel ?? 'Timeline'}
+      tabIndex={0}
       className={cx(styles.timelineRoot, classNames.root)}
       data-dragging={isDragging || undefined}
       onScroll={handleScroll}
@@ -1034,8 +1173,7 @@ export function DataViewTimeline<TData>({
               key={item.row.id}
               row={item.row}
               x={item.x}
-              top={laneGap + item.lane * lanePitch}
-              height={estimatedRowHeight}
+              top={laneTops[item.lane]}
               renderWidth={item.renderWidth}
               spanWidth={item.spanWidth}
               collapsed={item.endTime !== null && item.spanWidth < minCardWidth}
@@ -1043,6 +1181,7 @@ export function DataViewTimeline<TData>({
               startTime={item.startTime}
               endTime={item.endTime}
               renderCard={renderCard}
+              onMeasure={handleCardMeasure}
               onRowClick={onRowClick}
               className={cardClassName}
             />

--- a/packages/raystack/components/data-view/components/timeline.tsx
+++ b/packages/raystack/components/data-view/components/timeline.tsx
@@ -20,6 +20,7 @@ import { Badge } from '../../badge';
 import styles from '../data-view.module.css';
 import {
   DataViewTimelineProps,
+  GroupedData,
   TimelineActions,
   TimelineCardContext,
   TimelineScale
@@ -38,6 +39,16 @@ import { FilterSummary } from './clear-filters';
 
 const DEFAULT_ROW_HEIGHT = 66;
 const DEFAULT_LANE_GAP = 16;
+/**
+ * Height (px) of a group section's header band: `DataView.List`'s group header
+ * box exactly — `--rs-space-3` padding above and below a small `Badge` (8 + 22
+ * + 8) — so the band reads identically when switching between the two
+ * renderers. Fixed rather than measured because lane tops are derived from it,
+ * so a content-driven height would feed back into the geometry it seeds. (List
+ * only needs its own 36 as a virtualizer estimate, which it corrects by
+ * measuring after paint; the timeline has no such correction pass.)
+ */
+const GROUP_BAND_HEIGHT = 38;
 const DEFAULT_MIN_CARD_WIDTH = 60;
 /** Assumed width of content-sized point cards for lane packing and culling. */
 const DEFAULT_POINT_WIDTH = 120;
@@ -88,6 +99,35 @@ function upperBoundByX(list: readonly { x: number }[], value: number): number {
     else hi = mid;
   }
   return lo;
+}
+
+/** A row with its start/end resolved to timestamps. */
+interface TimedItem<TData> {
+  row: Row<TData>;
+  startTime: number;
+  /** Null when `endField` is omitted (point marker). */
+  endTime: number | null;
+}
+
+/** A timed row placed on the time scale. */
+interface PositionedItem<TData> extends TimedItem<TData> {
+  x: number;
+  spanWidth: number;
+  /** Null for point cards — the wrapper sizes to its content. */
+  renderWidth: number | null;
+  /** Width the lane packer and the culling window assume. */
+  packWidth: number;
+}
+
+/**
+ * One vertical section of the canvas. `group` is the row model's group row
+ * (`groupData` entry) when `group_by` is active, null for the implicit
+ * single section of an ungrouped timeline.
+ */
+interface TimelineSection<TData, TItem> {
+  key: string;
+  group: GroupedData<TData> | null;
+  items: TItem[];
 }
 
 interface TimelineCardViewProps<TData> {
@@ -243,6 +283,7 @@ export function DataViewTimeline<TData>({
   minCardWidth = DEFAULT_MIN_CARD_WIDTH,
   estimatedPointWidth = DEFAULT_POINT_WIDTH,
   virtualized = false,
+  showGroupHeaders = true,
   classNames = {}
 }: DataViewTimelineProps<TData>) {
   const {
@@ -300,42 +341,75 @@ export function DataViewTimeline<TData>({
   const rowModel = table?.getRowModel();
   const { rows = [] } = rowModel || {};
 
-  // Timeline bypasses group headers (RFC §Grouping) — position leaf rows only.
-  const leafRows = useMemo(
-    () => rows.filter(row => !(row.subRows && row.subRows.length > 0)),
-    [rows]
-  );
-
-  // Resolve each row's start/end timestamps. Rows without a valid start are
-  // skipped (dev warning); inverted ranges clamp to zero-length spans.
-  const timedItems = useMemo(() => {
-    const items: {
-      row: Row<TData>;
-      startTime: number;
-      endTime: number | null;
-    }[] = [];
-    let dropped = 0;
-    for (const row of leafRows) {
-      const original = row.original as Record<string, unknown>;
-      const startTime = toTimestamp(original?.[startField]);
-      if (startTime === null) {
-        dropped++;
+  // Sections walked out of the row model exactly as `DataView.List` reads it: a
+  // row with `subRows` is a group header (its `original` is the `groupData`
+  // entry), the leaf rows after it are that group's rows. Section order,
+  // labels, and counts therefore match List for free — in client *and* server
+  // mode, since the root groups unconditionally. Ungrouped data has no group
+  // rows, so the walk yields one implicit section with no band and the
+  // geometry below degenerates to the flat single-section layout.
+  const sections = useMemo(() => {
+    const list: TimelineSection<TData, Row<TData>>[] = [];
+    for (const row of rows) {
+      if (row.subRows && row.subRows.length > 0) {
+        list.push({
+          key: row.id,
+          group: row.original as GroupedData<TData>,
+          items: []
+        });
         continue;
       }
-      let endTime: number | null = null;
-      if (endField) {
-        endTime = toTimestamp(original?.[endField]);
-        if (endTime !== null && endTime < startTime) endTime = startTime;
+      let current = list[list.length - 1];
+      if (!current) {
+        current = { key: '__ungrouped', group: null, items: [] };
+        list.push(current);
       }
-      items.push({ row, startTime, endTime });
+      current.items.push(row);
     }
+    return list;
+  }, [rows]);
+
+  // Resolve each row's start/end timestamps, per section. Rows without a valid
+  // start are skipped (one dev warning for the whole model); inverted ranges
+  // clamp to zero-length spans.
+  const timedSections = useMemo(() => {
+    let dropped = 0;
+    const list = sections.map(section => {
+      const items: TimedItem<TData>[] = [];
+      for (const row of section.items) {
+        const original = row.original as Record<string, unknown>;
+        const startTime = toTimestamp(original?.[startField]);
+        if (startTime === null) {
+          dropped++;
+          continue;
+        }
+        let endTime: number | null = null;
+        if (endField) {
+          endTime = toTimestamp(original?.[endField]);
+          if (endTime !== null && endTime < startTime) endTime = startTime;
+        }
+        items.push({ row, startTime, endTime });
+      }
+      const timed: TimelineSection<TData, TimedItem<TData>> = {
+        key: section.key,
+        group: section.group,
+        items
+      };
+      return timed;
+    });
     if (process.env.NODE_ENV !== 'production' && dropped > 0) {
       console.warn(
         `[DataView.Timeline] Skipped ${dropped} row(s) with a missing or invalid "${startField}" value.`
       );
     }
-    return items;
-  }, [leafRows, startField, endField]);
+    return list;
+  }, [sections, startField, endField]);
+
+  // Flattened for the domain extent — grouping never changes the time domain.
+  const timedItems = useMemo(
+    () => timedSections.flatMap(section => section.items),
+    [timedSections]
+  );
 
   const todayTime = useMemo(() => {
     if (today === false) return null;
@@ -412,47 +486,63 @@ export function DataViewTimeline<TData>({
   // snapping) stays at full `scale`-unit granularity.
   const gridlineEvery = Math.max(1, Math.floor(gridlineInterval));
 
-  // Card geometry. `renderWidth` is null for point markers (no endField) —
-  // the wrapper sizes to its content instead of the time span. Rows entirely
-  // outside the domain are dropped: with an explicit `range`, fetched data
-  // routinely extends past the window (e.g. whole-month API buckets), and
-  // those rows must not render beyond the axis or occupy lanes.
-  const positioned = useMemo(() => {
-    const items: (typeof timedItems)[number][] = [];
-    for (const item of timedItems) {
-      const effectiveEnd = item.endTime ?? item.startTime;
-      if (item.startTime > timeScale.t1 || effectiveEnd < timeScale.t0) {
-        continue;
+  // Card geometry, per section. `renderWidth` is null for point markers (no
+  // endField) — the wrapper sizes to its content instead of the time span. Rows
+  // entirely outside the domain are dropped: with an explicit `range`, fetched
+  // data routinely extends past the window (e.g. whole-month API buckets), and
+  // those rows must not render beyond the axis or occupy lanes. A section left
+  // with no cards is dropped entirely (no band, no empty strip), the same way
+  // the ungrouped timeline silently culls out-of-domain rows.
+  const positionedSections = useMemo(() => {
+    const list: TimelineSection<TData, PositionedItem<TData>>[] = [];
+    for (const section of timedSections) {
+      const items: PositionedItem<TData>[] = [];
+      for (const item of section.items) {
+        const effectiveEnd = item.endTime ?? item.startTime;
+        if (item.startTime > timeScale.t1 || effectiveEnd < timeScale.t0) {
+          continue;
+        }
+        const x = timeScale.x(item.startTime);
+        const spanWidth =
+          item.endTime !== null
+            ? (item.endTime - item.startTime) * timeScale.pxPerMs
+            : 0;
+        const renderWidth =
+          item.endTime !== null ? Math.max(spanWidth, MIN_RENDER_WIDTH) : null;
+        // Point cards (no endField) size to their content, so the packer can't
+        // know their width — `estimatedPointWidth` stands in for lane packing
+        // and culling so wide chips don't overlap within a lane.
+        const packWidth = renderWidth ?? estimatedPointWidth;
+        items.push({ ...item, x, spanWidth, renderWidth, packWidth });
       }
-      items.push(item);
+      if (items.length === 0) continue;
+      list.push({ key: section.key, group: section.group, items });
     }
-    return items.map(item => {
-      const x = timeScale.x(item.startTime);
-      const spanWidth =
-        item.endTime !== null
-          ? (item.endTime - item.startTime) * timeScale.pxPerMs
-          : 0;
-      const renderWidth =
-        item.endTime !== null ? Math.max(spanWidth, MIN_RENDER_WIDTH) : null;
-      // Point cards (no endField) size to their content, so the packer can't
-      // know their width — `estimatedPointWidth` stands in for lane packing
-      // and culling so wide chips don't overlap within a lane.
-      const packWidth = renderWidth ?? estimatedPointWidth;
-      return { ...item, x, spanWidth, renderWidth, packWidth };
-    });
-  }, [timedItems, timeScale, estimatedPointWidth]);
+    return list;
+  }, [timedSections, timeScale, estimatedPointWidth]);
 
-  const { lanes, laneCount } = useMemo(() => {
-    if (lanePacking === 'one-per-row') {
-      return {
-        lanes: positioned.map((_, i) => i),
-        laneCount: positioned.length
-      };
-    }
-    return packLanes(
-      positioned.map(item => ({ x: item.x, width: item.packWidth }))
-    );
-  }, [positioned, lanePacking]);
+  // Lane assignment runs per section, so a card only ever shares a lane with
+  // cards in its own group. Section-relative lanes are what `renderCard` sees
+  // (`context.laneIndex`); `laneOffset` maps them into one global lane list for
+  // the vertical geometry below.
+  const { laidOutSections, laneCount } = useMemo(() => {
+    let offset = 0;
+    const list = positionedSections.map(section => {
+      const packed =
+        lanePacking === 'one-per-row'
+          ? {
+              lanes: section.items.map((_, i) => i),
+              laneCount: section.items.length
+            }
+          : packLanes(
+              section.items.map(item => ({ x: item.x, width: item.packWidth }))
+            );
+      const entry = { ...section, ...packed, laneOffset: offset };
+      offset += packed.laneCount;
+      return entry;
+    });
+    return { laidOutSections: list, laneCount: offset };
+  }, [positionedSections, lanePacking]);
 
   // Measured card heights by row id, `estimatedRowHeight` standing in until a
   // card reports (same estimate-then-measure contract as `DataView.List`).
@@ -470,18 +560,23 @@ export function DataViewTimeline<TData>({
     setMeasureVersion(version => version + 1);
   }, []);
 
-  // Lane assignments zipped in and sorted ascending by x so per-frame culling
-  // can binary-search the visible slice instead of scanning every item. Lane
-  // semantics (packing order, one-per-row row order) are unaffected — lanes
-  // are assigned before the sort. DOM order becomes chronological.
+  // All sections' cards flattened and sorted ascending by x so per-frame
+  // culling can binary-search the visible slice instead of scanning every item.
+  // Lane semantics (packing order, one-per-row row order) are unaffected —
+  // lanes are assigned before the sort. DOM order becomes chronological.
   const cards = useMemo(() => {
-    const list = positioned.map((item, index) => ({
-      ...item,
-      lane: lanes[index]
-    }));
+    const list = laidOutSections.flatMap(section =>
+      section.items.map((item, index) => ({
+        ...item,
+        // Section-relative (renderCard's `context.laneIndex`) …
+        laneIndex: section.lanes[index],
+        // … and global, for the lane-top lookup at render time.
+        lane: section.laneOffset + section.lanes[index]
+      }))
+    );
     list.sort((a, b) => a.x - b.x);
     return list;
-  }, [positioned, lanes]);
+  }, [laidOutSections]);
 
   // Drop measurements for rows that left the data set so a shrunk lane
   // doesn't stay sized to a card that no longer exists.
@@ -500,32 +595,69 @@ export function DataViewTimeline<TData>({
 
   // Vertical geometry. Each lane is as tall as its tallest card — measured
   // height when known, `estimatedRowHeight` until then — so lane tops are
-  // cumulative rather than a fixed pitch.
-  const { laneTops, canvasHeight } = useMemo(() => {
+  // cumulative rather than a fixed pitch. Sections stack: band, then that
+  // section's lanes, then the next section's band. `groupBands` carries each
+  // band's slot (top + full section height) for the sticky pin below.
+  const { laneTops, groupBands, canvasHeight } = useMemo(() => {
     // Reads measuredHeightsRef; measureVersion invalidates on new reports.
     void measureVersion;
     const measured = measuredHeightsRef.current;
-    const heights = new Array<number>(Math.max(laneCount, 1)).fill(0);
+    const heights = new Array<number>(laneCount).fill(0);
     for (const item of cards) {
       const height = measured.get(item.row.id) ?? estimatedRowHeight;
       if (height > heights[item.lane]) heights[item.lane] = height;
     }
-    const tops = new Array<number>(heights.length);
-    let y = laneGap;
-    for (let i = 0; i < heights.length; i++) {
-      // A lane with no cards (empty data) still reserves the estimate.
-      if (heights[i] === 0) heights[i] = estimatedRowHeight;
-      tops[i] = y;
-      y += heights[i] + laneGap;
+    const tops = new Array<number>(laneCount);
+    const bands: {
+      key: string;
+      group: GroupedData<TData>;
+      top: number;
+      height: number;
+    }[] = [];
+    let y = 0;
+    for (const section of laidOutSections) {
+      const sectionTop = y;
+      const banded = showGroupHeaders && section.group !== null;
+      if (banded) y += GROUP_BAND_HEIGHT;
+      y += laneGap;
+      for (let i = 0; i < section.laneCount; i++) {
+        const lane = section.laneOffset + i;
+        // A lane with no cards (empty data) still reserves the estimate.
+        if (heights[lane] === 0) heights[lane] = estimatedRowHeight;
+        tops[lane] = y;
+        y += heights[lane] + laneGap;
+      }
+      // Slots are contiguous (each spans its whole section, trailing gap
+      // included), so a pinned band is pushed out by the next section's band
+      // exactly as that one arrives at the pin line.
+      if (banded && section.group) {
+        bands.push({
+          key: section.key,
+          group: section.group,
+          top: sectionTop,
+          height: y - sectionTop
+        });
+      }
     }
-    return { laneTops: tops, canvasHeight: y };
-  }, [cards, laneCount, estimatedRowHeight, laneGap, measureVersion]);
+    // Nothing positioned (all rows culled, or loading with no rows yet): keep
+    // reserving one lane's worth of canvas so the pane doesn't collapse.
+    if (laneCount === 0) y = estimatedRowHeight + laneGap * 2;
+    return { laneTops: tops, groupBands: bands, canvasHeight: y };
+  }, [
+    cards,
+    laidOutSections,
+    laneCount,
+    estimatedRowHeight,
+    laneGap,
+    showGroupHeaders,
+    measureVersion
+  ]);
 
   // Widens the culling window's left bound: a card is visible when
   // `x + width >= min`, and width isn't sorted — only x is.
   const maxPackWidth = useMemo(
-    () => positioned.reduce((max, item) => Math.max(max, item.packWidth), 0),
-    [positioned]
+    () => cards.reduce((max, item) => Math.max(max, item.packWidth), 0),
+    [cards]
   );
 
   const resolvedMarkers = useMemo(() => {
@@ -1130,6 +1262,43 @@ export function DataViewTimeline<TData>({
         ) : null}
       </div>
 
+      {/* Group section bands. Kept outside the canvas for two reasons: the
+          canvas is `role="list"` (only cards belong in it), and its
+          `overflow: hidden` would neutralize the sticky positioning below.
+          The layer is absolute inside the scroll container, so it scrolls with
+          the content while each band sticks vertically within its own section
+          slot — pinned under the axis, pushed out by the next section's band. */}
+      {groupBands.length > 0 ? (
+        <div
+          className={styles.timelineGroupLayer}
+          style={{ width: timeScale.totalWidth, height: canvasHeight }}
+        >
+          {groupBands.map(band => (
+            <div
+              key={band.key}
+              className={styles.timelineGroupSlot}
+              style={{ top: band.top, height: band.height }}
+            >
+              <div
+                className={cx(
+                  styles.timelineGroupHeader,
+                  classNames.groupHeader
+                )}
+                style={{ height: GROUP_BAND_HEIGHT }}
+              >
+                {/* Sticky-left so the label stays readable while panning. */}
+                <span className={styles.timelineGroupHeaderLabel}>
+                  {band.group.label}
+                  {band.group.showGroupCount ? (
+                    <Badge variant='neutral'>{band.group.count}</Badge>
+                  ) : null}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
       <div
         role='list'
         className={cx(styles.timelineCanvas, classNames.canvas)}
@@ -1177,7 +1346,7 @@ export function DataViewTimeline<TData>({
               renderWidth={item.renderWidth}
               spanWidth={item.spanWidth}
               collapsed={item.endTime !== null && item.spanWidth < minCardWidth}
-              laneIndex={item.lane}
+              laneIndex={item.laneIndex}
               startTime={item.startTime}
               endTime={item.endTime}
               renderCard={renderCard}

--- a/packages/raystack/components/data-view/data-view.module.css
+++ b/packages/raystack/components/data-view/data-view.module.css
@@ -349,6 +349,7 @@
    sticks to the top on vertical scroll and moves with the canvas on
    horizontal scroll because both share the same explicit content width. */
 .timelineRoot {
+  --timeline-axis-height: 52px;
   position: relative;
   width: 100%;
   height: 100%;
@@ -357,6 +358,15 @@
      (horizontal swipe-back) or scroll the page behind. */
   overscroll-behavior: contain;
   background: var(--rs-color-background-base-primary);
+}
+
+/* Keyboard-focused pane (tabIndex=0 for arrow-key scrolling). Inset ring for
+   the same reason as .listRow: an outward outline would clip against parent
+   overflow. :focus-visible only — a mouse click on the background must not
+   ring the whole pane. */
+.timelineRoot:focus-visible {
+  outline: var(--rs-focus-ring);
+  outline-offset: var(--rs-focus-ring-offset-inset);
 }
 
 /* Drag-to-pan in progress — grabbing cursor everywhere (descendants too, so
@@ -374,7 +384,7 @@
   position: sticky;
   top: 0;
   z-index: 3;
-  height: 52px;
+  height: var(--timeline-axis-height);
   box-sizing: border-box;
   background: var(--rs-color-background-base-primary);
   border-bottom: 0.5px solid var(--rs-color-border-base-primary);
@@ -435,13 +445,13 @@
 }
 
 /* min-height keeps gridlines and marker lines running the full pane height
-   even when there are only a few lanes (52px = axis height). overflow:hidden
-   clips cards whose span crosses the domain edge at that edge, instead of
-   letting them dangle past the axis into unscaled space. */
+   even when there are only a few lanes. overflow:hidden clips cards whose
+   span crosses the domain edge at that edge, instead of letting them dangle
+   past the axis into unscaled space. */
 .timelineCanvas {
   position: relative;
   box-sizing: border-box;
-  min-height: calc(100% - 52px);
+  min-height: calc(100% - var(--timeline-axis-height));
   overflow: hidden;
 }
 
@@ -456,6 +466,10 @@
   pointer-events: none;
 }
 
+/* Gridlines, marker lines, and the cursor line all paint beneath cards (DOM
+   order, no z-index) by design — lines are context, cards are content, and a
+   line crossing a card would read as part of it. The axis badge stays visible
+   even where a card occludes the line. */
 .timelineMarkerLine {
   position: absolute;
   top: 0;

--- a/packages/raystack/components/data-view/data-view.module.css
+++ b/packages/raystack/components/data-view/data-view.module.css
@@ -351,6 +351,8 @@
 .timelineRoot {
   --timeline-axis-height: 52px;
   position: relative;
+  display: flex;
+  flex-direction: column;
   width: 100%;
   height: 100%;
   overflow: auto;
@@ -360,13 +362,16 @@
   background: var(--rs-color-background-base-primary);
 }
 
-/* Keyboard-focused pane (tabIndex=0 for arrow-key scrolling). Inset ring for
-   the same reason as .listRow: an outward outline would clip against parent
-   overflow. :focus-visible only — a mouse click on the background must not
-   ring the whole pane. */
+/* The pane stays focusable (tabIndex=0) so arrow/page keys scroll it — but it
+   never draws a focus ring. A ring around a canvas this large reads as a stray
+   blue line rather than a focus indicator: an inset outline is painted over by
+   the absolutely-positioned cards, leaving broken segments down the left edge
+   and a line along the bottom. `outline: none` rather than just dropping the
+   rule, because Chrome auto-focuses scroll containers that have no focusable
+   children and would otherwise paint its own UA outline. */
+.timelineRoot:focus,
 .timelineRoot:focus-visible {
-  outline: var(--rs-focus-ring);
-  outline-offset: var(--rs-focus-ring-offset-inset);
+  outline: none;
 }
 
 /* Drag-to-pan in progress — grabbing cursor everywhere (descendants too, so
@@ -385,6 +390,9 @@
   top: 0;
   z-index: 3;
   height: var(--timeline-axis-height);
+  /* Never let the flex line squash the axis: the group-band layer is offset by
+     --timeline-axis-height, so a shorter axis would desync the two. */
+  flex-shrink: 0;
   box-sizing: border-box;
   background: var(--rs-color-background-base-primary);
   border-bottom: 0.5px solid var(--rs-color-border-base-primary);
@@ -503,14 +511,16 @@
   white-space: nowrap;
 }
 
-/* min-height keeps gridlines and marker lines running the full pane height
-   even when there are only a few lanes. overflow:hidden clips cards whose
-   span crosses the domain edge at that edge, instead of letting them dangle
-   past the axis into unscaled space. */
+/* `flex: 1 0 auto` — grow into the pane's leftover height so gridlines and
+   marker lines run its full height even with only a few lanes, but never
+   shrink below the explicit lane geometry (that would clip cards). Growth is
+   bounded by the real free space, so a rendered footer is accounted for.
+   overflow:hidden clips cards whose span crosses the domain edge at that edge,
+   instead of letting them dangle past the axis into unscaled space. */
 .timelineCanvas {
   position: relative;
   box-sizing: border-box;
-  min-height: calc(100% - var(--timeline-axis-height));
+  flex: 1 0 auto;
   overflow: hidden;
 }
 
@@ -566,11 +576,13 @@
 }
 
 /* Sticky-left so the filter-summary footer stays aligned to the viewport
-   (not the full canvas width) under horizontal scroll. */
+   (not the full canvas width) under horizontal scroll. Never shrinks — the
+   canvas absorbs the free height instead. */
 .timelineFooter {
   position: sticky;
   left: 0;
   width: 100%;
+  flex-shrink: 0;
 }
 
 /* Empty/zero sibling container */

--- a/packages/raystack/components/data-view/data-view.module.css
+++ b/packages/raystack/components/data-view/data-view.module.css
@@ -444,6 +444,65 @@
   pointer-events: none;
 }
 
+/* Group section bands (`group_by` active). The layer sits between the axis and
+   the canvas in z-order: absolutely positioned inside the scroll container so
+   it pans with the content, spanning the canvas box. `pointer-events: none`
+   keeps drag-to-pan and card clicks working through a pinned band. */
+.timelineGroupLayer {
+  position: absolute;
+  top: var(--timeline-axis-height);
+  left: 0;
+  z-index: 2;
+  pointer-events: none;
+}
+
+/* One slot per section, spanning that section's full height. The band sticks
+   within it, so scrolling past a section slides its band out exactly as the
+   next section's band reaches the pin line — no JS scroll tracking. */
+.timelineGroupSlot {
+  position: absolute;
+  left: 0;
+  width: 100%;
+}
+
+/* Pins directly under the sticky axis while its section is in view. Same
+   treatment as `.listGroupHeader` (background, typography, count Badge) so the
+   band is visually identical across renderers — including no hairline, which
+   List's sticky header also does without. Height comes in inline from
+   GROUP_BAND_HEIGHT: lane tops are derived from it, so the band must not size
+   to its content. */
+.timelineGroupHeader {
+  position: sticky;
+  top: var(--timeline-axis-height);
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  background: var(--rs-color-background-neutral-primary);
+  color: var(--rs-color-foreground-base-primary);
+  font-family: var(--rs-font-body);
+  font-size: var(--rs-font-size-small);
+  font-weight: var(--rs-font-weight-medium);
+  line-height: var(--rs-line-height-small);
+  letter-spacing: var(--rs-letter-spacing-small);
+}
+
+/* Sticks to the viewport's left edge while its band spans the viewport — same
+   trick as the axis month/year band labels. No overflow:hidden on the band or
+   the slot: either would break this.
+
+   The inset matches `.timelineAxisBandLabel` rather than List's 8px group-header
+   padding: the two are the only left-anchored labels in the renderer and sit
+   directly above one another, so a band label at 8px would read as an 8px
+   stagger against the month label. */
+.timelineGroupHeaderLabel {
+  position: sticky;
+  left: var(--rs-space-5);
+  display: flex;
+  align-items: center;
+  gap: var(--rs-space-3);
+  white-space: nowrap;
+}
+
 /* min-height keeps gridlines and marker lines running the full pane height
    even when there are only a few lanes. overflow:hidden clips cards whose
    span crosses the domain edge at that edge, instead of letting them dangle

--- a/packages/raystack/components/data-view/data-view.module.css
+++ b/packages/raystack/components/data-view/data-view.module.css
@@ -344,6 +344,162 @@
   pointer-events: none;
 }
 
+/* Timeline renderer — cards absolutely positioned on a continuous time axis.
+   The root is the single scroll container for both axes; the axis strip
+   sticks to the top on vertical scroll and moves with the canvas on
+   horizontal scroll because both share the same explicit content width. */
+.timelineRoot {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  /* Reaching the domain edge must not chain into browser navigation
+     (horizontal swipe-back) or scroll the page behind. */
+  overscroll-behavior: contain;
+  background: var(--rs-color-background-base-primary);
+}
+
+/* Drag-to-pan in progress — grabbing cursor everywhere (descendants too, so
+   cards' own cursor styles don't flicker mid-drag) and selection locked. */
+.timelineRoot[data-dragging],
+.timelineRoot[data-dragging] * {
+  cursor: grabbing;
+  user-select: none;
+}
+
+/* Two-tier ruler: major bands (month/year) on top, minor tick labels below.
+   Marker badges (today, milestones) are pinned here so they stay visible
+   while the marker line runs down the canvas. */
+.timelineAxis {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  height: 52px;
+  box-sizing: border-box;
+  background: var(--rs-color-background-base-primary);
+  border-bottom: 0.5px solid var(--rs-color-border-base-primary);
+}
+
+.timelineAxisBand {
+  position: absolute;
+  top: var(--rs-space-2);
+  display: flex;
+  box-sizing: border-box;
+  color: var(--rs-color-foreground-base-primary);
+  font-family: var(--rs-font-body);
+  font-size: var(--rs-font-size-mini);
+  font-weight: var(--rs-font-weight-medium);
+  line-height: var(--rs-line-height-mini);
+  letter-spacing: var(--rs-letter-spacing-mini);
+  text-transform: uppercase;
+}
+
+/* Sticks to the viewport's left edge while its band is in view (the nearest
+   scroll container is the timeline root). No overflow:hidden on the band —
+   that would break the sticky behavior. */
+.timelineAxisBandLabel {
+  position: sticky;
+  left: var(--rs-space-5);
+  white-space: nowrap;
+}
+
+.timelineAxisTick {
+  position: absolute;
+  bottom: var(--rs-space-2);
+  transform: translateX(-50%);
+  white-space: nowrap;
+  color: var(--rs-color-foreground-base-tertiary);
+  font-family: var(--rs-font-body);
+  font-size: var(--rs-font-size-mini);
+  font-weight: var(--rs-font-weight-regular);
+  line-height: var(--rs-line-height-mini);
+  letter-spacing: var(--rs-letter-spacing-mini);
+}
+
+.timelineAxisMarker {
+  position: absolute;
+  top: var(--rs-space-2);
+  transform: translateX(-50%);
+  z-index: 1;
+  display: flex;
+}
+
+/* Hover-cursor date badge — above marker badges, never intercepts events. */
+.timelineAxisCursor {
+  position: absolute;
+  top: var(--rs-space-2);
+  transform: translateX(-50%);
+  z-index: 2;
+  display: flex;
+  pointer-events: none;
+}
+
+/* min-height keeps gridlines and marker lines running the full pane height
+   even when there are only a few lanes (52px = axis height). overflow:hidden
+   clips cards whose span crosses the domain edge at that edge, instead of
+   letting them dangle past the axis into unscaled space. */
+.timelineCanvas {
+  position: relative;
+  box-sizing: border-box;
+  min-height: calc(100% - 52px);
+  overflow: hidden;
+}
+
+/* Dashed so the grid recedes; marker/today/cursor lines stay solid so they
+   read as data, not grid. */
+.timelineGridline {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 0;
+  border-left: 0.5px dashed var(--rs-color-border-base-primary);
+  pointer-events: none;
+}
+
+.timelineMarkerLine {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 0;
+  border-left: 0.5px solid var(--rs-color-border-base-tertiary);
+  pointer-events: none;
+}
+
+.timelineMarkerLine[data-variant="accent"] {
+  border-left-color: var(--rs-color-border-accent-emphasis);
+}
+
+.timelineMarkerLine[data-variant="danger"] {
+  border-left-color: var(--rs-color-border-danger-emphasis);
+}
+
+/* Hover crosshair — darker than gridlines so the snapped position reads
+   clearly while tracking the pointer. */
+.timelineCursorLine {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 0;
+  border-left: 0.5px solid var(--rs-color-border-base-focus);
+  pointer-events: none;
+}
+
+/* Positioning wrapper only — visually neutral. The card interior (chrome,
+   states, truncation) is consumer-owned via `renderCard`. */
+.timelineCard {
+  position: absolute;
+  box-sizing: border-box;
+  min-width: 0;
+}
+
+/* Sticky-left so the filter-summary footer stays aligned to the viewport
+   (not the full canvas width) under horizontal scroll. */
+.timelineFooter {
+  position: sticky;
+  left: 0;
+  width: 100%;
+}
+
 /* Empty/zero sibling container */
 .dataStateContainer {
   display: flex;

--- a/packages/raystack/components/data-view/data-view.tsx
+++ b/packages/raystack/components/data-view/data-view.tsx
@@ -19,6 +19,7 @@ import { DataViewEmptyState } from './components/empty-state';
 import { Filters } from './components/filters';
 import { DataViewList } from './components/list';
 import { DataViewSearch } from './components/search';
+import { DataViewTimeline } from './components/timeline';
 import { Toolbar } from './components/toolbar';
 import { DataViewZeroState } from './components/zero-state';
 import { DataViewContext } from './context';
@@ -305,6 +306,7 @@ DataViewRoot.displayName = 'DataView';
 // biome-ignore lint/suspicious/noShadowRestrictedNames: public component name intentionally matches the package export
 export const DataView = Object.assign(DataViewRoot, {
   List: DataViewList,
+  Timeline: DataViewTimeline,
   Custom: DataViewCustom,
   DisplayAccess: DisplayAccess,
   EmptyState: DataViewEmptyState,

--- a/packages/raystack/components/data-view/data-view.types.tsx
+++ b/packages/raystack/components/data-view/data-view.types.tsx
@@ -1,5 +1,6 @@
 import type {
   ColumnDef,
+  Row,
   Table,
   Updater,
   VisibilityState
@@ -200,6 +201,160 @@ export interface DataViewListProps<TData, TValue = unknown> {
   /** When true, group headers stick under the table header while scrolling. Default false. */
   stickyGroupHeader?: boolean;
   classNames?: DataViewListClassNames;
+}
+
+/** Date inputs accepted by Timeline props and row fields: Date, epoch ms, or a parseable string. */
+export type TimelineDateInput = Date | number | string;
+
+/** Tick granularity of the Timeline axis. */
+export type TimelineScale = 'day' | 'week' | 'month' | 'quarter';
+
+/** Full-height marker line with a badge pinned to the axis (milestones, deadlines). */
+export interface TimelineMarker {
+  date: TimelineDateInput;
+  /** Badge content. Defaults to the marker date formatted as "17 Jan". */
+  label?: React.ReactNode;
+  variant?: 'default' | 'accent' | 'danger';
+}
+
+/**
+ * Geometry + state handed to `renderCard`. The Timeline owns positioning; the
+ * consumer owns the card visual and uses this context to adapt it (e.g. render
+ * a compact stub when `collapsed`).
+ */
+export interface TimelineCardContext {
+  /** Pixel width of the time span (0 when `endField` is omitted). */
+  width: number;
+  /** True when the span is narrower than `minCardWidth`. */
+  collapsed: boolean;
+  laneIndex: number;
+  start: Date;
+  /** Null when `endField` is omitted (point marker). */
+  end: Date | null;
+}
+
+/**
+ * Imperative navigation surface exposed through `actionsRef` on
+ * `DataView.Timeline` (same pattern as Tour's `actionsRef`). Available for the
+ * lifetime of the component; methods no-op (with a dev warning) while the
+ * renderer is hidden — inactive view or no data.
+ */
+export interface TimelineActions {
+  /**
+   * Scroll the viewport so `target` lands at `align` (default `'center'`).
+   * Accepts the `defaultScrollTo` vocabulary: a date input, `'today'`,
+   * `'start'`, or `'end'` (domain edges). Dates outside the domain clamp to
+   * the nearest edge; invalid dates no-op with a dev warning.
+   */
+  scrollTo: (
+    target: TimelineDateInput | 'today' | 'start' | 'end',
+    options?: {
+      align?: 'start' | 'center' | 'end';
+      /** Default `'smooth'` — a navigation action should visibly travel. */
+      behavior?: 'auto' | 'smooth';
+    }
+  ) => void;
+  /** The visible time window, or null while the renderer is hidden. */
+  getVisibleRange: () => [Date, Date] | null;
+}
+
+export type DataViewTimelineClassNames = {
+  root?: string;
+  axis?: string;
+  band?: string;
+  tick?: string;
+  marker?: string;
+  gridline?: string;
+  cursor?: string;
+  canvas?: string;
+  card?: string;
+};
+
+export interface DataViewTimelineProps<TData> {
+  /** Multi-view name. When set, the renderer gates itself on the active view. */
+  name?: string;
+  /** Optional view-scoped field override. Full replacement of root `fields` for this view's active session. */
+  fields?: DataViewField<TData>[];
+
+  /** Accessor key on the row yielding the start date. Rows with a missing/invalid value are skipped. */
+  startField: string;
+  /** Accessor key for the end date. Omitted → point markers; present → variable-width span cards. */
+  endField?: string;
+
+  /**
+   * Renders the card interior. The Timeline owns positioning (x from start,
+   * width from span, lane from packing, scroll); the consumer owns the card
+   * visual entirely — chrome, states, truncation, and the collapsed variant.
+   * Compose `<DataView.DisplayAccess>` inside for Display Properties support.
+   */
+  renderCard: (
+    row: Row<TData>,
+    context: TimelineCardContext
+  ) => React.ReactNode;
+
+  /** Tick granularity of the time axis. Default 'day'. */
+  scale?: TimelineScale;
+  /** Pixel width of one `scale` unit — density/zoom override. */
+  unitWidth?: number;
+  /**
+   * Explicit time domain. Defaults to the data extent (plus today when shown)
+   * with padding. Either way, a domain narrower than the container is extended
+   * at the end so the axis and gridlines always fill the visible width.
+   */
+  range?: [TimelineDateInput, TimelineDateInput];
+  /** Vertical "today" line + axis badge. `true` (default) uses the current date; a date pins it. */
+  today?: boolean | TimelineDateInput;
+  /** Additional full-height marker lines with axis badges. */
+  markers?: TimelineMarker[];
+  /** Vertical gridlines at every axis tick. Default true. */
+  showGridlines?: boolean;
+  /**
+   * Label every Nth `scale` unit on the axis, counted from the domain start
+   * (e.g. `2` on a day scale labels every other day). Labels never render
+   * closer than the collision floor, so a too-dense value degrades gracefully.
+   * Default: the densest interval whose labels fit.
+   */
+  tickInterval?: number;
+  /**
+   * Draw a gridline every Nth `scale` unit, counted from the domain start.
+   * Independent of `tickInterval` and purely visual — cards, the today line,
+   * and the hover cursor still land on every unit. Default 1.
+   */
+  gridlineInterval?: number;
+  /**
+   * Hover crosshair: a darker line snapped to the sub-interval (tick unit)
+   * under the pointer, with a date badge pinned to the axis. Default true.
+   */
+  showCursorLine?: boolean;
+  /** Initial horizontal scroll target. Default 'today'. */
+  defaultScrollTo?: TimelineDateInput | 'today' | 'start' | 'end';
+  /** Fires (rAF-throttled) with the visible time range as the user scrolls or resizes. */
+  onVisibleRangeChange?: (range: [Date, Date]) => void;
+  /** Receives the imperative navigation handle (`scrollTo`, `getVisibleRange`). */
+  actionsRef?: React.RefObject<TimelineActions | null>;
+
+  /**
+   * 'auto' (default) packs non-overlapping cards into shared lanes (greedy
+   * interval scheduling); 'one-per-row' gives every row its own lane.
+   */
+  lanePacking?: 'auto' | 'one-per-row';
+  /** Card height in px (cards render at exactly this height; named to match `DataView.List`). Default 66. */
+  estimatedRowHeight?: number;
+  /** Vertical gap between lanes in px. Default 16. */
+  laneGap?: number;
+  /** Spans narrower than this (px) flip `context.collapsed` for `renderCard`. Default 60. */
+  minCardWidth?: number;
+  /**
+   * Assumed width (px) of point-marker cards (rows without `endField`) for
+   * lane packing. Point cards size to their content, so the packer can't know
+   * their width — set this to roughly the widest point card to prevent
+   * horizontal overlap within a lane. Default 120.
+   */
+  estimatedPointWidth?: number;
+
+  /** When true, only cards/gridlines near the visible viewport are rendered (horizontal culling). */
+  virtualized?: boolean;
+  classNames?: DataViewTimelineClassNames;
 }
 
 export type TableQueryUpdateFn = (query: InternalQuery) => InternalQuery;

--- a/packages/raystack/components/data-view/data-view.types.tsx
+++ b/packages/raystack/components/data-view/data-view.types.tsx
@@ -225,7 +225,10 @@ export interface TimelineMarker {
 export interface TimelineCardContext {
   /** Pixel width of the time span (0 when `endField` is omitted). */
   width: number;
-  /** True when the span is narrower than `minCardWidth`. */
+  /**
+   * True when the span is narrower than `minCardWidth`. Always false for
+   * point cards (no `endField`) — they size to their content instead.
+   */
   collapsed: boolean;
   laneIndex: number;
   start: Date;
@@ -244,7 +247,9 @@ export interface TimelineActions {
    * Scroll the viewport so `target` lands at `align` (default `'center'`).
    * Accepts the `defaultScrollTo` vocabulary: a date input, `'today'`,
    * `'start'`, or `'end'` (domain edges). Dates outside the domain clamp to
-   * the nearest edge; invalid dates no-op with a dev warning.
+   * the nearest edge; invalid dates no-op with a dev warning. Edge
+   * alignments keep a small inset so the target doesn't sit flush against
+   * the viewport edge (yields at the domain edges).
    */
   scrollTo: (
     target: TimelineDateInput | 'today' | 'start' | 'end',
@@ -273,6 +278,12 @@ export type DataViewTimelineClassNames = {
 export interface DataViewTimelineProps<TData> {
   /** Multi-view name. When set, the renderer gates itself on the active view. */
   name?: string;
+  /**
+   * Accessible name of the scroll region. The pane is keyboard-focusable
+   * (arrow keys scroll it natively), so screen readers announce this label on
+   * focus. Default 'Timeline'.
+   */
+  'aria-label'?: string;
   /** Optional view-scoped field override. Full replacement of root `fields` for this view's active session. */
   fields?: DataViewField<TData>[];
 
@@ -286,6 +297,11 @@ export interface DataViewTimelineProps<TData> {
    * width from span, lane from packing, scroll); the consumer owns the card
    * visual entirely — chrome, states, truncation, and the collapsed variant.
    * Compose `<DataView.DisplayAccess>` inside for Display Properties support.
+   *
+   * Keep the reference stable (define outside the component or wrap in
+   * `useCallback`) — cards are memoized against it, and an inline function
+   * defeats the memo so every visible card re-renders on each scroll frame.
+   * The same applies to `onRowClick` on the `DataView` root.
    */
   renderCard: (
     row: Row<TData>,
@@ -328,6 +344,14 @@ export interface DataViewTimelineProps<TData> {
   showCursorLine?: boolean;
   /** Initial horizontal scroll target. Default 'today'. */
   defaultScrollTo?: TimelineDateInput | 'today' | 'start' | 'end';
+  /**
+   * After a filter or search change, scroll the earliest matching card into
+   * view when no match intersects the current viewport — otherwise a filter
+   * whose results are off-screen leaves the user parked on empty canvas. A
+   * query change that keeps at least one card on screen doesn't move the
+   * view. Default true.
+   */
+  scrollToResults?: boolean;
   /** Fires (rAF-throttled) with the visible time range as the user scrolls or resizes. */
   onVisibleRangeChange?: (range: [Date, Date]) => void;
   /** Receives the imperative navigation handle (`scrollTo`, `getVisibleRange`). */
@@ -338,7 +362,12 @@ export interface DataViewTimelineProps<TData> {
    * interval scheduling); 'one-per-row' gives every row its own lane.
    */
   lanePacking?: 'auto' | 'one-per-row';
-  /** Card height in px (cards render at exactly this height; named to match `DataView.List`). Default 66. */
+  /**
+   * Estimated card height in px, same contract as `DataView.List`: cards
+   * render at their natural content height and are measured after paint; the
+   * estimate only seeds lane layout until real heights arrive. Each lane
+   * sizes to its tallest card. Default 66.
+   */
   estimatedRowHeight?: number;
   /** Vertical gap between lanes in px. Default 16. */
   laneGap?: number;

--- a/packages/raystack/components/data-view/data-view.types.tsx
+++ b/packages/raystack/components/data-view/data-view.types.tsx
@@ -230,6 +230,10 @@ export interface TimelineCardContext {
    * point cards (no `endField`) — they size to their content instead.
    */
   collapsed: boolean;
+  /**
+   * Lane (row) index assigned by packing. Relative to the card's own group
+   * section when `group_by` is active — every section's first lane is 0.
+   */
   laneIndex: number;
   start: Date;
   /** Null when `endField` is omitted (point marker). */
@@ -273,6 +277,8 @@ export type DataViewTimelineClassNames = {
   cursor?: string;
   canvas?: string;
   card?: string;
+  /** Group section header band (same name/role as `DataViewListClassNames.groupHeader`). */
+  groupHeader?: string;
 };
 
 export interface DataViewTimelineProps<TData> {
@@ -359,7 +365,9 @@ export interface DataViewTimelineProps<TData> {
 
   /**
    * 'auto' (default) packs non-overlapping cards into shared lanes (greedy
-   * interval scheduling); 'one-per-row' gives every row its own lane.
+   * interval scheduling); 'one-per-row' gives every row its own lane, in
+   * row-model (sorted) order. Both apply per group section when `group_by` is
+   * active — cards never share a lane across sections.
    */
   lanePacking?: 'auto' | 'one-per-row';
   /**
@@ -383,6 +391,13 @@ export interface DataViewTimelineProps<TData> {
 
   /** When true, only cards/gridlines near the visible viewport are rendered (horizontal culling). */
   virtualized?: boolean;
+
+  /**
+   * Render the group header band above each section when `group_by` is active.
+   * Same contract as `DataViewListProps.showGroupHeaders`: false hides the
+   * bands only — rows stay grouped into their sections. Default true.
+   */
+  showGroupHeaders?: boolean;
   classNames?: DataViewTimelineClassNames;
 }
 

--- a/packages/raystack/components/data-view/index.ts
+++ b/packages/raystack/components/data-view/index.ts
@@ -20,10 +20,17 @@ export type {
   DataViewProps,
   DataViewQuery,
   DataViewSort,
+  DataViewTimelineClassNames,
+  DataViewTimelineProps,
   GroupByResolver,
   InternalFilter,
   InternalQuery,
   SortOrdersValues,
+  TimelineActions,
+  TimelineCardContext,
+  TimelineDateInput,
+  TimelineMarker,
+  TimelineScale,
   ViewSpec
 } from './data-view.types';
 export { defaultGroupOption } from './data-view.types';

--- a/packages/raystack/components/data-view/utils/pack-lanes.tsx
+++ b/packages/raystack/components/data-view/utils/pack-lanes.tsx
@@ -1,0 +1,43 @@
+export interface PackLaneItem {
+  /** Left edge in px (time-scale space). */
+  x: number;
+  /** Rendered width in px. */
+  width: number;
+}
+
+export interface PackLanesResult {
+  /** Lane index per input item, in the input's original order. */
+  lanes: number[];
+  laneCount: number;
+}
+
+const DEFAULT_LANE_GAP_PX = 8;
+
+/**
+ * Greedy interval scheduling. Items are visited in ascending `x` order and
+ * each is dropped into the first lane whose last occupant ends at least
+ * `gapPx` before the item starts; a new lane is opened when none fits.
+ * Produces the dense "packed" layout of the timeline design — many
+ * non-overlapping cards share a lane.
+ */
+export function packLanes(
+  items: PackLaneItem[],
+  gapPx: number = DEFAULT_LANE_GAP_PX
+): PackLanesResult {
+  const order = items
+    .map((_, i) => i)
+    .sort((a, b) => items[a].x - items[b].x || a - b);
+  const laneEnds: number[] = [];
+  const lanes = new Array<number>(items.length).fill(0);
+  for (const index of order) {
+    const item = items[index];
+    let lane = laneEnds.findIndex(end => end + gapPx <= item.x);
+    if (lane === -1) {
+      lane = laneEnds.length;
+      laneEnds.push(0);
+    }
+    laneEnds[lane] = item.x + item.width;
+    lanes[index] = lane;
+  }
+  return { lanes, laneCount: laneEnds.length };
+}

--- a/packages/raystack/components/data-view/utils/pack-lanes.tsx
+++ b/packages/raystack/components/data-view/utils/pack-lanes.tsx
@@ -11,7 +11,11 @@ export interface PackLanesResult {
   laneCount: number;
 }
 
-const DEFAULT_LANE_GAP_PX = 8;
+/**
+ * Horizontal gap between cards sharing a lane. Not the vertical gap between
+ * lanes — that's the `laneGap` prop (default 16) applied in timeline.tsx.
+ */
+const DEFAULT_CARD_GAP_PX = 8;
 
 /**
  * Greedy interval scheduling. Items are visited in ascending `x` order and
@@ -22,7 +26,7 @@ const DEFAULT_LANE_GAP_PX = 8;
  */
 export function packLanes(
   items: PackLaneItem[],
-  gapPx: number = DEFAULT_LANE_GAP_PX
+  gapPx: number = DEFAULT_CARD_GAP_PX
 ): PackLanesResult {
   const order = items
     .map((_, i) => i)

--- a/packages/raystack/components/data-view/utils/time-scale.tsx
+++ b/packages/raystack/components/data-view/utils/time-scale.tsx
@@ -1,0 +1,220 @@
+import dayjs, { type Dayjs } from 'dayjs';
+
+import type { TimelineScale } from '../data-view.types';
+
+/**
+ * Average unit durations in ms. Used only to derive px density (px/ms) from
+ * `unitWidth`; card and tick positions always use real timestamps, so
+ * variable-length months don't distort placement.
+ */
+export const TIMELINE_UNIT_MS: Record<TimelineScale, number> = {
+  day: 86_400_000,
+  week: 7 * 86_400_000,
+  month: 30.44 * 86_400_000,
+  quarter: 3 * 30.44 * 86_400_000
+};
+
+/** Default px width of one `scale` unit when `unitWidth` is not provided. */
+export const TIMELINE_DEFAULT_UNIT_WIDTH: Record<TimelineScale, number> = {
+  day: 20,
+  week: 56,
+  month: 96,
+  quarter: 140
+};
+
+/** Minimum px between rendered tick labels — denser ticks skip labels. */
+const TICK_LABEL_MIN_SPACE = 28;
+
+/** Coerce a consumer-provided date (Date | epoch ms | parseable string) to ms. */
+export function toTimestamp(value: unknown): number | null {
+  if (value == null) return null;
+  if (value instanceof Date) {
+    const time = value.getTime();
+    return Number.isNaN(time) ? null : time;
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === 'string') {
+    const parsed = dayjs(value);
+    return parsed.isValid() ? parsed.valueOf() : null;
+  }
+  return null;
+}
+
+/** `startOf` that also understands quarters without a dayjs plugin. */
+export function startOfUnit(date: Dayjs, scale: TimelineScale): Dayjs {
+  if (scale === 'quarter') {
+    return date.startOf('month').subtract(date.month() % 3, 'month');
+  }
+  return date.startOf(scale);
+}
+
+export function addUnits(date: Dayjs, scale: TimelineScale, n: number): Dayjs {
+  if (scale === 'quarter') return date.add(3 * n, 'month');
+  return date.add(n, scale);
+}
+
+export interface TimelineTimeScale {
+  /** Domain start (ms), snapped to a unit boundary. */
+  t0: number;
+  /** Domain end (ms), snapped to a unit boundary. */
+  t1: number;
+  pxPerMs: number;
+  totalWidth: number;
+  /** Time (ms) → x offset (px) from the canvas left edge. */
+  x: (time: number) => number;
+  /** Inverse of `x` — px offset → time (ms). */
+  timeAt: (px: number) => number;
+}
+
+export function createTimeScale(params: {
+  minTime: number;
+  maxTime: number;
+  scale: TimelineScale;
+  unitWidth: number;
+  /** Whole units of padding added on each side of the extent. */
+  padUnits?: number;
+  /**
+   * Minimum rendered width (px). The domain end extends by whole units until
+   * `totalWidth` reaches it; a domain already wider is left untouched. Lets
+   * the timeline fill its container when the data span is narrower.
+   */
+  minWidth?: number;
+}): TimelineTimeScale {
+  const {
+    minTime,
+    maxTime,
+    scale,
+    unitWidth,
+    padUnits = 0,
+    minWidth = 0
+  } = params;
+  const pxPerMs = unitWidth / TIMELINE_UNIT_MS[scale];
+  const t0 = addUnits(
+    startOfUnit(dayjs(Math.min(minTime, maxTime)), scale),
+    scale,
+    -padUnits
+  ).valueOf();
+  // +1 so the max instant's unit is fully inside the domain.
+  let end = addUnits(
+    startOfUnit(dayjs(Math.max(minTime, maxTime)), scale),
+    scale,
+    padUnits + 1
+  );
+  // Viewport fill: bulk-add the estimated deficit in one step, then correct
+  // for calendar drift (short months, DST days) — at most a few iterations.
+  const deficitPx = minWidth - (end.valueOf() - t0) * pxPerMs;
+  if (deficitPx > 0) {
+    end = addUnits(end, scale, Math.ceil(deficitPx / unitWidth));
+    while ((end.valueOf() - t0) * pxPerMs < minWidth) {
+      end = addUnits(end, scale, 1);
+    }
+  }
+  const t1 = end.valueOf();
+  return {
+    t0,
+    t1,
+    pxPerMs,
+    totalWidth: (t1 - t0) * pxPerMs,
+    x: time => (time - t0) * pxPerMs,
+    timeAt: px => t0 + px / pxPerMs
+  };
+}
+
+export interface TimelineTick {
+  time: number;
+  x: number;
+  label: string;
+  /** False when labels are thinned out at dense zoom levels. */
+  showLabel: boolean;
+  /** Sequential unit index from the domain start — drives interval thinning. */
+  index: number;
+}
+
+export interface TimelineBand {
+  time: number;
+  x: number;
+  width: number;
+  label: string;
+}
+
+function tickLabel(date: Dayjs, scale: TimelineScale): string {
+  switch (scale) {
+    case 'day':
+    case 'week':
+      return date.format('D');
+    case 'month':
+      return date.format('MMM');
+    case 'quarter':
+      return `Q${Math.floor(date.month() / 3) + 1}`;
+  }
+}
+
+/**
+ * Generates the two-tier axis: minor ticks at `scale` granularity and major
+ * bands one level up (months over day/week ticks, years over month/quarter
+ * ticks). The first band — and any band starting a new year — carries the
+ * year in its label ("Jan 2025", then "Feb").
+ *
+ * `labelEvery` labels every Nth unit, counted from the domain start. The
+ * collision floor (labels never closer than `TICK_LABEL_MIN_SPACE`) still
+ * applies, so a too-dense request degrades instead of overlapping.
+ */
+export function buildAxis(
+  timeScale: TimelineTimeScale,
+  scale: TimelineScale,
+  unitWidth: number,
+  labelEvery?: number
+): { ticks: TimelineTick[]; bands: TimelineBand[] } {
+  const autoLabelEvery = Math.max(
+    1,
+    Math.ceil(TICK_LABEL_MIN_SPACE / unitWidth)
+  );
+  const effectiveLabelEvery = Math.max(
+    autoLabelEvery,
+    Math.floor(labelEvery ?? 1)
+  );
+
+  const ticks: TimelineTick[] = [];
+  let cursor = startOfUnit(dayjs(timeScale.t0), scale);
+  if (cursor.valueOf() < timeScale.t0) cursor = addUnits(cursor, scale, 1);
+  let index = 0;
+  while (cursor.valueOf() <= timeScale.t1) {
+    ticks.push({
+      time: cursor.valueOf(),
+      x: timeScale.x(cursor.valueOf()),
+      label: tickLabel(cursor, scale),
+      showLabel: index % effectiveLabelEvery === 0,
+      index
+    });
+    cursor = addUnits(cursor, scale, 1);
+    index++;
+  }
+
+  const bands: TimelineBand[] = [];
+  const bandUnit = scale === 'day' || scale === 'week' ? 'month' : 'year';
+  let band = dayjs(timeScale.t0).startOf(bandUnit);
+  let isFirst = true;
+  while (band.valueOf() < timeScale.t1) {
+    const next = band.add(1, bandUnit);
+    const from = Math.max(band.valueOf(), timeScale.t0);
+    const to = Math.min(next.valueOf(), timeScale.t1);
+    const label =
+      bandUnit === 'month'
+        ? isFirst || band.month() === 0
+          ? band.format('MMM YYYY')
+          : band.format('MMM')
+        : band.format('YYYY');
+    bands.push({
+      time: band.valueOf(),
+      x: timeScale.x(from),
+      width: (to - from) * timeScale.pxPerMs,
+      label
+    });
+    isFirst = false;
+    band = next;
+  }
+
+  return { ticks, bands };
+}

--- a/packages/raystack/components/data-view/utils/time-scale.tsx
+++ b/packages/raystack/components/data-view/utils/time-scale.tsx
@@ -82,14 +82,12 @@ export function createTimeScale(params: {
    */
   minWidth?: number;
 }): TimelineTimeScale {
-  const {
-    minTime,
-    maxTime,
-    scale,
-    unitWidth,
-    padUnits = 0,
-    minWidth = 0
-  } = params;
+  const { minTime, maxTime, scale, padUnits = 0, minWidth = 0 } = params;
+  // Guard: `unitWidth` is consumer-controlled. Zero would make `pxPerMs` 0
+  // (NaN geometry via the Infinity bulk-add below) and a negative value
+  // inverts the scale so the viewport-fill loop never terminates. Clamp to a
+  // 1px floor instead of hanging the render on a bad prop.
+  const unitWidth = Math.max(1, params.unitWidth);
   const pxPerMs = unitWidth / TIMELINE_UNIT_MS[scale];
   const t0 = addUnits(
     startOfUnit(dayjs(Math.min(minTime, maxTime)), scale),
@@ -160,6 +158,12 @@ function tickLabel(date: Dayjs, scale: TimelineScale): string {
  * `labelEvery` labels every Nth unit, counted from the domain start. The
  * collision floor (labels never closer than `TICK_LABEL_MIN_SPACE`) still
  * applies, so a too-dense request degrades instead of overlapping.
+ *
+ * Cost note: this materializes one tick per `scale` unit across the whole
+ * domain on every rebuild — `virtualized` culls what renders, not what gets
+ * built here. Fine at the intended densities (weeks/months, a few years of
+ * days); a `day` scale over a decade-wide `range` allocates ~3.6k ticks per
+ * rebuild and would need windowed generation instead.
  */
 export function buildAxis(
   timeScale: TimelineTimeScale,
@@ -169,7 +173,7 @@ export function buildAxis(
 ): { ticks: TimelineTick[]; bands: TimelineBand[] } {
   const autoLabelEvery = Math.max(
     1,
-    Math.ceil(TICK_LABEL_MIN_SPACE / unitWidth)
+    Math.ceil(TICK_LABEL_MIN_SPACE / Math.max(1, unitWidth))
   );
   const effectiveLabelEvery = Math.max(
     autoLabelEvery,

--- a/packages/raystack/index.tsx
+++ b/packages/raystack/index.tsx
@@ -47,6 +47,12 @@ export {
   DataViewProps,
   DataViewQuery,
   DataViewSort,
+  DataViewTimelineProps,
+  TimelineActions,
+  TimelineCardContext,
+  TimelineDateInput,
+  TimelineMarker,
+  TimelineScale,
   useDataView
 } from './components/data-view';
 export { Dialog } from './components/dialog';


### PR DESCRIPTION
## Summary

- Adds `DataView.Timeline`, a renderer that positions the shared DataView row model as cards on a continuous, horizontally scrollable time axis — the card interior is fully consumer-owned via `renderCard(row, context)`, while the Timeline owns the time scale, lane packing, sticky two-tier axis (ticks, month/year bands, today + custom markers, gridlines), and native x/y scrolling with drag-to-pan, momentum glide, and a snapped hover cursor.
- Supports range-window data loading: explicit `range` for a stable coordinate space, `onVisibleRangeChange` (rAF-throttled, deduped by ms window), and time-anchored scrolling so the content never jumps when the domain shifts; imperative navigation ships via `actionsRef` (`scrollTo`, `getVisibleRange`).
- Performance: memoized card wrapper so per-frame cursor/viewport state never re-renders card interiors, and binary-search horizontal culling behind `virtualized`.
- Fixes from review: scroll position is restored when a gated view is re-activated, and point-marker lanes pack with `estimatedPointWidth` so content-sized cards don't overlap; `rowHeight` is renamed to `estimatedRowHeight` to match `DataView.List`.
- Includes docs (guide + props tables), playground demos, an order-desk example page, and 52 unit tests covering geometry, axis, panning, culling, and the imperative handle.