### PR TITLE
fix: code block border, and focus ring fixes

### DIFF
--- a/packages/raystack/components/checkbox/checkbox.module.css
+++ b/packages/raystack/components/checkbox/checkbox.module.css
@@ -47,10 +47,6 @@
 
 .checkbox:focus-visible {
   outline: var(--rs-focus-ring);
-}
-
-/* Checked = accent fill: offset the ring so it clears it. */
-.checkbox[data-checked]:focus-visible {
   outline-offset: var(--rs-focus-ring-offset-accent);
 }
 

--- a/packages/raystack/components/code-block/code-block.module.css
+++ b/packages/raystack/components/code-block/code-block.module.css
@@ -3,7 +3,6 @@
   border-radius: var(--rs-radius-2);
   overflow: hidden;
   width: 100%;
-  border: 0.5px solid var(--rs-color-overlay-base-a2);
   box-sizing: border-box;
 }
 

--- a/packages/raystack/components/radio/radio.module.css
+++ b/packages/raystack/components/radio/radio.module.css
@@ -47,7 +47,7 @@
   background: var(--rs-color-background-base-primary-hover);
 }
 
-.radioitem:focus-visible {
+.radioitem:focus-visible:not([data-disabled]) {
   outline: var(--rs-focus-ring);
   outline-offset: var(--rs-focus-ring-offset-accent);
 }

--- a/packages/raystack/components/radio/radio.module.css
+++ b/packages/raystack/components/radio/radio.module.css
@@ -49,10 +49,6 @@
 
 .radioitem:focus-visible {
   outline: var(--rs-focus-ring);
-}
-
-/* Checked = accent fill: offset the ring so it clears it. */
-.radioitem[data-checked]:focus-visible {
   outline-offset: var(--rs-focus-ring-offset-accent);
 }
 

--- a/packages/raystack/components/switch/switch.module.css
+++ b/packages/raystack/components/switch/switch.module.css
@@ -14,10 +14,6 @@
 
 .switch:focus-visible {
   outline: var(--rs-focus-ring);
-}
-
-/* Checked = accent track: offset the ring so it clears it. */
-.switch[data-checked]:focus-visible {
   outline-offset: var(--rs-focus-ring-offset-accent);
 }
 


### PR DESCRIPTION
## Summary
- Remove the border from the CodeBlock container
- Always apply the focus ring offset on Switch, Checkbox, and Radio, instead of only when checked
- Hide the focus ring on disabled Radio items