### PR TITLE
feat: add PromptInput AI element

### DIFF
--- a/apps/www/src/components/docs/search.tsx
+++ b/apps/www/src/components/docs/search.tsx
@@ -86,7 +86,7 @@ export default function DocsSearch({ pageTree }: { pageTree: Root }) {
        excluded until the user searches. */
     const items = flattened.reduce<Record<string, Item[]>>((acc, item) => {
       const folder = getFolderFromUrl(item.url);
-      if (folder === 'components') return acc;
+      if (folder === 'components' || folder === 'ai-elements') return acc;
       if (!acc[folder]) {
         acc[folder] = [];
       }

--- a/apps/www/src/content/docs/ai-elements/meta.json
+++ b/apps/www/src/content/docs/ai-elements/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "AI Elements",
+  "pages": ["prompt-input"]
+}

--- a/apps/www/src/content/docs/ai-elements/prompt-input/demo.ts
+++ b/apps/www/src/content/docs/ai-elements/prompt-input/demo.ts
@@ -1,0 +1,87 @@
+'use client';
+
+export const preview = {
+  type: 'code',
+  code: `function PromptInputPreview() {
+  const [status, setStatus] = React.useState('idle');
+  const timerRef = React.useRef(null);
+
+  React.useEffect(() => () => clearTimeout(timerRef.current), []);
+
+  return (
+    <div style={{ width: 420 }}>
+      <PromptInput
+        status={status}
+        onSubmit={(value, event) => {
+          event.currentTarget.reset();
+          setStatus('streaming');
+          timerRef.current = setTimeout(() => setStatus('idle'), 2500);
+        }}
+        onStop={() => {
+          clearTimeout(timerRef.current);
+          setStatus('idle');
+        }}
+      >
+        <PromptInput.Textarea placeholder="Ask anything…" />
+        <PromptInput.Footer>
+          <PromptInput.Button>Skills</PromptInput.Button>
+          <PromptInput.Button aria-label="Attach file">📎</PromptInput.Button>
+          <PromptInput.Submit />
+        </PromptInput.Footer>
+      </PromptInput>
+    </div>
+  );
+}`
+};
+
+export const attachmentsDemo = {
+  type: 'code',
+  code: `<div style={{ width: 420 }}>
+  <PromptInput onSubmit={value => console.log(value)}>
+    <PromptInput.Header>
+      <Chat.Attachment title="design-spec.pdf" description="1.2 MB" onRemove={() => {}} />
+      <Chat.Attachment title="screenshot.png" state="uploading" description="Uploading…" />
+    </PromptInput.Header>
+    <PromptInput.Textarea placeholder="Reply…" />
+    <PromptInput.Footer>
+      <PromptInput.Submit />
+    </PromptInput.Footer>
+  </PromptInput>
+</div>`
+};
+
+export const controlledDemo = {
+  type: 'code',
+  code: `function ControlledPromptInput() {
+  const [value, setValue] = React.useState('');
+
+  return (
+    <Flex direction="column" gap={4} style={{ width: 420 }}>
+      <PromptInput
+        value={value}
+        onValueChange={setValue}
+        onSubmit={() => setValue('')}
+      >
+        <PromptInput.Textarea placeholder="Write a message…" />
+        <PromptInput.Footer>
+          <PromptInput.Submit />
+        </PromptInput.Footer>
+      </PromptInput>
+      <Text size="small" variant="secondary">{value.length} characters</Text>
+    </Flex>
+  );
+}`
+};
+
+export const disabledDemo = {
+  type: 'code',
+  code: `<div style={{ width: 420 }}>
+  <PromptInput disabled>
+    <PromptInput.Textarea placeholder="Read-only conversation" />
+    <PromptInput.Footer>
+      <PromptInput.Button>Skills</PromptInput.Button>
+      <PromptInput.Submit />
+    </PromptInput.Footer>
+  </PromptInput>
+</div>`
+};

--- a/apps/www/src/content/docs/ai-elements/prompt-input/index.mdx
+++ b/apps/www/src/content/docs/ai-elements/prompt-input/index.mdx
@@ -1,0 +1,106 @@
+---
+title: PromptInput
+description: A composer for AI chat and standalone "Ask anything" boxes — auto-growing textarea, toolbar slots, and a status-aware submit button.
+source: packages/raystack/components/prompt-input
+tag: new
+---
+
+import { preview, attachmentsDemo, controlledDemo, disabledDemo } from "./demo.ts";
+
+<Demo data={preview} />
+
+## Anatomy
+
+Import and assemble the composer. The root is a form that owns submit
+semantics: Enter submits, Shift+Enter inserts a newline, and IME composition
+is respected.
+
+```tsx
+import { PromptInput } from '@raystack/apsara'
+
+<PromptInput onSubmit={send} onStop={stop} status={status}>
+  <PromptInput.Header>{/* attachment previews */}</PromptInput.Header>
+  <PromptInput.Textarea placeholder="Reply…" />
+  <PromptInput.Footer>
+    <PromptInput.Button>Skills</PromptInput.Button>
+    <PromptInput.Submit />
+  </PromptInput.Footer>
+</PromptInput>
+```
+
+`PromptInput` is purely presentational: it never talks to a model or manages a
+request. Pass the lifecycle in through `status` and react to `onSubmit` /
+`onStop` — it works with the AI SDK's `useChat`, a custom SSE client, or
+anything else.
+
+## API Reference
+
+### Root
+
+The `<form>` that holds the value and submit semantics.
+
+<auto-type-table path="./props.ts" name="PromptInputProps" />
+
+### Textarea
+
+The text field, built on `TextArea variant="borderless"`. It grows with its
+content up to a max-height cap (override with
+`--prompt-input-textarea-max-height`), then scrolls.
+
+<auto-type-table path="./props.ts" name="PromptInputTextareaProps" />
+
+### Header
+
+A slot row above the textarea, usually for `Chat.Attachment` previews. Hidden
+while empty.
+
+### Footer
+
+The bottom toolbar row. Hidden while empty.
+
+### Button
+
+A small neutral-ghost `Button` for the toolbar — attach, skills, model pickers
+and similar consumer-owned controls.
+
+<auto-type-table path="./props.ts" name="PromptInputButtonProps" />
+
+### Submit
+
+The trailing send button. It renders ↑ when idle, disables itself while the
+input is empty, shows a spinner while `status="submitted"`, and flips to a
+stop square that calls `onStop` while `status="streaming"`.
+
+<auto-type-table path="./props.ts" name="PromptInputSubmitProps" />
+
+## Examples
+
+### Attachments in the header
+
+Attachment previews are presentational (`Chat.Attachment`); file picking,
+drag-drop and uploads belong to your app.
+
+<Demo data={attachmentsDemo} />
+
+### Controlled value
+
+Control `value` to sync the draft elsewhere — persistence, slash-command
+menus, mention pickers.
+
+<Demo data={controlledDemo} />
+
+### Disabled
+
+<Demo data={disabledDemo} />
+
+## Accessibility
+
+- The root is a native `<form>`; `PromptInput.Submit` is a real submit button,
+  so assistive tech announces the submit affordance for free.
+- Enter submits and Shift+Enter inserts a newline. During IME composition
+  Enter confirms the composition instead of submitting.
+- While a response is in flight the submit button becomes `type="button"` with
+  an updated accessible name ("Stop response") so it can never resubmit the
+  form.
+- The composer frame carries the focus treatment (`:focus-within`), while the
+  borderless textarea suppresses its own duplicate focus ring.

--- a/apps/www/src/content/docs/ai-elements/prompt-input/props.ts
+++ b/apps/www/src/content/docs/ai-elements/prompt-input/props.ts
@@ -1,0 +1,95 @@
+import type React from 'react';
+
+export interface PromptInputProps {
+  /** The composed text (controlled). */
+  value?: string;
+
+  /**
+   * The initial text when uncontrolled.
+   * @defaultValue ""
+   */
+  defaultValue?: string;
+
+  /** Called when the composed text changes. */
+  onValueChange?: (value: string) => void;
+
+  /**
+   * Called with the trimmed text when the prompt is submitted — Enter in the
+   * textarea or a click on `PromptInput.Submit`. Call
+   * `event.currentTarget.reset()` to clear the input after sending.
+   */
+  onSubmit?: (value: string, event: React.FormEvent<HTMLFormElement>) => void;
+
+  /**
+   * Called when `PromptInput.Submit` is pressed while `status` is
+   * `"submitted"` or `"streaming"`.
+   */
+  onStop?: () => void;
+
+  /**
+   * The consumer-owned request lifecycle. Drives `PromptInput.Submit`:
+   * `"idle"`/`"error"` show a send arrow, `"submitted"` a spinner and
+   * `"streaming"` a stop square (both routed to `onStop`).
+   * @defaultValue "idle"
+   */
+  status?: 'idle' | 'submitted' | 'streaming' | 'error';
+
+  /**
+   * Disables the whole composer.
+   * @defaultValue false
+   */
+  disabled?: boolean;
+
+  /** Custom CSS class names. */
+  className?: string;
+}
+
+export interface PromptInputTextareaProps {
+  /** Placeholder shown while empty. @defaultValue "Write a message…" */
+  placeholder?: string;
+
+  /** Disables just the textarea. Inherits the root `disabled` by default. */
+  disabled?: boolean;
+
+  /** Custom CSS class names. */
+  className?: string;
+}
+
+export interface PromptInputSubmitProps {
+  /**
+   * Replaces the status-derived icon (send arrow, spinner or stop square).
+   */
+  children?: React.ReactNode;
+
+  /**
+   * Accessible name. Defaults to "Send message", or "Stop response" while a
+   * response is in flight.
+   */
+  'aria-label'?: string;
+
+  /** Custom CSS class names. */
+  className?: string;
+}
+
+export interface PromptInputButtonProps {
+  /**
+   * Visual style, forwarded to `Button`.
+   * @defaultValue "ghost"
+   */
+  variant?: 'solid' | 'outline' | 'ghost' | 'text';
+
+  /**
+   * Color, forwarded to `Button`.
+   * @defaultValue "neutral"
+   */
+  color?: 'accent' | 'danger' | 'neutral' | 'success';
+
+  /**
+   * Size, forwarded to `Button`.
+   * @defaultValue "small"
+   */
+  size?: 'small' | 'normal';
+
+  /** Custom CSS class names. */
+  className?: string;
+}

--- a/apps/www/src/content/docs/meta.json
+++ b/apps/www/src/content/docs/meta.json
@@ -1,3 +1,3 @@
 {
-  "pages": ["(overview)", "theme", "components"]
+  "pages": ["(overview)", "theme", "ai-elements", "components"]
 }

--- a/packages/raystack/components/prompt-input/__tests__/prompt-input.test.tsx
+++ b/packages/raystack/components/prompt-input/__tests__/prompt-input.test.tsx
@@ -1,0 +1,227 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { PromptInput } from '../prompt-input';
+
+const BasicPromptInput = (
+  props: Partial<Parameters<typeof PromptInput>[0]>
+) => (
+  <PromptInput {...props}>
+    <PromptInput.Header data-testid='header' />
+    <PromptInput.Textarea placeholder='Reply…' />
+    <PromptInput.Footer data-testid='footer'>
+      <PromptInput.Button>Skills</PromptInput.Button>
+      <PromptInput.Submit data-testid='submit' />
+    </PromptInput.Footer>
+  </PromptInput>
+);
+
+describe('PromptInput', () => {
+  describe('Basic Rendering', () => {
+    it('renders the textarea, toolbar button and submit', () => {
+      render(<BasicPromptInput />);
+
+      expect(screen.getByPlaceholderText('Reply…')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Skills' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Send message' })
+      ).toBeInTheDocument();
+    });
+
+    it('applies custom className to the root form', () => {
+      const { container } = render(
+        <PromptInput className='custom-root'>
+          <PromptInput.Textarea />
+        </PromptInput>
+      );
+      expect(container.querySelector('form')).toHaveClass('custom-root');
+    });
+
+    it('renders header and footer slots', () => {
+      render(<BasicPromptInput />);
+      expect(screen.getByTestId('header')).toBeInTheDocument();
+      expect(screen.getByTestId('footer')).toBeInTheDocument();
+    });
+
+    it('throws when parts are used outside the root', () => {
+      const spy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
+      expect(() => render(<PromptInput.Textarea />)).toThrow(
+        /must be used within <PromptInput>/
+      );
+      spy.mockRestore();
+    });
+  });
+
+  describe('Value and submission', () => {
+    it('updates the value while typing and calls onValueChange', async () => {
+      const onValueChange = vi.fn();
+      const user = userEvent.setup();
+      render(<BasicPromptInput onValueChange={onValueChange} />);
+
+      const textarea = screen.getByPlaceholderText('Reply…');
+      await user.type(textarea, 'hello');
+
+      expect(textarea).toHaveValue('hello');
+      expect(onValueChange).toHaveBeenLastCalledWith('hello');
+    });
+
+    it('submits the trimmed value on Enter', async () => {
+      const onSubmit = vi.fn();
+      const user = userEvent.setup();
+      render(<BasicPromptInput onSubmit={onSubmit} />);
+
+      const textarea = screen.getByPlaceholderText('Reply…');
+      await user.type(textarea, '  hello world  ');
+      await user.keyboard('{Enter}');
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(onSubmit.mock.calls[0][0]).toBe('hello world');
+    });
+
+    it('inserts a newline on Shift+Enter instead of submitting', async () => {
+      const onSubmit = vi.fn();
+      const user = userEvent.setup();
+      render(<BasicPromptInput onSubmit={onSubmit} />);
+
+      const textarea = screen.getByPlaceholderText('Reply…');
+      await user.type(textarea, 'line one');
+      await user.keyboard('{Shift>}{Enter}{/Shift}');
+      await user.type(textarea, 'line two');
+
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(textarea).toHaveValue('line one\nline two');
+    });
+
+    it('does not submit while composing with an IME', async () => {
+      const onSubmit = vi.fn();
+      render(<BasicPromptInput onSubmit={onSubmit} />);
+
+      const textarea = screen.getByPlaceholderText('Reply…');
+      fireEvent.change(textarea, { target: { value: 'かな' } });
+      fireEvent.keyDown(textarea, { key: 'Enter', isComposing: true });
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('does not submit when the value is empty or whitespace', async () => {
+      const onSubmit = vi.fn();
+      const user = userEvent.setup();
+      render(<BasicPromptInput onSubmit={onSubmit} />);
+
+      const textarea = screen.getByPlaceholderText('Reply…');
+      await user.type(textarea, '   ');
+      await user.keyboard('{Enter}');
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('submits via the submit button', async () => {
+      const onSubmit = vi.fn();
+      const user = userEvent.setup();
+      render(<BasicPromptInput onSubmit={onSubmit} />);
+
+      await user.type(screen.getByPlaceholderText('Reply…'), 'hi');
+      await user.click(screen.getByRole('button', { name: 'Send message' }));
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(onSubmit.mock.calls[0][0]).toBe('hi');
+    });
+
+    it('supports a controlled value', async () => {
+      const onValueChange = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <BasicPromptInput value='controlled' onValueChange={onValueChange} />
+      );
+
+      const textarea = screen.getByPlaceholderText('Reply…');
+      expect(textarea).toHaveValue('controlled');
+      await user.type(textarea, '!');
+      // Parent did not update the prop, so the value stays.
+      expect(textarea).toHaveValue('controlled');
+      expect(onValueChange).toHaveBeenCalledWith('controlled!');
+    });
+
+    it('clears the value when the form is reset from onSubmit', async () => {
+      const onSubmit = vi.fn((_value, event) => event.currentTarget.reset());
+      const user = userEvent.setup();
+      render(<BasicPromptInput onSubmit={onSubmit} />);
+
+      const textarea = screen.getByPlaceholderText('Reply…');
+      await user.type(textarea, 'clear me');
+      await user.keyboard('{Enter}');
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(textarea).toHaveValue('');
+    });
+  });
+
+  describe('Submit button states', () => {
+    it('is disabled while the value is empty', async () => {
+      const user = userEvent.setup();
+      render(<BasicPromptInput />);
+
+      const submit = screen.getByRole('button', { name: 'Send message' });
+      expect(submit).toBeDisabled();
+
+      await user.type(screen.getByPlaceholderText('Reply…'), 'x');
+      expect(submit).toBeEnabled();
+    });
+
+    it('becomes a stop control while streaming', async () => {
+      const onStop = vi.fn();
+      const onSubmit = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <BasicPromptInput
+          status='streaming'
+          onStop={onStop}
+          onSubmit={onSubmit}
+        />
+      );
+
+      const stop = screen.getByRole('button', { name: 'Stop response' });
+      expect(stop).toBeEnabled();
+      expect(stop).toHaveAttribute('type', 'button');
+
+      await user.click(stop);
+      expect(onStop).toHaveBeenCalledTimes(1);
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('shows the stop control while submitted', () => {
+      render(<BasicPromptInput status='submitted' />);
+      expect(
+        screen.getByRole('button', { name: 'Stop response' })
+      ).toBeInTheDocument();
+    });
+
+    it('does not submit on Enter while streaming', async () => {
+      const onSubmit = vi.fn();
+      const user = userEvent.setup();
+      render(<BasicPromptInput status='streaming' onSubmit={onSubmit} />);
+
+      const textarea = screen.getByPlaceholderText('Reply…');
+      await user.type(textarea, 'queued');
+      await user.keyboard('{Enter}');
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Disabled state', () => {
+    it('disables the textarea, buttons and submit', () => {
+      render(<BasicPromptInput disabled />);
+
+      expect(screen.getByPlaceholderText('Reply…')).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Skills' })).toBeDisabled();
+      expect(
+        screen.getByRole('button', { name: 'Send message' })
+      ).toBeDisabled();
+    });
+  });
+});

--- a/packages/raystack/components/prompt-input/index.tsx
+++ b/packages/raystack/components/prompt-input/index.tsx
@@ -1,0 +1,3 @@
+export { PromptInput } from './prompt-input';
+export type { PromptInputStatus } from './prompt-input-context';
+export type { PromptInputRootProps as PromptInputProps } from './prompt-input-root';

--- a/packages/raystack/components/prompt-input/prompt-input-context.tsx
+++ b/packages/raystack/components/prompt-input/prompt-input-context.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { createContext, RefObject, useContext } from 'react';
+
+export type PromptInputStatus = 'idle' | 'submitted' | 'streaming' | 'error';
+
+export interface PromptInputContextValue {
+  value: string;
+  setValue: (value: string) => void;
+  status: PromptInputStatus;
+  disabled: boolean;
+  onStop?: () => void;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  requestSubmit: () => void;
+}
+
+export const PromptInputContext = createContext<PromptInputContextValue | null>(
+  null
+);
+
+export function usePromptInputContext(part: string): PromptInputContextValue {
+  const context = useContext(PromptInputContext);
+  if (!context) {
+    throw new Error(`PromptInput.${part} must be used within <PromptInput>`);
+  }
+  return context;
+}

--- a/packages/raystack/components/prompt-input/prompt-input-parts.tsx
+++ b/packages/raystack/components/prompt-input/prompt-input-parts.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { cx } from 'class-variance-authority';
+import { ComponentProps } from 'react';
+import { Button } from '../button';
+import styles from './prompt-input.module.css';
+import { usePromptInputContext } from './prompt-input-context';
+
+export interface PromptInputHeaderProps extends ComponentProps<'div'> {}
+
+export function PromptInputHeader({
+  className,
+  ...props
+}: PromptInputHeaderProps) {
+  return <div className={cx(styles.header, className)} {...props} />;
+}
+
+PromptInputHeader.displayName = 'PromptInput.Header';
+
+export interface PromptInputFooterProps extends ComponentProps<'div'> {}
+
+export function PromptInputFooter({
+  className,
+  ...props
+}: PromptInputFooterProps) {
+  return <div className={cx(styles.footer, className)} {...props} />;
+}
+
+PromptInputFooter.displayName = 'PromptInput.Footer';
+
+export interface PromptInputButtonProps extends ComponentProps<typeof Button> {}
+
+export function PromptInputButton({
+  className,
+  variant = 'ghost',
+  color = 'neutral',
+  size = 'small',
+  type = 'button',
+  disabled,
+  ...props
+}: PromptInputButtonProps) {
+  const context = usePromptInputContext('Button');
+  return (
+    <Button
+      type={type}
+      variant={variant}
+      color={color}
+      size={size}
+      disabled={disabled ?? context.disabled}
+      className={cx(styles.button, className)}
+      {...props}
+    />
+  );
+}
+
+PromptInputButton.displayName = 'PromptInput.Button';

--- a/packages/raystack/components/prompt-input/prompt-input-root.tsx
+++ b/packages/raystack/components/prompt-input/prompt-input-root.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { useControlled } from '@base-ui/utils/useControlled';
+import { cx } from 'class-variance-authority';
+import { ComponentProps, FormEvent, useCallback, useMemo, useRef } from 'react';
+import styles from './prompt-input.module.css';
+import {
+  PromptInputContext,
+  type PromptInputContextValue,
+  type PromptInputStatus
+} from './prompt-input-context';
+
+export interface PromptInputRootProps
+  extends Omit<ComponentProps<'form'>, 'onSubmit'> {
+  /** The composed text (controlled). */
+  value?: string;
+  /**
+   * The initial text when uncontrolled.
+   * @defaultValue ""
+   */
+  defaultValue?: string;
+  /** Called when the composed text changes. */
+  onValueChange?: (value: string) => void;
+  /**
+   * Called with the trimmed text when the prompt is submitted — Enter in the
+   * textarea or a click on `PromptInput.Submit`. Call
+   * `event.currentTarget.reset()` to clear the input after sending.
+   */
+  onSubmit?: (value: string, event: FormEvent<HTMLFormElement>) => void;
+  /**
+   * Called when `PromptInput.Submit` is pressed while `status` is
+   * `"submitted"` or `"streaming"`.
+   */
+  onStop?: () => void;
+  /**
+   * The consumer-owned request lifecycle. Drives `PromptInput.Submit`:
+   * `"idle"`/`"error"` show a send arrow, `"submitted"` a spinner and
+   * `"streaming"` a stop square (both routed to `onStop`).
+   * @defaultValue "idle"
+   */
+  status?: PromptInputStatus;
+  /**
+   * Disables the whole composer.
+   * @defaultValue false
+   */
+  disabled?: boolean;
+}
+
+export function PromptInputRoot({
+  className,
+  value: valueProp,
+  defaultValue = '',
+  onValueChange,
+  onSubmit,
+  onStop,
+  onReset,
+  status = 'idle',
+  disabled = false,
+  children,
+  ref,
+  ...props
+}: PromptInputRootProps) {
+  const formRef = useRef<HTMLFormElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const [value, setValueUnwrapped] = useControlled({
+    controlled: valueProp,
+    default: defaultValue,
+    name: 'PromptInput',
+    state: 'value'
+  });
+
+  const onValueChangeRef = useRef(onValueChange);
+  onValueChangeRef.current = onValueChange;
+
+  const setValue = useCallback(
+    (next: string) => {
+      setValueUnwrapped(next);
+      onValueChangeRef.current?.(next);
+    },
+    [setValueUnwrapped]
+  );
+
+  const requestSubmit = useCallback(() => {
+    const form = formRef.current;
+    if (!form) return;
+    if (typeof form.requestSubmit === 'function') {
+      form.requestSubmit();
+    } else {
+      form.dispatchEvent(
+        new Event('submit', { cancelable: true, bubbles: true })
+      );
+    }
+  }, []);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (disabled || status === 'submitted' || status === 'streaming') return;
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onSubmit?.(trimmed, event);
+  };
+
+  const handleReset = (event: FormEvent<HTMLFormElement>) => {
+    onReset?.(event);
+    if (event.defaultPrevented) return;
+    setValue('');
+  };
+
+  const contextValue = useMemo<PromptInputContextValue>(
+    () => ({
+      value,
+      setValue,
+      status,
+      disabled,
+      onStop,
+      textareaRef,
+      requestSubmit
+    }),
+    [value, setValue, status, disabled, onStop, requestSubmit]
+  );
+
+  return (
+    <PromptInputContext.Provider value={contextValue}>
+      <form
+        ref={node => {
+          formRef.current = node;
+          if (typeof ref === 'function') ref(node);
+          else if (ref) ref.current = node;
+        }}
+        className={cx(styles.root, className)}
+        data-status={status}
+        data-disabled={disabled || undefined}
+        data-empty={value.trim() === '' || undefined}
+        onSubmit={handleSubmit}
+        onReset={handleReset}
+        {...props}
+      >
+        {children}
+      </form>
+    </PromptInputContext.Provider>
+  );
+}
+
+PromptInputRoot.displayName = 'PromptInput';

--- a/packages/raystack/components/prompt-input/prompt-input-submit.tsx
+++ b/packages/raystack/components/prompt-input/prompt-input-submit.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { ArrowUpIcon, StopIcon } from '@radix-ui/react-icons';
+import { cx } from 'class-variance-authority';
+import { ComponentProps, MouseEvent } from 'react';
+import { Spinner } from '../spinner';
+import styles from './prompt-input.module.css';
+import { usePromptInputContext } from './prompt-input-context';
+
+export interface PromptInputSubmitProps extends ComponentProps<'button'> {}
+
+export function PromptInputSubmit({
+  className,
+  children,
+  onClick,
+  disabled,
+  'aria-label': ariaLabel,
+  ...props
+}: PromptInputSubmitProps) {
+  const context = usePromptInputContext('Submit');
+  const busy = context.status === 'submitted' || context.status === 'streaming';
+  const empty = context.value.trim() === '';
+
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    if (event.defaultPrevented) return;
+    if (busy) context.onStop?.();
+  };
+
+  return (
+    <button
+      // While a response is in flight the button becomes a stop control and
+      // must not resubmit the form.
+      type={busy ? 'button' : 'submit'}
+      className={cx(styles.submit, className)}
+      data-status={context.status}
+      disabled={disabled ?? (context.disabled || (!busy && empty))}
+      aria-label={ariaLabel ?? (busy ? 'Stop response' : 'Send message')}
+      onClick={handleClick}
+      {...props}
+    >
+      {children ??
+        (context.status === 'submitted' ? (
+          <Spinner size={2} color='default' aria-hidden='true' />
+        ) : context.status === 'streaming' ? (
+          <StopIcon aria-hidden='true' />
+        ) : (
+          <ArrowUpIcon aria-hidden='true' />
+        ))}
+    </button>
+  );
+}
+
+PromptInputSubmit.displayName = 'PromptInput.Submit';

--- a/packages/raystack/components/prompt-input/prompt-input-textarea.tsx
+++ b/packages/raystack/components/prompt-input/prompt-input-textarea.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useMergedRefs } from '@base-ui/utils/useMergedRefs';
+import { cx } from 'class-variance-authority';
+import { ChangeEvent, KeyboardEvent, useLayoutEffect, useRef } from 'react';
+import { TextArea, type TextAreaProps } from '../text-area/text-area';
+import styles from './prompt-input.module.css';
+import { usePromptInputContext } from './prompt-input-context';
+
+export interface PromptInputTextareaProps
+  extends Omit<
+    TextAreaProps,
+    'value' | 'defaultValue' | 'onValueChange' | 'variant' | 'size' | 'rows'
+  > {}
+
+export function PromptInputTextarea({
+  className,
+  onChange,
+  onKeyDown,
+  disabled,
+  placeholder = 'Write a message…',
+  ref,
+  ...props
+}: PromptInputTextareaProps) {
+  const context = usePromptInputContext('Textarea');
+  const localRef = useRef<HTMLTextAreaElement | null>(null);
+  const mergedRef = useMergedRefs(localRef, context.textareaRef, ref);
+
+  const resolvedDisabled = disabled ?? context.disabled;
+
+  // Auto-grow with content: reset to a single row, then take the scroll
+  // height. The CSS max-height caps growth and hands off to scrolling.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-measure whenever the value changes.
+  useLayoutEffect(() => {
+    const el = localRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  }, [context.value]);
+
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    onChange?.(event);
+    context.setValue(event.target.value);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    onKeyDown?.(event);
+    if (event.defaultPrevented) return;
+    if (event.key !== 'Enter' || event.shiftKey) return;
+    // Let IME composition confirm with Enter instead of sending.
+    if (event.nativeEvent.isComposing || event.keyCode === 229) return;
+    event.preventDefault();
+    context.requestSubmit();
+  };
+
+  return (
+    <TextArea
+      ref={mergedRef}
+      rows={1}
+      variant='borderless'
+      size='small'
+      className={cx(styles.textarea, className)}
+      value={context.value}
+      onChange={handleChange}
+      onKeyDown={handleKeyDown}
+      disabled={resolvedDisabled}
+      placeholder={placeholder}
+      {...props}
+    />
+  );
+}
+
+PromptInputTextarea.displayName = 'PromptInput.Textarea';

--- a/packages/raystack/components/prompt-input/prompt-input.module.css
+++ b/packages/raystack/components/prompt-input/prompt-input.module.css
@@ -1,0 +1,130 @@
+.root {
+  --prompt-input-textarea-max-height: 200px;
+
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--rs-color-background-base-primary);
+  border: 0.5px solid var(--rs-color-border-base-tertiary);
+  border-radius: var(--rs-radius-4);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .root {
+    transition: var(--rs-transition-interactive);
+  }
+}
+
+/* Focus treatment matches Input's wrapper: the border tints accent. */
+.root:focus-within {
+  border-color: var(--rs-color-border-accent-emphasis);
+}
+
+.root[data-disabled] {
+  opacity: 0.5;
+}
+
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--rs-space-2);
+  padding: var(--rs-space-3) var(--rs-space-3) 0;
+}
+
+.header:empty {
+  display: none;
+}
+
+/* The textarea is borderless inside the composer frame; the frame itself
+   carries the focus treatment, so suppress the field's own focus ring. */
+.root .textarea:focus-visible:not(:disabled) {
+  box-shadow: none;
+}
+
+/* TextArea repaints an opaque background on focus; inside the frame it must
+   stay transparent or its squarer corners fill in the frame's corner radius. */
+.root .textarea:focus:not(:disabled) {
+  background: transparent;
+}
+
+.root .textarea {
+  border: none;
+  background: transparent;
+  resize: none;
+  max-height: var(--prompt-input-textarea-max-height);
+  min-height: var(--rs-space-9);
+  padding: var(--rs-space-3);
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  gap: var(--rs-space-2);
+  padding: var(--rs-space-2) var(--rs-space-3) var(--rs-space-3);
+}
+
+.footer:empty {
+  display: none;
+}
+
+.button {
+  flex-shrink: 0;
+}
+
+.submit {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  flex-shrink: 0;
+  margin-left: auto;
+  width: var(--rs-space-8);
+  height: var(--rs-space-8);
+  padding: 0;
+  border: none;
+  border-radius: var(--rs-radius-full);
+  background: var(--rs-color-background-accent-emphasis);
+  color: var(--rs-accent-contrast);
+  cursor: pointer;
+  outline: none;
+}
+
+/* The scale applies unconditionally (an instant state change); only the
+   eased tween is motion, so only the transitions are gated. Mirrors button. */
+@media (prefers-reduced-motion: no-preference) {
+  .submit {
+    transition: var(--rs-transition-interactive);
+  }
+
+  .submit:active {
+    transition: var(--rs-transition-pressed);
+  }
+}
+
+.submit:hover:not(:disabled) {
+  background: var(--rs-color-background-accent-emphasis-hover);
+}
+
+.submit:active:not(:disabled) {
+  transform: scale(var(--rs-scale-pressed));
+}
+
+.submit:focus-visible {
+  outline: var(--rs-focus-ring);
+  outline-offset: var(--rs-focus-ring-offset-accent);
+}
+
+/* The button keeps its accent fill in every state; disabled just dims it. */
+.submit:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+/* The disabled frame already dims everything to 50%; skip the button's own
+   dimming so it doesn't compound to 25%. */
+.root[data-disabled] .submit:disabled {
+  opacity: 1;
+}

--- a/packages/raystack/components/prompt-input/prompt-input.tsx
+++ b/packages/raystack/components/prompt-input/prompt-input.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import {
+  PromptInputButton,
+  PromptInputFooter,
+  PromptInputHeader
+} from './prompt-input-parts';
+import { PromptInputRoot } from './prompt-input-root';
+import { PromptInputSubmit } from './prompt-input-submit';
+import { PromptInputTextarea } from './prompt-input-textarea';
+
+export const PromptInput = Object.assign(PromptInputRoot, {
+  Textarea: PromptInputTextarea,
+  Header: PromptInputHeader,
+  Footer: PromptInputFooter,
+  Button: PromptInputButton,
+  Submit: PromptInputSubmit
+});

--- a/packages/raystack/index.tsx
+++ b/packages/raystack/index.tsx
@@ -81,6 +81,11 @@ export { OTPField } from './components/otp-field';
 export { Popover } from './components/popover';
 export { PreviewCard } from './components/preview-card';
 export { Progress } from './components/progress';
+export {
+  PromptInput,
+  type PromptInputProps,
+  type PromptInputStatus
+} from './components/prompt-input';
 export { Radio } from './components/radio';
 export { ScrollArea } from './components/scroll-area';
 export { Search } from './components/search';


### PR DESCRIPTION
## Summary
- Add the `PromptInput` compound component (`Root`, `Textarea`, `Submit`, `Toolbar`/parts) to `packages/raystack/components/prompt-input/`, with auto-growing textarea, Enter-to-submit handling, and a submit button that reflects status (idle/streaming/error)
- Style with CSS Modules using `--rs-*` tokens and export the component from the raystack package root
- Set up the new "AI Elements" docs section: sidebar `meta.json` entry and search grouping in `apps/www`
- Add the PromptInput docs page with live demos and a full props reference
- First PR of a 5-PR AI components stack: PromptInput -> Message -> Reasoning -> Chat -> ChatPanel