### PR TITLE
feat: improve Amount formatting capabilities

### DIFF
--- a/apps/www/src/components/playground/amount-examples.tsx
+++ b/apps/www/src/components/playground/amount-examples.tsx
@@ -46,6 +46,28 @@ export function AmountExamples() {
             />
           </Text>
         </Flex>
+        <Flex gap={5} align='center' direction='column'>
+          <Text>
+            Compact: <Amount value={120000000} notation='compact' />
+          </Text>
+          <Text>
+            Narrow symbol:{' '}
+            <Amount
+              value={1299}
+              locale='en-CA'
+              currencyDisplay='narrowSymbol'
+            />
+          </Text>
+          <Text>
+            Gain: <Amount value={1299} signDisplay='always' />
+          </Text>
+          <Text>
+            Loss: <Amount value={-1299} signDisplay='always' />
+          </Text>
+          <Text>
+            Proportional figures: <Amount value={1111} tabularNums={false} />
+          </Text>
+        </Flex>
       </Flex>
     </PlaygroundLayout>
   );

--- a/apps/www/src/content/docs/components/amount/demo.ts
+++ b/apps/www/src/content/docs/components/amount/demo.ts
@@ -32,8 +32,18 @@ export const playground = {
     },
     currencyDisplay: {
       type: 'select',
-      options: ['symbol', 'code', 'name'],
+      options: ['symbol', 'narrowSymbol', 'code', 'name'],
       defaultValue: 'symbol'
+    },
+    notation: {
+      type: 'select',
+      options: ['standard', 'compact'],
+      defaultValue: 'standard'
+    },
+    signDisplay: {
+      type: 'select',
+      options: ['auto', 'always', 'exceptZero', 'never'],
+      defaultValue: 'auto'
     },
     minimumFractionDigits: {
       type: 'number',
@@ -50,6 +60,10 @@ export const playground = {
     hideCurrency: {
       type: 'checkbox',
       defaultValue: false
+    },
+    tabularNums: {
+      type: 'checkbox',
+      defaultValue: true
     }
   },
   getCode
@@ -119,6 +133,44 @@ export const currencyDisplayDemo = {
     <Amount value={1299} currencyDisplay="symbol" /> {/* $12.99 */}
     <Amount value={1299} currencyDisplay="code" /> {/* USD 12.99 */}
     <Amount value={1299} currencyDisplay="name" /> {/* 12.99 US dollars */}
+  </Flex>
+  `
+};
+
+export const notationDemo = {
+  type: 'code',
+  code: `
+  <Flex gap={4}>
+    <Amount value={120000000} notation="compact" /> {/* $1.2M */}
+    <Amount value={1300000} notation="compact" /> {/* $13K */}
+    <Amount value={120000000} /> {/* $1,200,000.00 */}
+  </Flex>
+  `
+};
+
+export const signDisplayDemo = {
+  type: 'code',
+  code: `
+  <Flex gap={4}>
+    <Amount value={1299} signDisplay="always" /> {/* +$12.99 */}
+    <Amount value={-1299} signDisplay="always" /> {/* -$12.99 */}
+    <Amount value={0} signDisplay="exceptZero" /> {/* $0.00 */}
+    <Amount value={-1299} signDisplay="never" /> {/* $12.99 */}
+  </Flex>
+  `
+};
+
+export const tabularNumsDemo = {
+  type: 'code',
+  code: `
+  <Flex direction="column" gap={2}>
+    {/* Tabular figures (default) keep digits aligned across rows */}
+    <Amount value={111111} />
+    <Amount value={909090} />
+    {/* Proportional figures read better in running text */}
+    <Text>
+      You saved <Amount value={1299} tabularNums={false} /> today
+    </Text>
   </Flex>
   `
 };

--- a/apps/www/src/content/docs/components/amount/index.mdx
+++ b/apps/www/src/content/docs/components/amount/index.mdx
@@ -12,6 +12,9 @@ import {
   localeDemo,
   hideDecimalsDemo,
   currencyDisplayDemo,
+  notationDemo,
+  signDisplayDemo,
+  tabularNumsDemo,
   hideCurrencyDemo,
   groupDigitsDemo,
   withTextDemo,
@@ -61,6 +64,24 @@ Formats and displays monetary values with locale and currency support.
 ### currencyDisplay
 
 <Demo data={currencyDisplayDemo} />
+
+### notation
+
+Use `compact` to abbreviate large values, e.g. `$1.2M`. Handy for dashboards and summary views. Compact rounds values by design, so avoid it where the exact amount matters.
+
+<Demo data={notationDemo} />
+
+### signDisplay
+
+Control when the `+`/`-` sign appears. Useful for showing gains and losses.
+
+<Demo data={signDisplayDemo} />
+
+### tabularNums
+
+Tabular (fixed-width) figures are on by default so amounts align digit-for-digit when stacked in table rows. Turn it off in running text, where proportional figures look more natural.
+
+<Demo data={tabularNumsDemo} />
 
 ### hideCurrency
 

--- a/packages/raystack/components/amount/__tests__/amount.test.tsx
+++ b/packages/raystack/components/amount/__tests__/amount.test.tsx
@@ -321,4 +321,118 @@ describe('Amount', () => {
       expect(screen.getByText('12.990')).toBeInTheDocument();
     });
   });
+
+  describe('narrowSymbol', () => {
+    it('renders the narrow symbol instead of the locale-prefixed one', () => {
+      // en-CA formats USD as "US$12.99" with 'symbol'; narrowSymbol drops the prefix.
+      render(
+        <Amount
+          value={1299}
+          currency='USD'
+          locale='en-CA'
+          currencyDisplay='narrowSymbol'
+        />
+      );
+      expect(screen.getByText('$12.99')).toBeInTheDocument();
+    });
+
+    it('matches symbol output for the home locale', () => {
+      render(<Amount value={1299} currencyDisplay='narrowSymbol' />);
+      expect(screen.getByText('$12.99')).toBeInTheDocument();
+    });
+  });
+
+  describe('signDisplay', () => {
+    it('always shows the sign when signDisplay is always', () => {
+      render(<Amount value={1299} signDisplay='always' />);
+      expect(screen.getByText('+$12.99')).toBeInTheDocument();
+    });
+
+    it('shows the sign except for zero when signDisplay is exceptZero', () => {
+      const { rerender } = render(
+        <Amount value={1299} signDisplay='exceptZero' />
+      );
+      expect(screen.getByText('+$12.99')).toBeInTheDocument();
+      rerender(<Amount value={0} signDisplay='exceptZero' />);
+      expect(screen.getByText('$0.00')).toBeInTheDocument();
+    });
+
+    it('hides the sign for negative values when signDisplay is never', () => {
+      render(<Amount value={-1299} signDisplay='never' />);
+      expect(screen.getByText('$12.99')).toBeInTheDocument();
+    });
+
+    it('keeps the sign when hideCurrency strips the currency token', () => {
+      render(<Amount value={1299} signDisplay='always' hideCurrency />);
+      expect(screen.getByText('+12.99')).toBeInTheDocument();
+    });
+  });
+
+  describe('notation', () => {
+    it('renders compact notation for large values', () => {
+      render(<Amount value={120000000} notation='compact' />);
+      expect(screen.getByText('$1.2M')).toBeInTheDocument();
+    });
+
+    it('renders standard notation by default', () => {
+      render(<Amount value={120000000} />);
+      expect(screen.getByText('$1,200,000.00')).toBeInTheDocument();
+    });
+
+    it('rounds small values to compact defaults (no abbreviation below 1K)', () => {
+      // Compact notation caps fraction digits aggressively: 12.99 → "$13".
+      render(<Amount value={1299} notation='compact' />);
+      expect(screen.getByText('$13')).toBeInTheDocument();
+    });
+
+    it('works with hideDecimals', () => {
+      render(<Amount value={125000000} notation='compact' hideDecimals />);
+      expect(screen.getByText('$1M')).toBeInTheDocument();
+    });
+
+    it('works with string values', () => {
+      render(<Amount value='120000000' notation='compact' />);
+      expect(screen.getByText('$1.2M')).toBeInTheDocument();
+    });
+
+    it('works with hideCurrency', () => {
+      render(<Amount value={120000000} notation='compact' hideCurrency />);
+      expect(screen.getByText('1.2M')).toBeInTheDocument();
+    });
+
+    it('respects explicit fraction digits', () => {
+      render(
+        <Amount
+          value={123400000}
+          notation='compact'
+          minimumFractionDigits={2}
+          maximumFractionDigits={2}
+        />
+      );
+      expect(screen.getByText('$1.23M')).toBeInTheDocument();
+    });
+  });
+
+  describe('tabularNums', () => {
+    it('applies tabular figures by default', () => {
+      const { container } = render(<Amount value={1299} />);
+      const span = container.querySelector('span');
+      expect(span?.className).toContain('tabular');
+    });
+
+    it('omits tabular figures when tabularNums is false', () => {
+      const { container } = render(<Amount value={1299} tabularNums={false} />);
+      const span = container.querySelector('span');
+      expect(span?.className).not.toContain('tabular');
+    });
+
+    it('keeps custom className alongside the tabular class', () => {
+      const { container } = render(
+        <Amount value={1299} className='custom-class' />
+      );
+      const span = container.querySelector('span');
+      expect(span?.className).toContain('custom-class');
+      expect(span?.className).toContain('tabular');
+    });
+  });
 });

--- a/packages/raystack/components/amount/amount.module.css
+++ b/packages/raystack/components/amount/amount.module.css
@@ -1,3 +1,3 @@
-.amount {
+.tabular {
   font-variant-numeric: tabular-nums;
 }

--- a/packages/raystack/components/amount/amount.tsx
+++ b/packages/raystack/components/amount/amount.tsx
@@ -139,6 +139,11 @@ interface CurrencyInfo {
   decimals: number;
 }
 
+/**
+ * Sized to hold every valid ISO 4217 code (~180) without eviction;
+ * the cap only guards against unbounded growth from invalid inputs.
+ */
+const CURRENCY_INFO_CACHE_LIMIT = 256;
 const currencyInfoCache = new Map<string, CurrencyInfo>();
 
 /**
@@ -159,6 +164,9 @@ function getCurrencyInfo(currency: string): CurrencyInfo {
       };
     } catch {
       info = { valid: false, decimals: 2 };
+    }
+    if (currencyInfoCache.size >= CURRENCY_INFO_CACHE_LIMIT) {
+      currencyInfoCache.clear();
     }
     currencyInfoCache.set(code, info);
   }

--- a/packages/raystack/components/amount/amount.tsx
+++ b/packages/raystack/components/amount/amount.tsx
@@ -52,9 +52,27 @@ export interface AmountProps extends ComponentProps<'span'> {
   /**
    * Currency display format
    * @default 'symbol'
-   * @example 'symbol' - $12.99, 'code' - USD 12.99, 'name' - 12.99 US Dollars
+   * @example 'symbol' - $12.99 (may show "US$" in non-US locales), 'narrowSymbol' - $12.99 (always the narrow symbol), 'code' - USD 12.99, 'name' - 12.99 US Dollars
    */
-  currencyDisplay?: 'symbol' | 'code' | 'name';
+  currencyDisplay?: 'symbol' | 'narrowSymbol' | 'code' | 'name';
+
+  /**
+   * Number formatting notation.
+   * 'compact' abbreviates large values — useful for dashboards and summary views.
+   * Compact rounds aggressively by design; avoid it when the value must render exactly.
+   * @default 'standard'
+   * @example
+   * 'standard' - $1,200,000.00, 'compact' - $1.2M
+   */
+  notation?: 'standard' | 'compact';
+
+  /**
+   * When to show the +/- sign — useful for gains/losses.
+   * @default 'auto'
+   * @example
+   * 'auto' - -$12.99, 'always' - +$12.99, 'exceptZero' - +$12.99 but $0.00, 'never' - $12.99
+   */
+  signDisplay?: 'auto' | 'always' | 'exceptZero' | 'never';
 
   /**
    * Number of minimum fraction digits
@@ -83,41 +101,68 @@ export interface AmountProps extends ComponentProps<'span'> {
    * <Amount value={1299} hideCurrency /> => "12.99"
    */
   hideCurrency?: boolean;
+
+  /**
+   * Use fixed-width (tabular) figures so digits align vertically across rows —
+   * ideal for tables and lists of amounts. Set to false in running text,
+   * where proportional figures look more natural.
+   * @default true
+   */
+  tabularNums?: boolean;
 }
 
 /**
- * Get the number of decimal places for a currency
+ * Intl.NumberFormat construction is expensive, and Amount often renders
+ * hundreds of times in a table. Cache instances module-wide, keyed by
+ * locale + options. The cap guards against unbounded growth when
+ * locales/currencies are dynamic.
  */
-function getCurrencyDecimals(currency: string): number {
-  try {
-    const formatter = new Intl.NumberFormat('en', {
-      style: 'currency',
-      currency: currency.toUpperCase()
-    });
+const FORMATTER_CACHE_LIMIT = 64;
+const formatterCache = new Map<string, Intl.NumberFormat>();
 
-    // Format a number and count the decimal places
-    const formatted = formatter.format(1); // Get string representation of 1 unit with currency symbol
-    const match = formatted.match(/\.([\d]+)/); // Extract the decimal part
-    return match ? match[1].length : 0;
-  } catch {
-    // Default to 2 decimal places
-    return 2;
+function getFormatter(
+  locale: string,
+  options: Intl.NumberFormatOptions
+): Intl.NumberFormat {
+  const key = `${locale}|${JSON.stringify(options)}`;
+  let formatter = formatterCache.get(key);
+  if (!formatter) {
+    formatter = new Intl.NumberFormat(locale, options);
+    if (formatterCache.size >= FORMATTER_CACHE_LIMIT) formatterCache.clear();
+    formatterCache.set(key, formatter);
   }
+  return formatter;
 }
 
+interface CurrencyInfo {
+  valid: boolean;
+  decimals: number;
+}
+
+const currencyInfoCache = new Map<string, CurrencyInfo>();
+
 /**
- * Check if a currency is valid
+ * Resolve a currency's validity and decimal places in one cached lookup.
  */
-function isValidCurrency(currency: string): boolean {
-  try {
-    new Intl.NumberFormat('en', {
-      style: 'currency',
-      currency: currency.toUpperCase()
-    });
-    return true;
-  } catch {
-    return false;
+function getCurrencyInfo(currency: string): CurrencyInfo {
+  const code = currency.toUpperCase();
+  let info = currencyInfoCache.get(code);
+  if (!info) {
+    try {
+      const formatter = getFormatter('en', {
+        style: 'currency',
+        currency: code
+      });
+      info = {
+        valid: true,
+        decimals: formatter.resolvedOptions().maximumFractionDigits ?? 2
+      };
+    } catch {
+      info = { valid: false, decimals: 2 };
+    }
+    currencyInfoCache.set(code, info);
   }
+  return info;
 }
 
 /**
@@ -152,9 +197,14 @@ function isValidCurrency(currency: string): boolean {
  *   Amount: <Amount value={12.99} valueInMinorUnits={false} />  // Shows as "$12.99"
  * </Text>
  *
- * // With groupDigits (default is true)
+ * // Compact notation for dashboards
  * <Text>
- *   Amount: <Amount value={129999999} groupDigits />  // Shows as "$129,999,999.99"
+ *   Revenue: <Amount value={120000000} notation="compact" />  // Shows as "$1.2M"
+ * </Text>
+ *
+ * // Signed amounts for gains/losses
+ * <Text>
+ *   Change: <Amount value={1299} signDisplay="always" />  // Shows as "+$12.99"
  * </Text>
  * ```
  */
@@ -164,11 +214,14 @@ export const Amount = ({
   locale = 'en-US',
   hideDecimals = false,
   currencyDisplay = 'symbol',
+  notation = 'standard',
+  signDisplay = 'auto',
   minimumFractionDigits,
   maximumFractionDigits,
   groupDigits = true,
   valueInMinorUnits = true,
   hideCurrency = false,
+  tabularNums = true,
   className,
   ...props
 }: AmountProps) => {
@@ -183,12 +236,15 @@ export const Amount = ({
       );
     }
 
-    const validCurrency = isValidCurrency(currency) ? currency : 'USD';
-    if (validCurrency !== currency) {
+    const currencyInfo = getCurrencyInfo(currency);
+    const validCurrency = currencyInfo.valid ? currency : 'USD';
+    if (!currencyInfo.valid) {
       console.warn(`Invalid currency code: ${currency}. Falling back to USD.`);
     }
 
-    const decimals = getCurrencyDecimals(validCurrency);
+    const decimals = currencyInfo.valid
+      ? currencyInfo.decimals
+      : getCurrencyInfo('USD').decimals;
 
     /**
      * Convert minor → major units.
@@ -240,12 +296,14 @@ export const Amount = ({
       style: 'currency',
       currency: validCurrency.toUpperCase(),
       currencyDisplay,
+      notation,
+      signDisplay,
       minimumFractionDigits: hideDecimals ? 0 : minimumFractionDigits,
       maximumFractionDigits: hideDecimals ? 0 : maximumFractionDigits,
       useGrouping: groupDigits
     };
 
-    const formatter = new Intl.NumberFormat(locale, formatOptions);
+    const formatter = getFormatter(locale, formatOptions);
 
     /**
      * For hideCurrency, strip the `currency` parts and trim leading/trailing
@@ -269,14 +327,14 @@ export const Amount = ({
         );
 
     return (
-      <span {...props} className={cx(styles.amount, className)}>
+      <span {...props} className={cx(tabularNums && styles.tabular, className)}>
         {formattedValue}
       </span>
     );
   } catch (error) {
     console.error('Error formatting amount:', error);
     return (
-      <span {...props} className={cx(styles.amount, className)}>
+      <span {...props} className={cx(tabularNums && styles.tabular, className)}>
         {String(value)}
       </span>
     );


### PR DESCRIPTION
## Summary

Implements the remaining items from #595, plus a `tabularNums` prop.

### New props
- **`notation`** (`'standard' | 'compact'`, default `'standard'`) — compact formatting like `$1.2M` / `$13K` for dashboards and summary views. Note: compact rounds aggressively by design (Intl behavior), so small values like `$12.99` render as `$13`.
- **`currencyDisplay: 'narrowSymbol'`** — always shows the narrow symbol (`$` instead of `US$` in non-US locales).
- **`signDisplay`** (`'auto' | 'always' | 'exceptZero' | 'never'`, default `'auto'`) — controls the `+`/`-` sign, useful for gains/losses.
- **`tabularNums`** (default `true`) — fixed-width figures so digits align across table rows. Previously this was always on via CSS; it is now a prop so running text can opt out for proportional figures. Default behavior is unchanged.

### Performance
- `Intl.NumberFormat` instances are now memoized in a module-level cache (keyed by locale + options, capped at 64 entries). Previously every render created 3 formatter instances, which adds up fast when Amount renders in table rows.
- `isValidCurrency()` and `getCurrencyDecimals()` are merged into a single cached `getCurrencyInfo()` lookup. Decimals now come from `resolvedOptions().maximumFractionDigits` instead of regex-matching formatted output.

### Not included
- Issue item 6 (string slicing edge case) is already fixed on main — the `padStart` conversion handles short strings correctly (`"5"` → `$0.05`).

### Docs
- Playground controls for the new props, plus `notation`, `signDisplay`, and `tabularNums` example sections.

## Test plan
- 15 new test cases covering all four props and their interactions (compact + hideDecimals / string values / hideCurrency / explicit fraction digits; sign preserved when hideCurrency strips the currency token; tabular class toggling).
- Full Amount suite: 64/64 passing. Lint and typecheck clean for the touched files.

Closes #595