### PR TITLE
feat(ci): add pkg.pr.new canary releases

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -1,0 +1,41 @@
+name: Canary Release
+
+# Publishes a preview build of @raystack/apsara to pkg.pr.new on every push
+# to a pull request or to main, so changes can be installed and tested
+# before a real npm release. See https://pkg.pr.new
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Publish to pkg.pr.new
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm 9
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.3.0
+
+      - name: Setup Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: "pnpm"
+
+      - name: Install Dependencies 🔧
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Step 🔧
+        run: pnpm build:apsara
+
+      - name: Publish 🚀
+        run: pnpm exec pkg-pr-new publish ./packages/raystack --comment=update

--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -5,7 +5,6 @@ name: Canary Release
 # before a real npm release. See https://pkg.pr.new
 on:
   pull_request:
-    branches: [main]
   push:
     branches: [main]
 
@@ -46,4 +45,4 @@ jobs:
         run: pnpm build:apsara
 
       - name: Publish 🚀
-        run: pnpm exec pkg-pr-new publish ./packages/raystack --comment=update
+        run: pnpm exec pkg-pr-new publish ./packages/raystack --previewVersion --packageManager=pnpm --comment=update

--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -11,6 +11,12 @@ on:
 
 permissions: {}
 
+# --comment=update edits a single comment per PR; cancel superseded runs so a
+# stale run can't finish after a newer one and leave outdated info behind.
+concurrency:
+  group: canary-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     name: Publish to pkg.pr.new
@@ -19,6 +25,8 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm 9
         uses: pnpm/action-setup@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -282,7 +282,7 @@ Every pull request gets a preview build of `@raystack/apsara`, so you can try ou
 The [`canary.yaml`](.github/workflows/canary.yaml) workflow builds the package and publishes it to [pkg.pr.new](https://pkg.pr.new) on every push to a PR or to `main`. pkg.pr.new then comments on the PR with an install command, for example:
 
 ```bash
-npm i https://pkg.pr.new/raystack/apsara/@raystack/apsara@<pr-number>
+pnpm add https://pkg.pr.new/raystack/apsara/@raystack/apsara@<pr-number>
 ```
 
 Install that in a test project to check out the change. The preview build updates automatically as new commits are pushed to the same PR.
@@ -290,7 +290,7 @@ Install that in a test project to check out the change. The preview build update
 Pushes to `main` are published the same way but don't have a PR to comment on. Install those directly using the commit SHA:
 
 ```bash
-npm i https://pkg.pr.new/raystack/apsara/@raystack/apsara@<commit-sha>
+pnpm add https://pkg.pr.new/raystack/apsara/@raystack/apsara@<commit-sha>
 ```
 
 ## Getting Help

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ Thank you for your interest in contributing to Apsara! This guide will help you 
       - [For Maintainers](#for-maintainers)
     - [Release Workflow Details](#release-workflow-details)
     - [NPM Publishing](#npm-publishing)
+    - [Canary Releases](#canary-releases)
   - [Getting Help](#getting-help)
   - [Code of Conduct](#code-of-conduct)
 
@@ -213,6 +214,11 @@ Apsara follows an automated release process using GitHub Actions and semantic ve
    - Published to NPM with `next` tag
    - Triggered by pushing tags matching `v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+`
 
+3. **Canary Releases**:
+   - Built automatically for every pull request and every push to `main`
+   - Not published to NPM — hosted by [pkg.pr.new](https://pkg.pr.new) instead
+   - No tag or version bump needed
+
 ### Creating a Release
 
 #### For Maintainers
@@ -268,6 +274,18 @@ npm install @raystack/apsara
 # or
 pnpm add @raystack/apsara
 ```
+
+### Canary Releases
+
+Every pull request gets a preview build of `@raystack/apsara`, so you can try out changes before they're merged or released — no need to wait for a real NPM publish.
+
+The [`canary.yaml`](.github/workflows/canary.yaml) workflow builds the package and publishes it to [pkg.pr.new](https://pkg.pr.new) on every push to a PR or to `main`. pkg.pr.new then comments on the PR with an install command, for example:
+
+```bash
+pnpm add https://pkg.pr.new/@raystack/apsara@<commit-sha>
+```
+
+Install that in a test project to check out the change. The preview build updates automatically as new commits are pushed to the same PR.
 
 ## Getting Help
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -282,10 +282,16 @@ Every pull request gets a preview build of `@raystack/apsara`, so you can try ou
 The [`canary.yaml`](.github/workflows/canary.yaml) workflow builds the package and publishes it to [pkg.pr.new](https://pkg.pr.new) on every push to a PR or to `main`. pkg.pr.new then comments on the PR with an install command, for example:
 
 ```bash
-pnpm add https://pkg.pr.new/@raystack/apsara@<commit-sha>
+npm i https://pkg.pr.new/raystack/apsara/@raystack/apsara@<pr-number>
 ```
 
 Install that in a test project to check out the change. The preview build updates automatically as new commits are pushed to the same PR.
+
+Pushes to `main` are published the same way but don't have a PR to comment on. Install those directly using the commit SHA:
+
+```bash
+npm i https://pkg.pr.new/raystack/apsara/@raystack/apsara@<commit-sha>
+```
 
 ## Getting Help
 

--- a/apps/www/src/content/docs/(overview)/getting-started.mdx
+++ b/apps/www/src/content/docs/(overview)/getting-started.mdx
@@ -25,7 +25,7 @@ Install the package using your preferred package manager:
 Every pull request on [GitHub](https://github.com/raystack/apsara) gets a canary build, published automatically via [pkg.pr.new](https://pkg.pr.new). This lets you try out unreleased changes before they ship to npm. The PR will have a comment with an install command, for example:
 
 ```bash
-pnpm add https://pkg.pr.new/@raystack/apsara@<commit-sha>
+npm i https://pkg.pr.new/raystack/apsara/@raystack/apsara@<pr-number>
 ```
 
 ## Setup

--- a/apps/www/src/content/docs/(overview)/getting-started.mdx
+++ b/apps/www/src/content/docs/(overview)/getting-started.mdx
@@ -20,6 +20,14 @@ Install the package using your preferred package manager:
 @raystack/apsara
 ```
 
+### Try a preview build
+
+Every pull request on [GitHub](https://github.com/raystack/apsara) gets a canary build, published automatically via [pkg.pr.new](https://pkg.pr.new). This lets you try out unreleased changes before they ship to npm. The PR will have a comment with an install command, for example:
+
+```bash
+pnpm add https://pkg.pr.new/@raystack/apsara@<commit-sha>
+```
+
 ## Setup
 
 ### 1. Import styles

--- a/apps/www/src/content/docs/(overview)/getting-started.mdx
+++ b/apps/www/src/content/docs/(overview)/getting-started.mdx
@@ -25,7 +25,7 @@ Install the package using your preferred package manager:
 Every pull request on [GitHub](https://github.com/raystack/apsara) gets a canary build, published automatically via [pkg.pr.new](https://pkg.pr.new). This lets you try out unreleased changes before they ship to npm. The PR will have a comment with an install command, for example:
 
 ```bash
-npm i https://pkg.pr.new/raystack/apsara/@raystack/apsara@<pr-number>
+pnpm add https://pkg.pr.new/raystack/apsara/@raystack/apsara@<pr-number>
 ```
 
 ## Setup

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@turbo/gen": "^1.9.7",
     "concurrently": "^9.1.2",
     "lefthook": "^1.11.12",
+    "pkg-pr-new": "^0.0.86",
     "process": "^0.11.10",
     "turbo": "2.3.1",
     "typescript": "4.7"

--- a/packages/raystack/README.md
+++ b/packages/raystack/README.md
@@ -3,6 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/@raystack/apsara?logo=npm&color=cb3837)](https://www.npmjs.com/package/@raystack/apsara)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg?logo=apache)](LICENSE)
 [![Biome](https://img.shields.io/badge/Biome-60a5fa?logo=biome&logoColor=white)](https://biomejs.dev/)
+[![pkg.pr.new](https://pkg.pr.new/badge/raystack/apsara)](https://pkg.pr.new/~/raystack/apsara)
 
 Apsara is an open-source React component library for building accessible, data-heavy interfaces. It is built on [Base UI](https://base-ui.com/) primitives and written in TypeScript.
 

--- a/packages/raystack/package.json
+++ b/packages/raystack/package.json
@@ -79,6 +79,11 @@
   ],
   "author": "",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/raystack/apsara.git",
+    "directory": "packages/raystack"
+  },
   "devDependencies": {
     "@figma/code-connect": "^1.4.7",
     "@raystack/tools-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       lefthook:
         specifier: ^1.11.12
         version: 1.11.12
+      pkg-pr-new:
+        specifier: ^0.0.86
+        version: 0.0.86
       process:
         specifier: ^0.11.10
         version: 0.11.10
@@ -6396,6 +6399,10 @@ packages:
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
+
+  pkg-pr-new@0.0.86:
+    resolution: {integrity: sha512-BwPsw/e1Be7F0SfpxhNc2VSxX7uHgCy46Ck+2Z/vqCwXoePhUBrX/VbcawpAlZgMvQe2iwGbZIQ6HSj9bmCk8A==}
+    hasBin: true
 
   pluralize@2.0.0:
     resolution: {integrity: sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==}
@@ -15115,6 +15122,8 @@ snapshots:
   pify@5.0.0: {}
 
   pirates@4.0.6: {}
+
+  pkg-pr-new@0.0.86: {}
 
   pluralize@2.0.0: {}
 


### PR DESCRIPTION
## Summary
- Add `.github/workflows/canary.yaml` to publish a preview build of `@raystack/apsara` to [pkg.pr.new](https://pkg.pr.new) on every PR and push to `main`, so changes can be installed and tested before a real npm release
- Document the canary workflow in `CONTRIBUTING.md`
- Add a "Try a preview build" section to the Getting Started docs

## Test plan
- [ ] Merge and confirm the workflow runs on the next PR
- [ ] Confirm pkg.pr.new comments on the PR with an install link
- [ ] Install the preview build in a test project and verify it works