### PR TITLE
fix: interface polish — text-wrap, tabular numbers, concentric radius

### DIFF
--- a/packages/raystack/components/accordion/accordion.module.css
+++ b/packages/raystack/components/accordion/accordion.module.css
@@ -90,7 +90,7 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .accordion-icon {
-    transition: transform var(--rs-duration-fast) var(--rs-ease-in-out);
+    transition: transform var(--rs-duration-fast) var(--rs-ease-out);
   }
 
   .accordion-content {

--- a/packages/raystack/components/callout/callout.module.css
+++ b/packages/raystack/components/callout/callout.module.css
@@ -46,6 +46,7 @@
   flex-shrink: 1;
   min-width: 0;
   overflow-wrap: break-word;
+  text-wrap: pretty;
 }
 
 .actionsContainer {

--- a/packages/raystack/components/chat/chat.module.css
+++ b/packages/raystack/components/chat/chat.module.css
@@ -49,6 +49,7 @@
 .item {
   flex-shrink: 0;
   min-width: 0;
+  text-wrap: pretty;
   content-visibility: auto;
   contain-intrinsic-size: auto 10rem;
 }
@@ -185,7 +186,7 @@
   flex-shrink: 0;
   width: var(--rs-space-9);
   height: var(--rs-space-9);
-  border-radius: var(--rs-radius-2);
+  border-radius: var(--rs-radius-1);
   background: var(--rs-color-background-neutral-secondary);
   color: var(--rs-color-foreground-base-secondary);
   overflow: hidden;

--- a/packages/raystack/components/chip/chip.module.css
+++ b/packages/raystack/components/chip/chip.module.css
@@ -151,7 +151,8 @@
   border-radius: var(--rs-radius-1);
 }
 
-.dismiss-button:active {
+.dismiss-button:active,
+.chip-interactive:active {
   transform: scale(var(--rs-scale-pressed-strong));
 }
 

--- a/packages/raystack/components/combobox/combobox.module.css
+++ b/packages/raystack/components/combobox/combobox.module.css
@@ -62,7 +62,7 @@
   color: var(--rs-color-foreground-base-primary);
   white-space: normal;
   word-break: break-word;
-  border-radius: var(--rs-radius-2);
+  border-radius: var(--rs-radius-1);
 }
 
 .menuitem[data-highlighted] {

--- a/packages/raystack/components/command/command.module.css
+++ b/packages/raystack/components/command/command.module.css
@@ -124,6 +124,7 @@
 .empty {
   padding: var(--rs-space-7) var(--rs-space-3);
   text-align: center;
+  text-wrap: pretty;
   font-family: var(--rs-font-body);
   font-size: var(--rs-font-size-small);
   line-height: var(--rs-line-height-small);

--- a/packages/raystack/components/dialog/dialog.module.css
+++ b/packages/raystack/components/dialog/dialog.module.css
@@ -117,6 +117,7 @@
   font-weight: var(--rs-font-weight-regular);
   line-height: var(--rs-line-height-small);
   letter-spacing: var(--rs-letter-spacing-small);
+  text-wrap: pretty;
   margin: 0;
 }
 

--- a/packages/raystack/components/drawer/drawer.module.css
+++ b/packages/raystack/components/drawer/drawer.module.css
@@ -166,6 +166,7 @@
   line-height: var(--rs-line-height-regular);
   letter-spacing: var(--rs-letter-spacing-regular);
   color: var(--rs-color-foreground-base-secondary);
+  text-wrap: pretty;
 }
 
 .body {

--- a/packages/raystack/components/field/field.module.css
+++ b/packages/raystack/components/field/field.module.css
@@ -16,6 +16,7 @@
   font-size: var(--rs-font-size-mini);
   line-height: var(--rs-line-height-mini);
   letter-spacing: var(--rs-letter-spacing-mini);
+  text-wrap: pretty;
   margin: 0;
 }
 
@@ -25,6 +26,7 @@
   font-size: var(--rs-font-size-mini);
   line-height: var(--rs-line-height-mini);
   letter-spacing: var(--rs-letter-spacing-mini);
+  text-wrap: pretty;
   margin: 0;
 }
 

--- a/packages/raystack/components/headline/headline.module.css
+++ b/packages/raystack/components/headline/headline.module.css
@@ -5,6 +5,7 @@
   font-family: var(--rs-font-title);
   font-weight: var(--rs-font-weight-regular);
   color: var(--rs-color-foreground-base-primary);
+  text-wrap: balance;
 }
 
 .headline-t1 {

--- a/packages/raystack/components/indicator/indicator.module.css
+++ b/packages/raystack/components/indicator/indicator.module.css
@@ -11,6 +11,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  font-variant-numeric: tabular-nums;
   border-radius: var(--rs-radius-full);
   white-space: nowrap;
   font-weight: var(--rs-font-weight-regular);

--- a/packages/raystack/components/menu/menu.module.css
+++ b/packages/raystack/components/menu/menu.module.css
@@ -94,6 +94,7 @@
   justify-content: center;
   padding: var(--rs-space-4);
   text-align: center;
+  text-wrap: pretty;
 }
 
 .menuBarTrigger[data-pressed] {

--- a/packages/raystack/components/message/message.module.css
+++ b/packages/raystack/components/message/message.module.css
@@ -138,6 +138,7 @@
      inside it the bubble just fills what the text needs. */
   max-width: 100%;
   min-width: 0;
+  text-wrap: pretty;
   padding: var(--rs-space-3) var(--rs-space-4);
   border-radius: var(--rs-radius-5);
   font-size: var(--rs-font-size-small);

--- a/packages/raystack/components/meter/meter.module.css
+++ b/packages/raystack/components/meter/meter.module.css
@@ -21,6 +21,7 @@
   line-height: var(--rs-line-height-mini);
   letter-spacing: var(--rs-letter-spacing-mini);
   color: var(--rs-color-foreground-base-primary);
+  font-variant-numeric: tabular-nums;
   text-align: right;
 }
 

--- a/packages/raystack/components/progress/progress.module.css
+++ b/packages/raystack/components/progress/progress.module.css
@@ -21,6 +21,7 @@
   line-height: var(--rs-line-height-mini);
   letter-spacing: var(--rs-letter-spacing-mini);
   color: var(--rs-color-foreground-base-primary);
+  font-variant-numeric: tabular-nums;
   text-align: right;
 }
 

--- a/packages/raystack/components/reasoning/reasoning.module.css
+++ b/packages/raystack/components/reasoning/reasoning.module.css
@@ -96,6 +96,7 @@
   flex-direction: column;
   gap: var(--rs-space-3);
   padding-top: var(--rs-space-3);
+  text-wrap: pretty;
 }
 
 .reasoning-step {

--- a/packages/raystack/components/select/select.module.css
+++ b/packages/raystack/components/select/select.module.css
@@ -47,7 +47,7 @@
   color: var(--rs-color-foreground-base-primary);
   white-space: normal;
   word-break: break-word;
-  border-radius: var(--rs-radius-2);
+  border-radius: var(--rs-radius-1);
 }
 
 .menuitem[data-highlighted] {

--- a/packages/raystack/components/switch/switch.module.css
+++ b/packages/raystack/components/switch/switch.module.css
@@ -56,7 +56,6 @@
   background: var(--rs-color-foreground-base-emphasis);
   border-radius: var(--rs-radius-full);
   transform: translateX(var(--rs-space-1));
-  will-change: transform;
 }
 
 @media (prefers-reduced-motion: no-preference) {

--- a/packages/raystack/components/text/text.module.css
+++ b/packages/raystack/components/text/text.module.css
@@ -1,6 +1,7 @@
 .text {
   margin: 0;
   color: var(--rs-color-foreground-base-primary);
+  text-wrap: pretty;
 }
 
 /* Text Size */

--- a/packages/raystack/components/toast/toast.module.css
+++ b/packages/raystack/components/toast/toast.module.css
@@ -288,6 +288,7 @@
 /* ===== Description ===== */
 .description {
   color: var(--rs-color-foreground-base-primary);
+  text-wrap: pretty;
   font-size: var(--rs-font-size-small);
   font-weight: var(--rs-font-weight-regular);
   line-height: var(--rs-line-height-small);

--- a/packages/raystack/components/toggle/toggle.module.css
+++ b/packages/raystack/components/toggle/toggle.module.css
@@ -9,7 +9,7 @@
   transition: color var(--rs-duration-normal) var(--rs-ease-out);
   background-color: var(--rs-color-background-base-secondary);
   border: 0.5px solid var(--rs-color-border-base-primary);
-  border-radius: var(--rs-radius-1);
+  border-radius: var(--rs-radius-2);
 }
 .toggleContent {
   border-radius: var(--rs-radius-1);

--- a/packages/raystack/components/toolbar/toolbar.module.css
+++ b/packages/raystack/components/toolbar/toolbar.module.css
@@ -1,7 +1,7 @@
 .root {
   padding: var(--rs-space-1);
   border: 0.5px solid var(--rs-color-border-base-primary);
-  border-radius: var(--rs-radius-2);
+  border-radius: var(--rs-radius-3);
   overflow: clip;
 }
 .root,

--- a/packages/raystack/components/tooltip/tooltip.module.css
+++ b/packages/raystack/components/tooltip/tooltip.module.css
@@ -17,6 +17,7 @@
   letter-spacing: var(--rs-letter-spacing-mini);
   width: fit-content;
   max-width: 400px;
+  text-wrap: pretty;
   transition: opacity var(--rs-duration-fast) var(--rs-ease-out);
 }
 

--- a/packages/raystack/components/tour/tour-parts.tsx
+++ b/packages/raystack/components/tour/tour-parts.tsx
@@ -64,6 +64,7 @@ export function TourProgress({ format, ...props }: TourProgressProps) {
       size='mini'
       weight='medium'
       variant='secondary'
+      style={{ fontVariantNumeric: 'tabular-nums' }}
       {...props}
     >
       {format ? format(index, steps.length) : `${index + 1} of ${steps.length}`}

--- a/packages/raystack/components/tour/tour.module.css
+++ b/packages/raystack/components/tour/tour.module.css
@@ -188,6 +188,7 @@
   line-height: var(--rs-line-height-small);
   letter-spacing: var(--rs-letter-spacing-small);
   color: var(--rs-color-foreground-base-secondary);
+  text-wrap: pretty;
 }
 
 .footer {


### PR DESCRIPTION
Small interface-polish fixes across the design system, from a full `/make-interfaces-feel-better` sweep of all 76 components. Every change stays in the existing `--rs-*` token system. No new styling approach, no API changes.

Hit-area findings (the one HIGH systemic issue — small `IconButton` close/dismiss targets) are **left out on purpose** and tracked as a follow-up.

## Changes

**Text wrapping**
- `text-wrap: pretty` on body copy: tooltip, callout, toast, chat item, message bubble, command/menu empty states, dialog/drawer/tour descriptions, field description + error, reasoning body, and the base `Text` primitive.
- `text-wrap: balance` on the `Headline` class so it holds when `render` swaps the tag (global `balance` only lands on real `h1`–`h4`).

**Tabular numbers**
- `font-variant-numeric: tabular-nums` on live numbers: meter value, progress value, indicator badge, tour step counter. Stops horizontal jitter as digit widths change.

**Concentric radius** (outer = inner + padding)
- toggle `radius-1`→`radius-2`, toolbar `radius-2`→`radius-3`, select/combobox menu items `radius-2`→`radius-1`, chat attachment thumb `radius-2`→`radius-1`.

**Animations**
- Accordion chevron now shares the panel's `ease-out` curve so they move as one.
- Interactive chips get the `--rs-scale-pressed-strong` press feedback their dismiss button already had (a chip is interactive *or* dismissible, never both).

**Performance**
- Dropped the always-on `will-change: transform` from the switch thumb.

## Verification
Biome clean (pre-commit passed). Changes are additive one-liners in the token system. Not driven in a browser — reviewer should confirm meter/progress digit stability and the accordion chevron/panel timing in the Animations panel.