### PR TITLE
feat(kbd): add Kbd component, remove Command.Shortcut

### DIFF
--- a/apps/www/src/content/docs/components/command/demo.ts
+++ b/apps/www/src/content/docs/components/command/demo.ts
@@ -27,26 +27,14 @@ export const preview = {
                 <Command.Label>Actions</Command.Label>
                 <Command.Item
                   leadingIcon={<TransformIcon />}
-                  trailingIcon={
-                    <Kbd.Group variant="ghost">
-                      <Kbd aria-label="Command">⌘</Kbd>
-                      <Kbd aria-label="Shift">⇧</Kbd>
-                      <Kbd>A</Kbd>
-                    </Kbd.Group>
-                  }
+                  trailingIcon={<Command.Shortcut>⌘ ⇧ A</Command.Shortcut>}
                   onClick={() => setOpen(false)}
                 >
                   Create AOI...
                 </Command.Item>
                 <Command.Item
                   leadingIcon={<Share2Icon />}
-                  trailingIcon={
-                    <Kbd.Group variant="ghost">
-                      <Kbd aria-label="Command">⌘</Kbd>
-                      <Kbd aria-label="Shift">⇧</Kbd>
-                      <Kbd>W</Kbd>
-                    </Kbd.Group>
-                  }
+                  trailingIcon={<Command.Shortcut>⌘ ⇧ W</Command.Shortcut>}
                   onClick={() => setOpen(false)}
                   disabled
                 >
@@ -149,34 +137,19 @@ export const shortcutDemo = {
               <Command.Group>
                 <Command.Label>Suggestions</Command.Label>
                 <Command.Item
-                  trailingIcon={
-                    <Kbd.Group variant="ghost">
-                      <Kbd aria-label="Command">⌘</Kbd>
-                      <Kbd>P</Kbd>
-                    </Kbd.Group>
-                  }
+                  trailingIcon={<Command.Shortcut>⌘ P</Command.Shortcut>}
                   onClick={() => setOpen(false)}
                 >
                   Profile
                 </Command.Item>
                 <Command.Item
-                  trailingIcon={
-                    <Kbd.Group variant="ghost">
-                      <Kbd aria-label="Command">⌘</Kbd>
-                      <Kbd>B</Kbd>
-                    </Kbd.Group>
-                  }
+                  trailingIcon={<Command.Shortcut>⌘ B</Command.Shortcut>}
                   onClick={() => setOpen(false)}
                 >
                   Billing
                 </Command.Item>
                 <Command.Item
-                  trailingIcon={
-                    <Kbd.Group variant="ghost">
-                      <Kbd aria-label="Command">⌘</Kbd>
-                      <Kbd>S</Kbd>
-                    </Kbd.Group>
-                  }
+                  trailingIcon={<Command.Shortcut>⌘ S</Command.Shortcut>}
                   onClick={() => setOpen(false)}
                 >
                   Settings

--- a/apps/www/src/content/docs/components/command/demo.ts
+++ b/apps/www/src/content/docs/components/command/demo.ts
@@ -27,14 +27,26 @@ export const preview = {
                 <Command.Label>Actions</Command.Label>
                 <Command.Item
                   leadingIcon={<TransformIcon />}
-                  trailingIcon={<Command.Shortcut>⌘ ⇧ A</Command.Shortcut>}
+                  trailingIcon={
+                    <Kbd.Group variant="ghost">
+                      <Kbd aria-label="Command">⌘</Kbd>
+                      <Kbd aria-label="Shift">⇧</Kbd>
+                      <Kbd>A</Kbd>
+                    </Kbd.Group>
+                  }
                   onClick={() => setOpen(false)}
                 >
                   Create AOI...
                 </Command.Item>
                 <Command.Item
                   leadingIcon={<Share2Icon />}
-                  trailingIcon={<Command.Shortcut>⌘ ⇧ W</Command.Shortcut>}
+                  trailingIcon={
+                    <Kbd.Group variant="ghost">
+                      <Kbd aria-label="Command">⌘</Kbd>
+                      <Kbd aria-label="Shift">⇧</Kbd>
+                      <Kbd>W</Kbd>
+                    </Kbd.Group>
+                  }
                   onClick={() => setOpen(false)}
                   disabled
                 >
@@ -137,19 +149,34 @@ export const shortcutDemo = {
               <Command.Group>
                 <Command.Label>Suggestions</Command.Label>
                 <Command.Item
-                  trailingIcon={<Command.Shortcut>⌘ P</Command.Shortcut>}
+                  trailingIcon={
+                    <Kbd.Group variant="ghost">
+                      <Kbd aria-label="Command">⌘</Kbd>
+                      <Kbd>P</Kbd>
+                    </Kbd.Group>
+                  }
                   onClick={() => setOpen(false)}
                 >
                   Profile
                 </Command.Item>
                 <Command.Item
-                  trailingIcon={<Command.Shortcut>⌘ B</Command.Shortcut>}
+                  trailingIcon={
+                    <Kbd.Group variant="ghost">
+                      <Kbd aria-label="Command">⌘</Kbd>
+                      <Kbd>B</Kbd>
+                    </Kbd.Group>
+                  }
                   onClick={() => setOpen(false)}
                 >
                   Billing
                 </Command.Item>
                 <Command.Item
-                  trailingIcon={<Command.Shortcut>⌘ S</Command.Shortcut>}
+                  trailingIcon={
+                    <Kbd.Group variant="ghost">
+                      <Kbd aria-label="Command">⌘</Kbd>
+                      <Kbd>S</Kbd>
+                    </Kbd.Group>
+                  }
                   onClick={() => setOpen(false)}
                 >
                   Settings

--- a/apps/www/src/content/docs/components/command/index.mdx
+++ b/apps/www/src/content/docs/components/command/index.mdx
@@ -73,7 +73,7 @@ Rendered when no items are visible (all filtered out, or the list is empty). Aut
 
 ### Item
 
-A selectable entry. When `value` is omitted and `children` is a string, the string is used as the value. `onClick` fires on pointer click **and** on keyboard `Enter` when the item is highlighted. Pass a [`Kbd`](/docs/components/kbd) as `trailingIcon` to show a keyboard hint — use the `ghost` variant so the keys sit on the item's own background.
+A selectable entry. When `value` is omitted and `children` is a string, the string is used as the value. `onClick` fires on pointer click **and** on keyboard `Enter` when the item is highlighted.
 
 <auto-type-table path="./props.ts" name="CommandItemProps" />
 
@@ -94,6 +94,12 @@ Renders a label inside `Command.Group`. The label is hidden automatically while 
 Visual divider between groups. The separator is hidden automatically while the user is searching.
 
 <auto-type-table path="./props.ts" name="CommandSeparatorProps" />
+
+### Shortcut
+
+A `<kbd>` element for keyboard hints. Typically passed as `trailingIcon` on `Command.Item`.
+
+<auto-type-table path="./props.ts" name="CommandShortcutProps" />
 
 ### Dialog
 
@@ -125,6 +131,8 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `command-item-label` | The item's label text |
 | `command-item-trailing-icon` | Trailing icon inside an item (when provided) |
 | `command-separator` | `Command.Separator` |
+| `command-shortcut` | `Command.Shortcut` wrapper |
+| `command-shortcut-key` | Each `<kbd>` key inside a shortcut |
 | `command-dialog-trigger` | `Command.DialogTrigger` |
 | `command-dialog-viewport` | Viewport wrapper for the dialog popup |
 | `command-dialog-content` | `Command.DialogContent` popup |

--- a/apps/www/src/content/docs/components/command/index.mdx
+++ b/apps/www/src/content/docs/components/command/index.mdx
@@ -97,7 +97,7 @@ Visual divider between groups. The separator is hidden automatically while the u
 
 ### Shortcut
 
-A `<kbd>` element for keyboard hints. Typically passed as `trailingIcon` on `Command.Item`.
+Keyboard hints for an item, typically passed as `trailingIcon` on `Command.Item`. Built on [`Kbd`](/docs/components/kbd): it renders a `Kbd.Group` of `ghost` keys and forwards every prop.
 
 <auto-type-table path="./props.ts" name="CommandShortcutProps" />
 

--- a/apps/www/src/content/docs/components/command/index.mdx
+++ b/apps/www/src/content/docs/components/command/index.mdx
@@ -73,7 +73,7 @@ Rendered when no items are visible (all filtered out, or the list is empty). Aut
 
 ### Item
 
-A selectable entry. When `value` is omitted and `children` is a string, the string is used as the value. `onClick` fires on pointer click **and** on keyboard `Enter` when the item is highlighted.
+A selectable entry. When `value` is omitted and `children` is a string, the string is used as the value. `onClick` fires on pointer click **and** on keyboard `Enter` when the item is highlighted. Pass a [`Kbd`](/docs/components/kbd) as `trailingIcon` to show a keyboard hint — use the `ghost` variant so the keys sit on the item's own background.
 
 <auto-type-table path="./props.ts" name="CommandItemProps" />
 
@@ -94,12 +94,6 @@ Renders a label inside `Command.Group`. The label is hidden automatically while 
 Visual divider between groups. The separator is hidden automatically while the user is searching.
 
 <auto-type-table path="./props.ts" name="CommandSeparatorProps" />
-
-### Shortcut
-
-Keyboard hints for an item, typically passed as `trailingIcon` on `Command.Item`. Built on [`Kbd`](/docs/components/kbd): it renders a `Kbd.Group` whose keys default to the `ghost` variant, and forwards every prop.
-
-<auto-type-table path="./props.ts" name="CommandShortcutProps" />
 
 ### Dialog
 
@@ -131,8 +125,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `command-item-label` | The item's label text |
 | `command-item-trailing-icon` | Trailing icon inside an item (when provided) |
 | `command-separator` | `Command.Separator` |
-| `command-shortcut` | `Command.Shortcut` wrapper |
-| `command-shortcut-key` | Each `<kbd>` key inside a shortcut |
 | `command-dialog-trigger` | `Command.DialogTrigger` |
 | `command-dialog-viewport` | Viewport wrapper for the dialog popup |
 | `command-dialog-content` | `Command.DialogContent` popup |

--- a/apps/www/src/content/docs/components/command/index.mdx
+++ b/apps/www/src/content/docs/components/command/index.mdx
@@ -97,7 +97,7 @@ Visual divider between groups. The separator is hidden automatically while the u
 
 ### Shortcut
 
-Keyboard hints for an item, typically passed as `trailingIcon` on `Command.Item`. Built on [`Kbd`](/docs/components/kbd): it renders a `Kbd.Group` of `ghost` keys and forwards every prop.
+Keyboard hints for an item, typically passed as `trailingIcon` on `Command.Item`. Built on [`Kbd`](/docs/components/kbd): it renders a `Kbd.Group` whose keys default to the `ghost` variant, and forwards every prop.
 
 <auto-type-table path="./props.ts" name="CommandShortcutProps" />
 

--- a/apps/www/src/content/docs/components/command/index.mdx
+++ b/apps/www/src/content/docs/components/command/index.mdx
@@ -73,7 +73,7 @@ Rendered when no items are visible (all filtered out, or the list is empty). Aut
 
 ### Item
 
-A selectable entry. When `value` is omitted and `children` is a string, the string is used as the value. `onClick` fires on pointer click **and** on keyboard `Enter` when the item is highlighted.
+A selectable entry. When `value` is omitted and `children` is a string, the string is used as the value. `onClick` fires on pointer click **and** on keyboard `Enter` when the item is highlighted. Pass a [`Kbd`](/docs/components/kbd) as `trailingIcon` to show a keyboard hint — use the `ghost` variant so the keys sit on the item's own background.
 
 <auto-type-table path="./props.ts" name="CommandItemProps" />
 
@@ -94,12 +94,6 @@ Renders a label inside `Command.Group`. The label is hidden automatically while 
 Visual divider between groups. The separator is hidden automatically while the user is searching.
 
 <auto-type-table path="./props.ts" name="CommandSeparatorProps" />
-
-### Shortcut
-
-A `<kbd>` element for keyboard hints. Typically passed as `trailingIcon` on `Command.Item`.
-
-<auto-type-table path="./props.ts" name="CommandShortcutProps" />
 
 ### Dialog
 
@@ -131,8 +125,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `command-item-label` | The item's label text |
 | `command-item-trailing-icon` | Trailing icon inside an item (when provided) |
 | `command-separator` | `Command.Separator` |
-| `command-shortcut` | `Command.Shortcut` wrapper |
-| `command-shortcut-key` | Each `<kbd>` key inside a shortcut |
 | `command-dialog-trigger` | `Command.DialogTrigger` |
 | `command-dialog-viewport` | Viewport wrapper for the dialog popup |
 | `command-dialog-content` | `Command.DialogContent` popup |

--- a/apps/www/src/content/docs/components/command/props.ts
+++ b/apps/www/src/content/docs/components/command/props.ts
@@ -103,7 +103,7 @@ export interface CommandItemProps {
   /** Icon rendered before the item label. */
   leadingIcon?: React.ReactNode;
 
-  /** Node rendered after the item label (e.g. `Command.Shortcut` or an icon). */
+  /** Node rendered after the item label (e.g. a `Kbd` shortcut hint or an icon). */
   trailingIcon?: React.ReactNode;
 
   /**
@@ -127,24 +127,6 @@ export interface CommandLabelProps {
 }
 
 export interface CommandSeparatorProps {
-  /** Additional CSS class names. */
-  className?: string;
-}
-
-export interface CommandShortcutProps {
-  /**
-   * The keys to display. A whitespace-separated string is split into one key
-   * per token, so `"⌘ K"` renders two keys.
-   */
-  children?: React.ReactNode;
-
-  /**
-   * Visual style variant inherited by the keys of the shortcut. A `Kbd`
-   * passed as a child keeps its own `variant`.
-   * @defaultValue "ghost"
-   */
-  variant?: 'solid' | 'ghost';
-
   /** Additional CSS class names. */
   className?: string;
 }

--- a/apps/www/src/content/docs/components/command/props.ts
+++ b/apps/www/src/content/docs/components/command/props.ts
@@ -103,7 +103,7 @@ export interface CommandItemProps {
   /** Icon rendered before the item label. */
   leadingIcon?: React.ReactNode;
 
-  /** Node rendered after the item label (e.g. `Command.Shortcut` or an icon). */
+  /** Node rendered after the item label (e.g. a `Kbd` shortcut hint or an icon). */
   trailingIcon?: React.ReactNode;
 
   /**
@@ -127,11 +127,6 @@ export interface CommandLabelProps {
 }
 
 export interface CommandSeparatorProps {
-  /** Additional CSS class names. */
-  className?: string;
-}
-
-export interface CommandShortcutProps {
   /** Additional CSS class names. */
   className?: string;
 }

--- a/apps/www/src/content/docs/components/command/props.ts
+++ b/apps/www/src/content/docs/components/command/props.ts
@@ -103,7 +103,7 @@ export interface CommandItemProps {
   /** Icon rendered before the item label. */
   leadingIcon?: React.ReactNode;
 
-  /** Node rendered after the item label (e.g. a `Kbd` shortcut hint or an icon). */
+  /** Node rendered after the item label (e.g. `Command.Shortcut` or an icon). */
   trailingIcon?: React.ReactNode;
 
   /**
@@ -127,6 +127,11 @@ export interface CommandLabelProps {
 }
 
 export interface CommandSeparatorProps {
+  /** Additional CSS class names. */
+  className?: string;
+}
+
+export interface CommandShortcutProps {
   /** Additional CSS class names. */
   className?: string;
 }

--- a/apps/www/src/content/docs/components/command/props.ts
+++ b/apps/www/src/content/docs/components/command/props.ts
@@ -132,6 +132,18 @@ export interface CommandSeparatorProps {
 }
 
 export interface CommandShortcutProps {
+  /**
+   * The keys to display. A whitespace-separated string is split into one key
+   * per token, so `"⌘ K"` renders two keys.
+   */
+  children?: React.ReactNode;
+
+  /**
+   * Visual style variant, applied to every key in the shortcut.
+   * @defaultValue "ghost"
+   */
+  variant?: 'solid' | 'ghost';
+
   /** Additional CSS class names. */
   className?: string;
 }

--- a/apps/www/src/content/docs/components/command/props.ts
+++ b/apps/www/src/content/docs/components/command/props.ts
@@ -139,7 +139,8 @@ export interface CommandShortcutProps {
   children?: React.ReactNode;
 
   /**
-   * Visual style variant, applied to every key in the shortcut.
+   * Visual style variant inherited by the keys of the shortcut. A `Kbd`
+   * passed as a child keeps its own `variant`.
    * @defaultValue "ghost"
    */
   variant?: 'solid' | 'ghost';

--- a/apps/www/src/content/docs/components/kbd/demo.ts
+++ b/apps/www/src/content/docs/components/kbd/demo.ts
@@ -1,0 +1,87 @@
+'use client';
+
+export const preview = {
+  type: 'code',
+  code: `<Kbd.Group>
+    <Kbd>⌘</Kbd>
+    <Kbd>K</Kbd>
+  </Kbd.Group>`
+};
+
+export const singleDemo = {
+  type: 'code',
+  code: `<Flex gap={5} align="center">
+    <Kbd>Esc</Kbd>
+    <Kbd>⌘</Kbd>
+    <Kbd>⇧</Kbd>
+    <Kbd>↵</Kbd>
+    <Kbd>Tab</Kbd>
+  </Flex>`
+};
+
+export const groupDemo = {
+  type: 'code',
+  code: `<Flex gap={7} align="center">
+    <Kbd.Group>
+      <Kbd>⌘</Kbd>
+      <Kbd>K</Kbd>
+    </Kbd.Group>
+    <Kbd.Group>
+      <Kbd>⌘</Kbd>
+      <Kbd>⇧</Kbd>
+      <Kbd>P</Kbd>
+    </Kbd.Group>
+  </Flex>`
+};
+
+export const separatorDemo = {
+  type: 'code',
+  tabs: [
+    {
+      name: 'Plus',
+      code: `<Kbd.Group>
+        <Kbd>⌘</Kbd>
+        +
+        <Kbd>K</Kbd>
+      </Kbd.Group>`
+    },
+    {
+      name: 'Then',
+      code: `<Kbd.Group>
+        <Kbd>G</Kbd>
+        then
+        <Kbd>P</Kbd>
+      </Kbd.Group>`
+    }
+  ]
+};
+
+export const withTextDemo = {
+  type: 'code',
+  code: `<Flex gap={3} align="center">
+    <Text size="small" variant="secondary">Press</Text>
+    <Kbd.Group>
+      <Kbd>⌘</Kbd>
+      <Kbd>K</Kbd>
+    </Kbd.Group>
+    <Text size="small" variant="secondary">to open the command palette</Text>
+  </Flex>`
+};
+
+export const withTooltipDemo = {
+  type: 'code',
+  code: `<Tooltip>
+    <Tooltip.Trigger render={<Button variant="outline" />}>
+      Search
+    </Tooltip.Trigger>
+    <Tooltip.Content>
+      <Flex gap={3} align="center">
+        Open search
+        <Kbd.Group>
+          <Kbd>⌘</Kbd>
+          <Kbd>K</Kbd>
+        </Kbd.Group>
+      </Flex>
+    </Tooltip.Content>
+  </Tooltip>`
+};

--- a/apps/www/src/content/docs/components/kbd/demo.ts
+++ b/apps/www/src/content/docs/components/kbd/demo.ts
@@ -1,21 +1,52 @@
 'use client';
 
-export const preview = {
-  type: 'code',
-  code: `<Kbd.Group>
-    <Kbd>⌘</Kbd>
-    <Kbd>K</Kbd>
-  </Kbd.Group>`
+import type { ComponentPropsType } from '@/components/demo/types';
+import { getPropsString } from '@/lib/utils';
+
+export const getCode = (props: ComponentPropsType) => {
+  const { children, ...rest } = props;
+
+  return `<Kbd${getPropsString(rest)}>${children}</Kbd>`;
+};
+
+export const playground = {
+  type: 'playground',
+  controls: {
+    variant: {
+      type: 'select',
+      options: ['solid', 'ghost'],
+      defaultValue: 'solid'
+    },
+    children: {
+      type: 'text',
+      initialValue: 'Esc'
+    }
+  },
+  getCode
 };
 
 export const singleDemo = {
   type: 'code',
   code: `<Flex gap={5} align="center">
     <Kbd>Esc</Kbd>
-    <Kbd>⌘</Kbd>
-    <Kbd>⇧</Kbd>
-    <Kbd>↵</Kbd>
+    <Kbd aria-label="Command">⌘</Kbd>
+    <Kbd aria-label="Shift">⇧</Kbd>
+    <Kbd aria-label="Enter">↵</Kbd>
     <Kbd>Tab</Kbd>
+  </Flex>`
+};
+
+export const variantDemo = {
+  type: 'code',
+  code: `<Flex gap={7} align="center">
+    <Kbd.Group>
+      <Kbd aria-label="Command">⌘</Kbd>
+      <Kbd>K</Kbd>
+    </Kbd.Group>
+    <Kbd.Group variant="ghost">
+      <Kbd aria-label="Command">⌘</Kbd>
+      <Kbd>K</Kbd>
+    </Kbd.Group>
   </Flex>`
 };
 
@@ -23,12 +54,12 @@ export const groupDemo = {
   type: 'code',
   code: `<Flex gap={7} align="center">
     <Kbd.Group>
-      <Kbd>⌘</Kbd>
+      <Kbd aria-label="Command">⌘</Kbd>
       <Kbd>K</Kbd>
     </Kbd.Group>
     <Kbd.Group>
-      <Kbd>⌘</Kbd>
-      <Kbd>⇧</Kbd>
+      <Kbd aria-label="Command">⌘</Kbd>
+      <Kbd aria-label="Shift">⇧</Kbd>
       <Kbd>P</Kbd>
     </Kbd.Group>
   </Flex>`
@@ -40,7 +71,7 @@ export const separatorDemo = {
     {
       name: 'Plus',
       code: `<Kbd.Group>
-        <Kbd>⌘</Kbd>
+        <Kbd aria-label="Command">⌘</Kbd>
         +
         <Kbd>K</Kbd>
       </Kbd.Group>`
@@ -58,14 +89,17 @@ export const separatorDemo = {
 
 export const withTextDemo = {
   type: 'code',
-  code: `<Flex gap={3} align="center">
-    <Text size="small" variant="secondary">Press</Text>
-    <Kbd.Group>
-      <Kbd>⌘</Kbd>
-      <Kbd>K</Kbd>
-    </Kbd.Group>
-    <Text size="small" variant="secondary">to open the command palette</Text>
-  </Flex>`
+  code: `<Text size="small" variant="secondary">
+    Press <Kbd.Group><Kbd aria-label="Command">⌘</Kbd><Kbd>K</Kbd></Kbd.Group> to open the command palette.
+  </Text>`
+};
+
+export const withInputDemo = {
+  type: 'code',
+  code: `<Input
+    placeholder="Search projects"
+    trailingIcon={<Kbd variant="ghost" aria-label="Command K">⌘K</Kbd>}
+  />`
 };
 
 export const withTooltipDemo = {
@@ -77,8 +111,8 @@ export const withTooltipDemo = {
     <Tooltip.Content>
       <Flex gap={3} align="center">
         Open search
-        <Kbd.Group>
-          <Kbd>⌘</Kbd>
+        <Kbd.Group variant="ghost">
+          <Kbd aria-label="Command">⌘</Kbd>
           <Kbd>K</Kbd>
         </Kbd.Group>
       </Flex>

--- a/apps/www/src/content/docs/components/kbd/index.mdx
+++ b/apps/www/src/content/docs/components/kbd/index.mdx
@@ -74,7 +74,7 @@ Use `Kbd` on its own for a one-key hint. Keys share a minimum width so a narrow 
 
 ### Sequences
 
-Wrap keys in `Kbd.Group` to show a chord. Setting `variant` on the group applies it to every key inside.
+Wrap keys in `Kbd.Group` to show a chord. Setting `variant` on the group sets the variant for the keys inside, and an individual `Kbd` can override it.
 
 <Demo data={groupDemo} />
 

--- a/apps/www/src/content/docs/components/kbd/index.mdx
+++ b/apps/www/src/content/docs/components/kbd/index.mdx
@@ -1,0 +1,96 @@
+---
+title: Kbd
+description: Displays a keyboard key or a shortcut sequence.
+source: packages/raystack/components/kbd
+tag: new
+---
+
+import {
+  preview,
+  singleDemo,
+  groupDemo,
+  separatorDemo,
+  withTextDemo,
+  withTooltipDemo,
+} from "./demo.ts";
+
+<Demo data={preview} />
+
+## Anatomy
+
+Import and assemble the component. A single `Kbd` renders one key; wrap several in `Kbd.Group` to show a sequence.
+
+```tsx
+import { Kbd } from "@raystack/apsara";
+
+<Kbd>Esc</Kbd>
+
+<Kbd.Group>
+  <Kbd>⌘</Kbd>
+  <Kbd>K</Kbd>
+</Kbd.Group>
+```
+
+## API Reference
+
+Both parts render a `<kbd>` element and forward any native attributes (`id`, `title`, `aria-label`, …) to it.
+
+### Root
+
+A single keyboard key. Renders a `<kbd>` element.
+
+<auto-type-table path="./props.ts" name="KbdProps" />
+
+### Group
+
+Spaces a sequence of keys evenly. Also renders a `<kbd>`: per the HTML spec, a `kbd` nested inside a `kbd` represents an individual key within a larger input, which is exactly what a shortcut sequence is.
+
+<auto-type-table path="./props.ts" name="KbdGroupProps" />
+
+### Slots
+
+Every rendered part carries a stable `data-slot` attribute for [styling and testing](/docs/styling#with-data-slot):
+
+| Slot | Element |
+|------|---------|
+| `kbd` | Each individual key |
+| `kbd-group` | The `Kbd.Group` wrapper |
+
+## Examples
+
+### Single keys
+
+Use `Kbd` on its own for a one-key hint. Keys share a minimum width so a narrow `K` lines up with a wide `⌘`.
+
+<Demo data={singleDemo} />
+
+### Sequences
+
+Wrap keys in `Kbd.Group` to show a chord.
+
+<Demo data={groupDemo} />
+
+### Separators
+
+`Kbd.Group` renders whatever you put between the keys, so separators are plain text. Use `+` for keys pressed together and a word like `then` for keys pressed in order.
+
+<Demo data={separatorDemo} />
+
+### Inline with text
+
+Keys sit on the text baseline, so they can be dropped into a sentence.
+
+<Demo data={withTextDemo} />
+
+### In a tooltip
+
+A common use is surfacing a shortcut alongside the action it triggers.
+
+<Demo data={withTooltipDemo} />
+
+## Accessibility
+
+- `Kbd` is presentational and renders the semantic `<kbd>` element, which screen readers announce as keyboard input.
+- Symbol-only keys such as `⌘`, `⇧`, or `↵` are not announced usefully on their own. Add an `aria-label` when the symbol is the only cue: `<Kbd aria-label="Command">⌘</Kbd>`.
+- Keys are not focusable and carry no interaction. Keep the shortcut wired to a real handler elsewhere — `Kbd` only displays it.
+- Text selection is disabled so dragging across a menu row does not highlight the key labels.

--- a/apps/www/src/content/docs/components/kbd/index.mdx
+++ b/apps/www/src/content/docs/components/kbd/index.mdx
@@ -1,20 +1,22 @@
 ---
 title: Kbd
-description: Displays a keyboard key or a shortcut sequence.
+description: A component for displaying keyboard keys and shortcuts.
 source: packages/raystack/components/kbd
 tag: new
 ---
 
 import {
-  preview,
+  playground,
   singleDemo,
+  variantDemo,
   groupDemo,
   separatorDemo,
   withTextDemo,
+  withInputDemo,
   withTooltipDemo,
 } from "./demo.ts";
 
-<Demo data={preview} />
+<Demo data={playground} />
 
 ## Anatomy
 
@@ -43,7 +45,7 @@ A single keyboard key. Renders a `<kbd>` element.
 
 ### Group
 
-Spaces a sequence of keys evenly. Also renders a `<kbd>`: per the HTML spec, a `kbd` nested inside a `kbd` represents an individual key within a larger input, which is exactly what a shortcut sequence is.
+Groups multiple keyboard keys for key combinations.
 
 <auto-type-table path="./props.ts" name="KbdGroupProps" />
 
@@ -64,23 +66,35 @@ Use `Kbd` on its own for a one-key hint. Keys share a minimum width so a narrow 
 
 <Demo data={singleDemo} />
 
+### Variants
+
+`solid` is the default and suits standalone hints. Use `ghost` on surfaces that already have their own background, such as a menu row, a tooltip, or an input.
+
+<Demo data={variantDemo} />
+
 ### Sequences
 
-Wrap keys in `Kbd.Group` to show a chord.
+Wrap keys in `Kbd.Group` to show a chord. Setting `variant` on the group applies it to every key inside.
 
 <Demo data={groupDemo} />
 
 ### Separators
 
-`Kbd.Group` renders whatever you put between the keys, so separators are plain text. Use `+` for keys pressed together and a word like `then` for keys pressed in order.
+`Kbd.Group` renders whatever you put between the keys, so separators are plain text. Use `+` for keys pressed together and a word like `then` for keys pressed in order. Separator text takes the surrounding typography rather than the key styling.
 
 <Demo data={separatorDemo} />
 
 ### Inline with text
 
-Keys sit on the text baseline, so they can be dropped into a sentence.
+Keys sit on the text baseline, so they can be dropped straight into a sentence.
 
 <Demo data={withTextDemo} />
+
+### In an input
+
+Surface a focus shortcut in a search field. Use a single `ghost` key here — the input's trailing slot is sized for an icon, so a multi-key `Kbd.Group` will be clipped.
+
+<Demo data={withInputDemo} />
 
 ### In a tooltip
 
@@ -90,7 +104,7 @@ A common use is surfacing a shortcut alongside the action it triggers.
 
 ## Accessibility
 
-- `Kbd` is presentational and renders the semantic `<kbd>` element, which screen readers announce as keyboard input.
-- Symbol-only keys such as `⌘`, `⇧`, or `↵` are not announced usefully on their own. Add an `aria-label` when the symbol is the only cue: `<Kbd aria-label="Command">⌘</Kbd>`.
+- `Kbd` is presentational and renders the semantic `<kbd>` element. It has no ARIA role of its own and is not exposed as a separate accessible object, so it does not change how surrounding content is announced.
+- Symbol-only keys such as `⌘`, `⇧`, or `↵` are not announced usefully on their own — they are read by their Unicode names, if at all. Add an `aria-label` when the symbol is the only cue: `<Kbd aria-label="Command">⌘</Kbd>`.
 - Keys are not focusable and carry no interaction. Keep the shortcut wired to a real handler elsewhere — `Kbd` only displays it.
-- Text selection is disabled so dragging across a menu row does not highlight the key labels.
+- Keys ignore pointer events and text selection, so clicking or dragging across a menu row does not highlight the key labels.

--- a/apps/www/src/content/docs/components/kbd/index.mdx
+++ b/apps/www/src/content/docs/components/kbd/index.mdx
@@ -68,7 +68,7 @@ Use `Kbd` on its own for a one-key hint. Keys share a minimum width so a narrow 
 
 ### Variants
 
-`solid` is the default and suits standalone hints. Use `ghost` on surfaces that already have their own background, such as a menu row, a tooltip, or an input.
+`solid` is the default and suits standalone hints. Use `ghost` on surfaces that already have their own background, such as a command item, a tooltip, or an input.
 
 <Demo data={variantDemo} />
 
@@ -104,7 +104,7 @@ A common use is surfacing a shortcut alongside the action it triggers.
 
 ## Accessibility
 
-- `Kbd` is presentational and renders the semantic `<kbd>` element. It has no ARIA role of its own and is not exposed as a separate accessible object, so it does not change how surrounding content is announced.
-- Symbol-only keys such as `⌘`, `⇧`, or `↵` are not announced usefully on their own — they are read by their Unicode names, if at all. Add an `aria-label` when the symbol is the only cue: `<Kbd aria-label="Command">⌘</Kbd>`.
+- `Kbd` is presentational: it styles a key. The `<kbd>` element carries no ARIA role and no accessible name of its own, so it adds no semantics to the text around it.
+- A symbol on its own — `⌘`, `⇧`, `↵` — carries no name for the key it stands for, and how any given screen reader reads the bare glyph varies. Give the key a name whenever the symbol is the only cue: `<Kbd aria-label="Command">⌘</Kbd>`.
 - Keys are not focusable and carry no interaction. Keep the shortcut wired to a real handler elsewhere — `Kbd` only displays it.
-- Keys ignore pointer events and text selection, so clicking or dragging across a menu row does not highlight the key labels.
+- Keys ignore pointer events and text selection, so clicking or dragging across a command item does not highlight the key labels.

--- a/apps/www/src/content/docs/components/kbd/props.ts
+++ b/apps/www/src/content/docs/components/kbd/props.ts
@@ -4,6 +4,12 @@ export interface KbdProps {
   /** The key to display, e.g. `⌘`, `Esc`, or `Enter`. */
   children?: ReactNode;
 
+  /**
+   * Visual style variant. Inherited from a parent `Kbd.Group` when set there.
+   * @defaultValue "solid"
+   */
+  variant?: 'solid' | 'ghost';
+
   /** Additional CSS class names. */
   className?: string;
 }
@@ -11,6 +17,12 @@ export interface KbdProps {
 export interface KbdGroupProps {
   /** The keys in the sequence, plus any plain-text separators between them. */
   children?: ReactNode;
+
+  /**
+   * Visual style variant applied to every key in the group.
+   * @defaultValue "solid"
+   */
+  variant?: 'solid' | 'ghost';
 
   /** Additional CSS class names. */
   className?: string;

--- a/apps/www/src/content/docs/components/kbd/props.ts
+++ b/apps/www/src/content/docs/components/kbd/props.ts
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+
+export interface KbdProps {
+  /** The key to display, e.g. `⌘`, `Esc`, or `Enter`. */
+  children?: ReactNode;
+
+  /** Additional CSS class names. */
+  className?: string;
+}
+
+export interface KbdGroupProps {
+  /** The keys in the sequence, plus any plain-text separators between them. */
+  children?: ReactNode;
+
+  /** Additional CSS class names. */
+  className?: string;
+}

--- a/apps/www/src/content/docs/components/kbd/props.ts
+++ b/apps/www/src/content/docs/components/kbd/props.ts
@@ -19,7 +19,8 @@ export interface KbdGroupProps {
   children?: ReactNode;
 
   /**
-   * Visual style variant applied to every key in the group.
+   * Visual style variant inherited by every key in the group. A key's own
+   * `variant` takes precedence over it.
    * @defaultValue "solid"
    */
   variant?: 'solid' | 'ghost';

--- a/packages/raystack/components/command/__tests__/command.test.tsx
+++ b/packages/raystack/components/command/__tests__/command.test.tsx
@@ -2,8 +2,6 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { Kbd } from '../../kbd';
-import kbdStyles from '../../kbd/kbd.module.css';
 import { Command } from '../command';
 import styles from '../command.module.css';
 
@@ -315,32 +313,6 @@ describe('Command', () => {
       await waitFor(() => {
         expect(screen.queryByText('Calendar')).not.toBeInTheDocument();
       });
-    });
-  });
-
-  describe('Shortcut hints', () => {
-    it('renders a Kbd.Group passed as trailingIcon', () => {
-      const { container } = render(
-        <Command>
-          <Command.Content>
-            <Command.Item
-              trailingIcon={
-                <Kbd.Group variant='ghost'>
-                  <Kbd>⌘</Kbd>
-                  <Kbd>K</Kbd>
-                </Kbd.Group>
-              }
-            >
-              Search
-            </Command.Item>
-          </Command.Content>
-        </Command>
-      );
-      expect(screen.getByText('⌘')).toBeInTheDocument();
-      expect(screen.getByText('K')).toBeInTheDocument();
-      expect(container.querySelectorAll(`.${kbdStyles['kbd']}`)).toHaveLength(
-        2
-      );
     });
   });
 });

--- a/packages/raystack/components/command/__tests__/command.test.tsx
+++ b/packages/raystack/components/command/__tests__/command.test.tsx
@@ -318,56 +318,29 @@ describe('Command', () => {
     });
   });
 
-  describe('Command.Shortcut', () => {
-    it('splits a string of keys into individual keys', () => {
-      render(<Command.Shortcut>⌘ K</Command.Shortcut>);
+  describe('Shortcut hints', () => {
+    it('renders a Kbd.Group passed as trailingIcon', () => {
+      const { container } = render(
+        <Command>
+          <Command.Content>
+            <Command.Item
+              trailingIcon={
+                <Kbd.Group variant='ghost'>
+                  <Kbd>⌘</Kbd>
+                  <Kbd>K</Kbd>
+                </Kbd.Group>
+              }
+            >
+              Search
+            </Command.Item>
+          </Command.Content>
+        </Command>
+      );
       expect(screen.getByText('⌘')).toBeInTheDocument();
       expect(screen.getByText('K')).toBeInTheDocument();
-    });
-
-    it('renders each key through Kbd', () => {
-      render(<Command.Shortcut>⌘ K</Command.Shortcut>);
-      const key = screen.getByText('⌘');
-      expect(key.tagName).toBe('KBD');
-      expect(key).toHaveClass(kbdStyles['kbd']);
-    });
-
-    it('defaults its keys to the ghost variant', () => {
-      render(<Command.Shortcut>⌘ K</Command.Shortcut>);
-      expect(screen.getByText('⌘')).toHaveClass(kbdStyles['kbd-ghost']);
-    });
-
-    it('allows the variant to be overridden', () => {
-      render(<Command.Shortcut variant='solid'>⌘ K</Command.Shortcut>);
-      expect(screen.getByText('⌘')).toHaveClass(kbdStyles['kbd-solid']);
-    });
-
-    it('forwards props and merges className onto the group', () => {
-      const { container } = render(
-        <Command.Shortcut className='custom' aria-label='Command K'>
-          ⌘ K
-        </Command.Shortcut>
+      expect(container.querySelectorAll(`.${kbdStyles['kbd']}`)).toHaveLength(
+        2
       );
-      const group = container.querySelector('[data-slot="command-shortcut"]');
-      expect(group).toHaveClass('custom');
-      expect(group).toHaveClass(styles.shortcut);
-      expect(group).toHaveAttribute('aria-label', 'Command K');
-    });
-
-    it('forwards ref', () => {
-      const ref = React.createRef<HTMLElement>();
-      render(<Command.Shortcut ref={ref}>⌘ K</Command.Shortcut>);
-      expect(ref.current?.tagName).toBe('KBD');
-    });
-
-    it('does not double-wrap element children in a second key', () => {
-      const { container } = render(
-        <Command.Shortcut>
-          <Kbd>⌘</Kbd>
-        </Command.Shortcut>
-      );
-      const keys = container.querySelectorAll(`.${kbdStyles['kbd']}`);
-      expect(keys).toHaveLength(1);
     });
   });
 });

--- a/packages/raystack/components/command/__tests__/command.test.tsx
+++ b/packages/raystack/components/command/__tests__/command.test.tsx
@@ -2,6 +2,8 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
+import { Kbd } from '../../kbd';
+import kbdStyles from '../../kbd/kbd.module.css';
 import { Command } from '../command';
 import styles from '../command.module.css';
 
@@ -313,6 +315,32 @@ describe('Command', () => {
       await waitFor(() => {
         expect(screen.queryByText('Calendar')).not.toBeInTheDocument();
       });
+    });
+  });
+
+  describe('Shortcut hints', () => {
+    it('renders a Kbd.Group passed as trailingIcon', () => {
+      const { container } = render(
+        <Command>
+          <Command.Content>
+            <Command.Item
+              trailingIcon={
+                <Kbd.Group variant='ghost'>
+                  <Kbd>⌘</Kbd>
+                  <Kbd>K</Kbd>
+                </Kbd.Group>
+              }
+            >
+              Search
+            </Command.Item>
+          </Command.Content>
+        </Command>
+      );
+      expect(screen.getByText('⌘')).toBeInTheDocument();
+      expect(screen.getByText('K')).toBeInTheDocument();
+      expect(container.querySelectorAll(`.${kbdStyles['kbd']}`)).toHaveLength(
+        2
+      );
     });
   });
 });

--- a/packages/raystack/components/command/__tests__/command.test.tsx
+++ b/packages/raystack/components/command/__tests__/command.test.tsx
@@ -2,6 +2,8 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
+import { Kbd } from '../../kbd';
+import kbdStyles from '../../kbd/kbd.module.css';
 import { Command } from '../command';
 import styles from '../command.module.css';
 
@@ -313,6 +315,59 @@ describe('Command', () => {
       await waitFor(() => {
         expect(screen.queryByText('Calendar')).not.toBeInTheDocument();
       });
+    });
+  });
+
+  describe('Command.Shortcut', () => {
+    it('splits a string of keys into individual keys', () => {
+      render(<Command.Shortcut>⌘ K</Command.Shortcut>);
+      expect(screen.getByText('⌘')).toBeInTheDocument();
+      expect(screen.getByText('K')).toBeInTheDocument();
+    });
+
+    it('renders each key through Kbd', () => {
+      render(<Command.Shortcut>⌘ K</Command.Shortcut>);
+      const key = screen.getByText('⌘');
+      expect(key.tagName).toBe('KBD');
+      expect(key).toHaveClass(kbdStyles['kbd']);
+    });
+
+    it('defaults its keys to the ghost variant', () => {
+      render(<Command.Shortcut>⌘ K</Command.Shortcut>);
+      expect(screen.getByText('⌘')).toHaveClass(kbdStyles['kbd-ghost']);
+    });
+
+    it('allows the variant to be overridden', () => {
+      render(<Command.Shortcut variant='solid'>⌘ K</Command.Shortcut>);
+      expect(screen.getByText('⌘')).toHaveClass(kbdStyles['kbd-solid']);
+    });
+
+    it('forwards props and merges className onto the group', () => {
+      const { container } = render(
+        <Command.Shortcut className='custom' aria-label='Command K'>
+          ⌘ K
+        </Command.Shortcut>
+      );
+      const group = container.querySelector('[data-slot="command-shortcut"]');
+      expect(group).toHaveClass('custom');
+      expect(group).toHaveClass(styles.shortcut);
+      expect(group).toHaveAttribute('aria-label', 'Command K');
+    });
+
+    it('forwards ref', () => {
+      const ref = React.createRef<HTMLElement>();
+      render(<Command.Shortcut ref={ref}>⌘ K</Command.Shortcut>);
+      expect(ref.current?.tagName).toBe('KBD');
+    });
+
+    it('does not double-wrap element children in a second key', () => {
+      const { container } = render(
+        <Command.Shortcut>
+          <Kbd>⌘</Kbd>
+        </Command.Shortcut>
+      );
+      const keys = container.querySelectorAll(`.${kbdStyles['kbd']}`);
+      expect(keys).toHaveLength(1);
     });
   });
 });

--- a/packages/raystack/components/command/__tests__/data-slots.test.tsx
+++ b/packages/raystack/components/command/__tests__/data-slots.test.tsx
@@ -1,7 +1,6 @@
 import { render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { expectSlots, getSlot } from '~/test-utils/data-slots';
-import { Kbd } from '../../kbd';
 import { Command } from '../command';
 
 // Mock scrollIntoView for test environment
@@ -19,12 +18,7 @@ const BasicCommand = () => (
         <Command.Label>Suggestions</Command.Label>
         <Command.Item
           leadingIcon={<span />}
-          trailingIcon={
-            <Kbd.Group variant='ghost'>
-              <Kbd>⌘</Kbd>
-              <Kbd>K</Kbd>
-            </Kbd.Group>
-          }
+          trailingIcon={<Command.Shortcut>⌘ K</Command.Shortcut>}
         >
           Calendar
         </Command.Item>
@@ -50,6 +44,8 @@ describe('Command data-slot contract', () => {
       'command-item-leading-icon',
       'command-item-label',
       'command-item-trailing-icon',
+      'command-shortcut',
+      'command-shortcut-key',
       'command-separator'
     ]);
   });

--- a/packages/raystack/components/command/__tests__/data-slots.test.tsx
+++ b/packages/raystack/components/command/__tests__/data-slots.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { expectSlots, getSlot } from '~/test-utils/data-slots';
+import { Kbd } from '../../kbd';
 import { Command } from '../command';
 
 // Mock scrollIntoView for test environment
@@ -18,7 +19,12 @@ const BasicCommand = () => (
         <Command.Label>Suggestions</Command.Label>
         <Command.Item
           leadingIcon={<span />}
-          trailingIcon={<Command.Shortcut>⌘ K</Command.Shortcut>}
+          trailingIcon={
+            <Kbd.Group variant='ghost'>
+              <Kbd>⌘</Kbd>
+              <Kbd>K</Kbd>
+            </Kbd.Group>
+          }
         >
           Calendar
         </Command.Item>
@@ -44,8 +50,6 @@ describe('Command data-slot contract', () => {
       'command-item-leading-icon',
       'command-item-label',
       'command-item-trailing-icon',
-      'command-shortcut',
-      'command-shortcut-key',
       'command-separator'
     ]);
   });

--- a/packages/raystack/components/command/command-item.tsx
+++ b/packages/raystack/components/command/command-item.tsx
@@ -10,7 +10,7 @@ import { useCommandContext } from './command-root';
 export interface CommandItemProps extends AutocompletePrimitive.Item.Props {
   /** Icon rendered at the start of the item. */
   leadingIcon?: ReactNode;
-  /** Icon rendered at the end of the item (e.g. `Command.Shortcut`). */
+  /** Icon rendered at the end of the item (e.g. a `Kbd` shortcut hint). */
   trailingIcon?: ReactNode;
 }
 

--- a/packages/raystack/components/command/command-item.tsx
+++ b/packages/raystack/components/command/command-item.tsx
@@ -10,7 +10,7 @@ import { useCommandContext } from './command-root';
 export interface CommandItemProps extends AutocompletePrimitive.Item.Props {
   /** Icon rendered at the start of the item. */
   leadingIcon?: ReactNode;
-  /** Icon rendered at the end of the item (e.g. a `Kbd` shortcut hint). */
+  /** Icon rendered at the end of the item (e.g. `Command.Shortcut`). */
   trailingIcon?: ReactNode;
 }
 

--- a/packages/raystack/components/command/command-misc.tsx
+++ b/packages/raystack/components/command/command-misc.tsx
@@ -2,7 +2,8 @@
 
 import { Autocomplete as AutocompletePrimitive } from '@base-ui/react/autocomplete';
 import { cx } from 'class-variance-authority';
-import { type ComponentProps } from 'react';
+import { Fragment, isValidElement } from 'react';
+import { Kbd, type KbdGroupProps } from '../kbd';
 import styles from './command.module.css';
 import { useCommandContext } from './command-root';
 
@@ -63,11 +64,12 @@ export const CommandSeparator = ({
 };
 CommandSeparator.displayName = 'Command.Separator';
 
-export type CommandShortcutProps = ComponentProps<'span'>;
+export type CommandShortcutProps = KbdGroupProps;
 
 export const CommandShortcut = ({
   className,
   children,
+  variant = 'ghost',
   ...props
 }: CommandShortcutProps) => {
   const keys =
@@ -78,21 +80,22 @@ export const CommandShortcut = ({
         : [children];
 
   return (
-    <span
+    <Kbd.Group
       data-slot='command-shortcut'
+      variant={variant}
       className={cx(styles.shortcut, className)}
       {...props}
     >
-      {keys.map((key, index) => (
-        <kbd
-          key={index}
-          data-slot='command-shortcut-key'
-          className={styles.shortcutKey}
-        >
-          {key}
-        </kbd>
-      ))}
-    </span>
+      {keys.map((key, index) =>
+        isValidElement(key) ? (
+          <Fragment key={index}>{key}</Fragment>
+        ) : (
+          <Kbd key={index} data-slot='command-shortcut-key'>
+            {key}
+          </Kbd>
+        )
+      )}
+    </Kbd.Group>
   );
 };
 CommandShortcut.displayName = 'Command.Shortcut';

--- a/packages/raystack/components/command/command-misc.tsx
+++ b/packages/raystack/components/command/command-misc.tsx
@@ -2,7 +2,6 @@
 
 import { Autocomplete as AutocompletePrimitive } from '@base-ui/react/autocomplete';
 import { cx } from 'class-variance-authority';
-import { type ComponentProps } from 'react';
 import styles from './command.module.css';
 import { useCommandContext } from './command-root';
 
@@ -62,37 +61,3 @@ export const CommandSeparator = ({
   );
 };
 CommandSeparator.displayName = 'Command.Separator';
-
-export type CommandShortcutProps = ComponentProps<'span'>;
-
-export const CommandShortcut = ({
-  className,
-  children,
-  ...props
-}: CommandShortcutProps) => {
-  const keys =
-    typeof children === 'string'
-      ? children.trim().split(/\s+/).filter(Boolean)
-      : Array.isArray(children)
-        ? children
-        : [children];
-
-  return (
-    <span
-      data-slot='command-shortcut'
-      className={cx(styles.shortcut, className)}
-      {...props}
-    >
-      {keys.map((key, index) => (
-        <kbd
-          key={index}
-          data-slot='command-shortcut-key'
-          className={styles.shortcutKey}
-        >
-          {key}
-        </kbd>
-      ))}
-    </span>
-  );
-};
-CommandShortcut.displayName = 'Command.Shortcut';

--- a/packages/raystack/components/command/command-misc.tsx
+++ b/packages/raystack/components/command/command-misc.tsx
@@ -2,6 +2,7 @@
 
 import { Autocomplete as AutocompletePrimitive } from '@base-ui/react/autocomplete';
 import { cx } from 'class-variance-authority';
+import { type ComponentProps } from 'react';
 import styles from './command.module.css';
 import { useCommandContext } from './command-root';
 
@@ -61,3 +62,37 @@ export const CommandSeparator = ({
   );
 };
 CommandSeparator.displayName = 'Command.Separator';
+
+export type CommandShortcutProps = ComponentProps<'span'>;
+
+export const CommandShortcut = ({
+  className,
+  children,
+  ...props
+}: CommandShortcutProps) => {
+  const keys =
+    typeof children === 'string'
+      ? children.trim().split(/\s+/).filter(Boolean)
+      : Array.isArray(children)
+        ? children
+        : [children];
+
+  return (
+    <span
+      data-slot='command-shortcut'
+      className={cx(styles.shortcut, className)}
+      {...props}
+    >
+      {keys.map((key, index) => (
+        <kbd
+          key={index}
+          data-slot='command-shortcut-key'
+          className={styles.shortcutKey}
+        >
+          {key}
+        </kbd>
+      ))}
+    </span>
+  );
+};
+CommandShortcut.displayName = 'Command.Shortcut';

--- a/packages/raystack/components/command/command-misc.tsx
+++ b/packages/raystack/components/command/command-misc.tsx
@@ -2,8 +2,6 @@
 
 import { Autocomplete as AutocompletePrimitive } from '@base-ui/react/autocomplete';
 import { cx } from 'class-variance-authority';
-import { Fragment, isValidElement } from 'react';
-import { Kbd, type KbdGroupProps } from '../kbd';
 import styles from './command.module.css';
 import { useCommandContext } from './command-root';
 
@@ -63,39 +61,3 @@ export const CommandSeparator = ({
   );
 };
 CommandSeparator.displayName = 'Command.Separator';
-
-export type CommandShortcutProps = KbdGroupProps;
-
-export const CommandShortcut = ({
-  className,
-  children,
-  variant = 'ghost',
-  ...props
-}: CommandShortcutProps) => {
-  const keys =
-    typeof children === 'string'
-      ? children.trim().split(/\s+/).filter(Boolean)
-      : Array.isArray(children)
-        ? children
-        : [children];
-
-  return (
-    <Kbd.Group
-      data-slot='command-shortcut'
-      variant={variant}
-      className={cx(styles.shortcut, className)}
-      {...props}
-    >
-      {keys.map((key, index) =>
-        isValidElement(key) ? (
-          <Fragment key={index}>{key}</Fragment>
-        ) : (
-          <Kbd key={index} data-slot='command-shortcut-key'>
-            {key}
-          </Kbd>
-        )
-      )}
-    </Kbd.Group>
-  );
-};
-CommandShortcut.displayName = 'Command.Shortcut';

--- a/packages/raystack/components/command/command.module.css
+++ b/packages/raystack/components/command/command.module.css
@@ -103,22 +103,8 @@
 }
 
 .shortcut {
-  display: inline-flex;
-  align-items: center;
   justify-content: flex-end;
-  gap: var(--rs-space-1);
   white-space: nowrap;
-  font-family: var(--rs-font-body);
-  font-weight: var(--rs-font-weight-regular);
-  font-size: var(--rs-font-size-micro);
-  line-height: var(--rs-line-height-micro);
-  letter-spacing: var(--rs-letter-spacing-micro);
-  color: var(--rs-color-foreground-base-tertiary);
-}
-
-.shortcutKey {
-  font: inherit;
-  color: inherit;
 }
 
 .empty {

--- a/packages/raystack/components/command/command.module.css
+++ b/packages/raystack/components/command/command.module.css
@@ -102,11 +102,6 @@
   height: var(--rs-space-5);
 }
 
-.shortcut {
-  justify-content: flex-end;
-  white-space: nowrap;
-}
-
 .empty {
   padding: var(--rs-space-7) var(--rs-space-3);
   text-align: center;

--- a/packages/raystack/components/command/command.module.css
+++ b/packages/raystack/components/command/command.module.css
@@ -102,25 +102,6 @@
   height: var(--rs-space-5);
 }
 
-.shortcut {
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: var(--rs-space-1);
-  white-space: nowrap;
-  font-family: var(--rs-font-body);
-  font-weight: var(--rs-font-weight-regular);
-  font-size: var(--rs-font-size-micro);
-  line-height: var(--rs-line-height-micro);
-  letter-spacing: var(--rs-letter-spacing-micro);
-  color: var(--rs-color-foreground-base-tertiary);
-}
-
-.shortcutKey {
-  font: inherit;
-  color: inherit;
-}
-
 .empty {
   padding: var(--rs-space-7) var(--rs-space-3);
   text-align: center;

--- a/packages/raystack/components/command/command.module.css
+++ b/packages/raystack/components/command/command.module.css
@@ -102,6 +102,25 @@
   height: var(--rs-space-5);
 }
 
+.shortcut {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--rs-space-1);
+  white-space: nowrap;
+  font-family: var(--rs-font-body);
+  font-weight: var(--rs-font-weight-regular);
+  font-size: var(--rs-font-size-micro);
+  line-height: var(--rs-line-height-micro);
+  letter-spacing: var(--rs-letter-spacing-micro);
+  color: var(--rs-color-foreground-base-tertiary);
+}
+
+.shortcutKey {
+  font: inherit;
+  color: inherit;
+}
+
 .empty {
   padding: var(--rs-space-7) var(--rs-space-3);
   text-align: center;

--- a/packages/raystack/components/command/command.tsx
+++ b/packages/raystack/components/command/command.tsx
@@ -7,12 +7,7 @@ import {
 import { CommandEmpty } from './command-empty';
 import { CommandInput } from './command-input';
 import { CommandItem } from './command-item';
-import {
-  CommandGroup,
-  CommandLabel,
-  CommandSeparator,
-  CommandShortcut
-} from './command-misc';
+import { CommandGroup, CommandLabel, CommandSeparator } from './command-misc';
 import { CommandRoot } from './command-root';
 
 export const Command = Object.assign(CommandRoot, {
@@ -23,7 +18,6 @@ export const Command = Object.assign(CommandRoot, {
   Group: CommandGroup,
   Label: CommandLabel,
   Separator: CommandSeparator,
-  Shortcut: CommandShortcut,
   Dialog: CommandDialog,
   DialogTrigger: CommandDialogTrigger,
   DialogContent: CommandDialogContent

--- a/packages/raystack/components/command/command.tsx
+++ b/packages/raystack/components/command/command.tsx
@@ -7,7 +7,12 @@ import {
 import { CommandEmpty } from './command-empty';
 import { CommandInput } from './command-input';
 import { CommandItem } from './command-item';
-import { CommandGroup, CommandLabel, CommandSeparator } from './command-misc';
+import {
+  CommandGroup,
+  CommandLabel,
+  CommandSeparator,
+  CommandShortcut
+} from './command-misc';
 import { CommandRoot } from './command-root';
 
 export const Command = Object.assign(CommandRoot, {
@@ -18,6 +23,7 @@ export const Command = Object.assign(CommandRoot, {
   Group: CommandGroup,
   Label: CommandLabel,
   Separator: CommandSeparator,
+  Shortcut: CommandShortcut,
   Dialog: CommandDialog,
   DialogTrigger: CommandDialogTrigger,
   DialogContent: CommandDialogContent

--- a/packages/raystack/components/kbd/__tests__/data-slots.test.tsx
+++ b/packages/raystack/components/kbd/__tests__/data-slots.test.tsx
@@ -1,0 +1,38 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { expectSlots, getAllSlots, getSlot } from '~/test-utils/data-slots';
+import { Kbd } from '../kbd';
+
+describe('Kbd data-slot contract', () => {
+  it('exposes slots for every rendered part', () => {
+    const { container } = render(
+      <Kbd.Group>
+        <Kbd>⌘</Kbd>
+        <Kbd>K</Kbd>
+      </Kbd.Group>
+    );
+    expectSlots(container, ['kbd-group', 'kbd']);
+  });
+
+  it('marks each key with the same slot name', () => {
+    const { container } = render(
+      <Kbd.Group>
+        <Kbd>⌘</Kbd>
+        <Kbd>K</Kbd>
+      </Kbd.Group>
+    );
+    expect(getAllSlots(container, 'kbd')).toHaveLength(2);
+  });
+
+  it('drops the group slot when no group is rendered', () => {
+    const { container } = render(<Kbd>Esc</Kbd>);
+    expectSlots(container, ['kbd']);
+    expect(getSlot(container, 'kbd-group')).toBeNull();
+  });
+
+  it('lets callers override the slot name', () => {
+    const { container } = render(<Kbd data-slot='custom'>Esc</Kbd>);
+    expect(getSlot(container, 'custom')).not.toBeNull();
+    expect(getSlot(container, 'kbd')).toBeNull();
+  });
+});

--- a/packages/raystack/components/kbd/__tests__/kbd.test.tsx
+++ b/packages/raystack/components/kbd/__tests__/kbd.test.tsx
@@ -44,6 +44,61 @@ describe('Kbd', () => {
     });
   });
 
+  describe('Variants', () => {
+    it('applies the solid variant by default', () => {
+      render(<Kbd>Ctrl</Kbd>);
+      expect(screen.getByText('Ctrl')).toHaveClass(styles['kbd-solid']);
+    });
+
+    it('applies the ghost variant when requested', () => {
+      render(<Kbd variant='ghost'>Ctrl</Kbd>);
+      const kbd = screen.getByText('Ctrl');
+      expect(kbd).toHaveClass(styles['kbd-ghost']);
+      expect(kbd).not.toHaveClass(styles['kbd-solid']);
+    });
+
+    it('inherits the variant from a parent group', () => {
+      render(
+        <Kbd.Group variant='ghost'>
+          <Kbd>⌘</Kbd>
+          <Kbd>K</Kbd>
+        </Kbd.Group>
+      );
+      expect(screen.getByText('⌘')).toHaveClass(styles['kbd-ghost']);
+      expect(screen.getByText('K')).toHaveClass(styles['kbd-ghost']);
+    });
+
+    it('lets a key override the variant inherited from its group', () => {
+      render(
+        <Kbd.Group variant='ghost'>
+          <Kbd variant='solid'>⌘</Kbd>
+          <Kbd>K</Kbd>
+        </Kbd.Group>
+      );
+      expect(screen.getByText('⌘')).toHaveClass(styles['kbd-solid']);
+      expect(screen.getByText('K')).toHaveClass(styles['kbd-ghost']);
+    });
+
+    it('falls back to solid for keys in a group with no variant', () => {
+      render(
+        <Kbd.Group>
+          <Kbd>K</Kbd>
+        </Kbd.Group>
+      );
+      expect(screen.getByText('K')).toHaveClass(styles['kbd-solid']);
+    });
+
+    it('does not put a key variant class on the group', () => {
+      const { container } = render(
+        <Kbd.Group variant='ghost'>
+          <Kbd>K</Kbd>
+        </Kbd.Group>
+      );
+      const group = container.querySelector(`.${styles['kbd-group']}`);
+      expect(group).not.toHaveClass(styles['kbd-ghost']);
+    });
+  });
+
   describe('Kbd.Group', () => {
     it('renders every key it contains', () => {
       render(

--- a/packages/raystack/components/kbd/__tests__/kbd.test.tsx
+++ b/packages/raystack/components/kbd/__tests__/kbd.test.tsx
@@ -45,27 +45,36 @@ describe('Kbd', () => {
   });
 
   describe('Variants', () => {
-    it('applies the solid variant by default', () => {
-      render(<Kbd>Ctrl</Kbd>);
+    it('carries the solid styling on the base class by default', () => {
+      const kbd = render(<Kbd>Ctrl</Kbd>).getByText('Ctrl');
+      expect(kbd).toHaveClass(styles.kbd);
+      expect(kbd).not.toHaveClass(styles['kbd-solid']);
+      expect(kbd).not.toHaveClass(styles['kbd-ghost']);
+    });
+
+    it('applies the solid variant when requested', () => {
+      render(<Kbd variant='solid'>Ctrl</Kbd>);
       expect(screen.getByText('Ctrl')).toHaveClass(styles['kbd-solid']);
     });
 
     it('applies the ghost variant when requested', () => {
-      render(<Kbd variant='ghost'>Ctrl</Kbd>);
-      const kbd = screen.getByText('Ctrl');
+      const kbd = render(<Kbd variant='ghost'>Ctrl</Kbd>).getByText('Ctrl');
       expect(kbd).toHaveClass(styles['kbd-ghost']);
       expect(kbd).not.toHaveClass(styles['kbd-solid']);
     });
 
-    it('inherits the variant from a parent group', () => {
-      render(
+    it('marks the group so its keys inherit the variant in CSS', () => {
+      const { container } = render(
         <Kbd.Group variant='ghost'>
           <Kbd>⌘</Kbd>
           <Kbd>K</Kbd>
         </Kbd.Group>
       );
-      expect(screen.getByText('⌘')).toHaveClass(styles['kbd-ghost']);
-      expect(screen.getByText('K')).toHaveClass(styles['kbd-ghost']);
+      const group = container.querySelector(`.${styles['kbd-group']}`);
+      expect(group).toHaveClass(styles['kbd-group-ghost']);
+      // Keys carry no variant class of their own, so the group rule applies.
+      expect(screen.getByText('⌘')).not.toHaveClass(styles['kbd-solid']);
+      expect(screen.getByText('K')).not.toHaveClass(styles['kbd-solid']);
     });
 
     it('lets a key override the variant inherited from its group', () => {
@@ -76,16 +85,18 @@ describe('Kbd', () => {
         </Kbd.Group>
       );
       expect(screen.getByText('⌘')).toHaveClass(styles['kbd-solid']);
-      expect(screen.getByText('K')).toHaveClass(styles['kbd-ghost']);
+      expect(screen.getByText('K')).not.toHaveClass(styles['kbd-solid']);
     });
 
-    it('falls back to solid for keys in a group with no variant', () => {
-      render(
+    it('leaves a group with no variant unmarked', () => {
+      const { container } = render(
         <Kbd.Group>
           <Kbd>K</Kbd>
         </Kbd.Group>
       );
-      expect(screen.getByText('K')).toHaveClass(styles['kbd-solid']);
+      const group = container.querySelector(`.${styles['kbd-group']}`);
+      expect(group).not.toHaveClass(styles['kbd-group-ghost']);
+      expect(group).not.toHaveClass(styles['kbd-group-solid']);
     });
 
     it('does not put a key variant class on the group', () => {

--- a/packages/raystack/components/kbd/__tests__/kbd.test.tsx
+++ b/packages/raystack/components/kbd/__tests__/kbd.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+import { describe, expect, it } from 'vitest';
+import { Kbd } from '../kbd';
+import styles from '../kbd.module.css';
+
+describe('Kbd', () => {
+  describe('Basic Rendering', () => {
+    it('renders its children', () => {
+      render(<Kbd>Ctrl</Kbd>);
+      expect(screen.getByText('Ctrl')).toBeInTheDocument();
+    });
+
+    it('renders a kbd element', () => {
+      render(<Kbd>Ctrl</Kbd>);
+      expect(screen.getByText('Ctrl').tagName).toBe('KBD');
+    });
+
+    it('applies the base class', () => {
+      render(<Kbd>Ctrl</Kbd>);
+      expect(screen.getByText('Ctrl')).toHaveClass(styles.kbd);
+    });
+
+    it('merges a custom className with the base class', () => {
+      render(<Kbd className='custom'>Ctrl</Kbd>);
+      const kbd = screen.getByText('Ctrl');
+      expect(kbd).toHaveClass(styles.kbd);
+      expect(kbd).toHaveClass('custom');
+    });
+
+    it('forwards arbitrary props to the element', () => {
+      render(<Kbd aria-label='Control key'>Ctrl</Kbd>);
+      expect(screen.getByText('Ctrl')).toHaveAttribute(
+        'aria-label',
+        'Control key'
+      );
+    });
+
+    it('forwards ref', () => {
+      const ref = createRef<HTMLElement>();
+      render(<Kbd ref={ref}>Ctrl</Kbd>);
+      expect(ref.current).toBeInstanceOf(HTMLElement);
+      expect(ref.current?.tagName).toBe('KBD');
+    });
+  });
+
+  describe('Kbd.Group', () => {
+    it('renders every key it contains', () => {
+      render(
+        <Kbd.Group>
+          <Kbd>⌘</Kbd>
+          <Kbd>K</Kbd>
+        </Kbd.Group>
+      );
+      expect(screen.getByText('⌘')).toBeInTheDocument();
+      expect(screen.getByText('K')).toBeInTheDocument();
+    });
+
+    it('renders a kbd element so nested keys stay semantic', () => {
+      const { container } = render(
+        <Kbd.Group>
+          <Kbd>K</Kbd>
+        </Kbd.Group>
+      );
+      const group = container.querySelector(`.${styles['kbd-group']}`);
+      expect(group?.tagName).toBe('KBD');
+    });
+
+    it('applies the group class, not the key class', () => {
+      const { container } = render(
+        <Kbd.Group>
+          <Kbd>K</Kbd>
+        </Kbd.Group>
+      );
+      const group = container.querySelector(`.${styles['kbd-group']}`);
+      expect(group).not.toHaveClass(styles.kbd);
+    });
+
+    it('merges a custom className with the group class', () => {
+      const { container } = render(
+        <Kbd.Group className='custom'>
+          <Kbd>K</Kbd>
+        </Kbd.Group>
+      );
+      const group = container.querySelector(`.${styles['kbd-group']}`);
+      expect(group).toHaveClass('custom');
+    });
+
+    it('forwards ref', () => {
+      const ref = createRef<HTMLElement>();
+      render(
+        <Kbd.Group ref={ref}>
+          <Kbd>K</Kbd>
+        </Kbd.Group>
+      );
+      expect(ref.current?.tagName).toBe('KBD');
+    });
+
+    it('allows plain text separators between keys', () => {
+      render(
+        <Kbd.Group>
+          <Kbd>⌘</Kbd>+<Kbd>K</Kbd>
+        </Kbd.Group>
+      );
+      expect(screen.getByText('+')).toBeInTheDocument();
+    });
+  });
+
+  describe('Composition', () => {
+    it('exposes Group off the root', () => {
+      expect(Kbd.Group).toBeDefined();
+    });
+
+    it('sets displayName on both parts', () => {
+      expect(Kbd.displayName).toBe('Kbd');
+      expect(Kbd.Group.displayName).toBe('Kbd.Group');
+    });
+  });
+});

--- a/packages/raystack/components/kbd/index.tsx
+++ b/packages/raystack/components/kbd/index.tsx
@@ -1,0 +1,1 @@
+export { Kbd } from './kbd';

--- a/packages/raystack/components/kbd/index.tsx
+++ b/packages/raystack/components/kbd/index.tsx
@@ -1,1 +1,1 @@
-export { Kbd } from './kbd';
+export { Kbd, type KbdGroupProps, type KbdProps } from './kbd';

--- a/packages/raystack/components/kbd/kbd.module.css
+++ b/packages/raystack/components/kbd/kbd.module.css
@@ -1,32 +1,38 @@
-/* normalize.css sets `kbd { font-family: monospace }`, so both parts restore
-   the body font explicitly rather than relying on inheritance. */
-
 .kbd,
 .kbd-group {
   display: inline-flex;
   align-items: center;
-  color: var(--rs-color-foreground-base-tertiary);
-  font-family: var(--rs-font-body);
-  font-size: var(--rs-font-size-mini);
-  line-height: var(--rs-line-height-mini);
-  letter-spacing: var(--rs-letter-spacing-mini);
+  width: fit-content;
+  pointer-events: none;
+  user-select: none;
 }
 
 .kbd {
   justify-content: center;
   box-sizing: border-box;
   height: var(--rs-space-6);
-  /* Square minimum so a narrow "K" reads the same width as a wide "⌘". */
   min-width: var(--rs-space-6);
   padding: 0 var(--rs-space-2);
   border-radius: var(--rs-radius-1);
-  background: var(--rs-color-background-neutral-primary);
+  font-family: var(--rs-font-body);
+  font-size: var(--rs-font-size-mini);
   font-weight: var(--rs-font-weight-medium);
+  line-height: var(--rs-line-height-mini);
+  letter-spacing: var(--rs-letter-spacing-mini);
   white-space: nowrap;
-  user-select: none;
 }
 
-/* Spacing container only — the nested keys carry the chip treatment. */
+.kbd-solid {
+  background: var(--rs-color-background-neutral-primary);
+  color: var(--rs-color-foreground-base-secondary);
+}
+
+.kbd-ghost {
+  background: transparent;
+  color: var(--rs-color-foreground-base-secondary);
+}
+
 .kbd-group {
   gap: var(--rs-space-2);
+  font: inherit;
 }

--- a/packages/raystack/components/kbd/kbd.module.css
+++ b/packages/raystack/components/kbd/kbd.module.css
@@ -20,16 +20,20 @@
   line-height: var(--rs-line-height-mini);
   letter-spacing: var(--rs-letter-spacing-mini);
   white-space: nowrap;
-}
-
-.kbd-solid {
   background: var(--rs-color-background-neutral-primary);
   color: var(--rs-color-foreground-base-secondary);
 }
 
-.kbd-ghost {
-  background: transparent;
+:where(.kbd-group-solid) .kbd,
+.kbd.kbd-solid {
+  background: var(--rs-color-background-neutral-primary);
   color: var(--rs-color-foreground-base-secondary);
+}
+
+:where(.kbd-group-ghost) .kbd,
+.kbd.kbd-ghost {
+  background: transparent;
+  color: var(--rs-color-foreground-base-tertiary);
 }
 
 .kbd-group {

--- a/packages/raystack/components/kbd/kbd.module.css
+++ b/packages/raystack/components/kbd/kbd.module.css
@@ -1,0 +1,32 @@
+/* normalize.css sets `kbd { font-family: monospace }`, so both parts restore
+   the body font explicitly rather than relying on inheritance. */
+
+.kbd,
+.kbd-group {
+  display: inline-flex;
+  align-items: center;
+  color: var(--rs-color-foreground-base-tertiary);
+  font-family: var(--rs-font-body);
+  font-size: var(--rs-font-size-mini);
+  line-height: var(--rs-line-height-mini);
+  letter-spacing: var(--rs-letter-spacing-mini);
+}
+
+.kbd {
+  justify-content: center;
+  box-sizing: border-box;
+  height: var(--rs-space-6);
+  /* Square minimum so a narrow "K" reads the same width as a wide "⌘". */
+  min-width: var(--rs-space-6);
+  padding: 0 var(--rs-space-2);
+  border-radius: var(--rs-radius-1);
+  background: var(--rs-color-background-neutral-primary);
+  font-weight: var(--rs-font-weight-medium);
+  white-space: nowrap;
+  user-select: none;
+}
+
+/* Spacing container only — the nested keys carry the chip treatment. */
+.kbd-group {
+  gap: var(--rs-space-2);
+}

--- a/packages/raystack/components/kbd/kbd.tsx
+++ b/packages/raystack/components/kbd/kbd.tsx
@@ -1,0 +1,32 @@
+import { cx } from 'class-variance-authority';
+import type { ComponentProps } from 'react';
+import styles from './kbd.module.css';
+
+export type KbdProps = ComponentProps<'kbd'>;
+
+const KbdRoot = ({ className, ...props }: KbdProps) => (
+  <kbd data-slot='kbd' className={cx(styles.kbd, className)} {...props} />
+);
+
+KbdRoot.displayName = 'Kbd';
+
+export type KbdGroupProps = ComponentProps<'kbd'>;
+
+/**
+ * Renders a `<kbd>` rather than a `<div>`: per the HTML spec a `kbd` nested
+ * inside a `kbd` represents an individual key within a larger input, which is
+ * exactly a shortcut sequence.
+ */
+const KbdGroup = ({ className, ...props }: KbdGroupProps) => (
+  <kbd
+    data-slot='kbd-group'
+    className={cx(styles['kbd-group'], className)}
+    {...props}
+  />
+);
+
+KbdGroup.displayName = 'Kbd.Group';
+
+export const Kbd = Object.assign(KbdRoot, {
+  Group: KbdGroup
+});

--- a/packages/raystack/components/kbd/kbd.tsx
+++ b/packages/raystack/components/kbd/kbd.tsx
@@ -1,28 +1,51 @@
-import { cx } from 'class-variance-authority';
-import type { ComponentProps } from 'react';
+'use client';
+
+import { cva, cx, type VariantProps } from 'class-variance-authority';
+import { type ComponentProps, createContext, useContext } from 'react';
 import styles from './kbd.module.css';
 
-export type KbdProps = ComponentProps<'kbd'>;
+const kbd = cva(styles['kbd'], {
+  variants: {
+    variant: {
+      solid: styles['kbd-solid'],
+      ghost: styles['kbd-ghost']
+    }
+  },
+  defaultVariants: {
+    variant: 'solid'
+  }
+});
 
-const KbdRoot = ({ className, ...props }: KbdProps) => (
-  <kbd data-slot='kbd' className={cx(styles.kbd, className)} {...props} />
-);
+type KbdVariant = NonNullable<VariantProps<typeof kbd>['variant']>;
+
+const KbdGroupContext = createContext<KbdVariant | undefined>(undefined);
+
+export type KbdProps = ComponentProps<'kbd'> & VariantProps<typeof kbd>;
+
+const KbdRoot = ({ className, variant, ...props }: KbdProps) => {
+  const groupVariant = useContext(KbdGroupContext);
+
+  return (
+    <kbd
+      data-slot='kbd'
+      className={kbd({ variant: variant ?? groupVariant, className })}
+      {...props}
+    />
+  );
+};
 
 KbdRoot.displayName = 'Kbd';
 
-export type KbdGroupProps = ComponentProps<'kbd'>;
+export type KbdGroupProps = ComponentProps<'kbd'> & VariantProps<typeof kbd>;
 
-/**
- * Renders a `<kbd>` rather than a `<div>`: per the HTML spec a `kbd` nested
- * inside a `kbd` represents an individual key within a larger input, which is
- * exactly a shortcut sequence.
- */
-const KbdGroup = ({ className, ...props }: KbdGroupProps) => (
-  <kbd
-    data-slot='kbd-group'
-    className={cx(styles['kbd-group'], className)}
-    {...props}
-  />
+const KbdGroup = ({ className, variant, ...props }: KbdGroupProps) => (
+  <KbdGroupContext.Provider value={variant ?? undefined}>
+    <kbd
+      data-slot='kbd-group'
+      className={cx(styles['kbd-group'], className)}
+      {...props}
+    />
+  </KbdGroupContext.Provider>
 );
 
 KbdGroup.displayName = 'Kbd.Group';

--- a/packages/raystack/components/kbd/kbd.tsx
+++ b/packages/raystack/components/kbd/kbd.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { cva, cx, type VariantProps } from 'class-variance-authority';
-import { type ComponentProps, createContext, useContext } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import type { ComponentProps } from 'react';
 import styles from './kbd.module.css';
 
 const kbd = cva(styles['kbd'], {
@@ -10,42 +10,35 @@ const kbd = cva(styles['kbd'], {
       solid: styles['kbd-solid'],
       ghost: styles['kbd-ghost']
     }
-  },
-  defaultVariants: {
-    variant: 'solid'
   }
 });
 
-type KbdVariant = NonNullable<VariantProps<typeof kbd>['variant']>;
-
-const KbdGroupContext = createContext<KbdVariant | undefined>(undefined);
+const kbdGroup = cva(styles['kbd-group'], {
+  variants: {
+    variant: {
+      solid: styles['kbd-group-solid'],
+      ghost: styles['kbd-group-ghost']
+    }
+  }
+});
 
 export type KbdProps = ComponentProps<'kbd'> & VariantProps<typeof kbd>;
 
-const KbdRoot = ({ className, variant, ...props }: KbdProps) => {
-  const groupVariant = useContext(KbdGroupContext);
-
-  return (
-    <kbd
-      data-slot='kbd'
-      className={kbd({ variant: variant ?? groupVariant, className })}
-      {...props}
-    />
-  );
-};
+const KbdRoot = ({ className, variant, ...props }: KbdProps) => (
+  <kbd data-slot='kbd' className={kbd({ variant, className })} {...props} />
+);
 
 KbdRoot.displayName = 'Kbd';
 
-export type KbdGroupProps = ComponentProps<'kbd'> & VariantProps<typeof kbd>;
+export type KbdGroupProps = ComponentProps<'kbd'> &
+  VariantProps<typeof kbdGroup>;
 
 const KbdGroup = ({ className, variant, ...props }: KbdGroupProps) => (
-  <KbdGroupContext.Provider value={variant ?? undefined}>
-    <kbd
-      data-slot='kbd-group'
-      className={cx(styles['kbd-group'], className)}
-      {...props}
-    />
-  </KbdGroupContext.Provider>
+  <kbd
+    data-slot='kbd-group'
+    className={kbdGroup({ variant, className })}
+    {...props}
+  />
 );
 
 KbdGroup.displayName = 'Kbd.Group';

--- a/packages/raystack/index.tsx
+++ b/packages/raystack/index.tsx
@@ -97,6 +97,7 @@ export { IconButton } from './components/icon-button';
 export { Image } from './components/image';
 export { Indicator } from './components/indicator';
 export { Input } from './components/input';
+export { Kbd } from './components/kbd';
 export { Label } from './components/label';
 export { Link } from './components/link';
 export { List } from './components/list';


### PR DESCRIPTION
## Description

Adds `Kbd`, a component for displaying keyboard keys and shortcut sequences.

Apsara has no shared way to render a keyboard key today, so it gets hand-rolled with inline styles wherever it appears. `Command.Shortcut` rendered unstyled `<kbd>` elements, `Menu` has no shortcut support, and tooltips have no way to show an action's shortcut.

```tsx
<Kbd>Esc</Kbd>

<Kbd.Group>
  <Kbd>⌘</Kbd>
  <Kbd>K</Kbd>
</Kbd.Group>
```

The API follows [shadcn's Kbd](https://ui.shadcn.com/docs/components/base/kbd), converted to Apsara conventions: dot-notation sub-components and `--rs-*` tokens. The visual treatment reuses the existing key styling from `Command.Shortcut` and the docs-site `Kbd`, so no new tokens were added.

Two variants: `solid` (default) and `ghost`, for surfaces that already carry their own background — a command item, a tooltip, an input. Setting `variant` on `Kbd.Group` applies it to the keys inside; a key's own `variant` still wins. That inheritance is resolved in CSS with `:where()`, the same way `radio.module.css` handles group-level size, so no React context is involved.

One note for review: `Kbd.Group` renders a `<kbd>` rather than a `<div>`, since the HTML spec defines a nested `kbd` as an individual key within a larger input.

### Breaking: `Command.Shortcut` is removed

Per review, `Command.Shortcut` is removed rather than re-pointed at `Kbd`. It existed to split a whitespace-separated string into one `<kbd>` per token, and it was only ever used as an item's `trailingIcon` — where a `Kbd` or `Kbd.Group` says the same thing without the loop.

```diff
-<Command.Item trailingIcon={<Command.Shortcut>⌘ K</Command.Shortcut>}>
+<Command.Item
+  trailingIcon={
+    <Kbd.Group variant="ghost">
+      <Kbd aria-label="Command">⌘</Kbd>
+      <Kbd>K</Kbd>
+    </Kbd.Group>
+  }
+>
```

The `command-shortcut` and `command-shortcut-key` data-slots go with it; style the keys via `kbd` / `kbd-group` instead. `Command.Shortcut` ships in `@raystack/apsara@1.5.0`, so this needs to land in the release notes as a breaking change — the commit carries a `BREAKING CHANGE:` footer with the migration above.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes, no bug fixes just code improvements)
- [ ] Chore (changes to the build process or auxiliary tools and libraries such as documentation generation)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, etc))
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Improvement (Improvements to existing code)
- [ ] Other (please specify)

## How Has This Been Tested?

- 25 tests for `Kbd` covering rendering, `className` merging, ref forwarding, variants, group inheritance, composition, and the `data-slot` contract. Full suite: 2597 passed, 1 skipped.
- `pnpm build:apsara` passes and the Vercel preview builds the docs site.
- `tsc --noEmit` and `biome check` clean on all changed files.
- Variant cascade verified against the *built* stylesheet (hashed class names, real theme tokens): a bare key is solid, a `ghost` group ghosts its keys, an explicit `variant="solid"` inside a ghost group stays solid, and keys ignore pointer events throughout.
- Checked in light and dark themes on a tooltip surface, in a command item, and inline in text.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (.mdx files)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

N/A

## Related Issues

N/A
