### PR TITLE
fix: preserve falsy select filter values in FilterChip

### DIFF
--- a/packages/raystack/components/filter-chip/filter-chip.tsx
+++ b/packages/raystack/components/filter-chip/filter-chip.tsx
@@ -113,7 +113,8 @@ export const FilterChip = ({
   const [operation, setOperation] = useState<FilterOperation | undefined>(
     computedOperations?.[0]
   );
-  const [filterValue, setFilterValue] = useState<any>(value || '');
+  // `??` not `||` — a falsy option value like `0` is a real selection.
+  const [filterValue, setFilterValue] = useState<any>(value ?? '');
 
   const showOnRemove = typeof onRemove === 'function';
   const isMultiSelectColumn = columnType === FilterType.multiselect;


### PR DESCRIPTION
## Description

A DataView `select` filter whose option value is `0` looked unset even though the filter was applied.

`FilterChip` seeded its internal value state with `value || ''`, so `0` (and any other falsy option value) was discarded on mount:

```ts
const [filterValue, setFilterValue] = useState<any>(value || '');
```

Flow for `filterOptions: [{ label: 'Zero', value: 0 }, ...]`:

1. `useFilters.onAddFilter` seeds the query filter with `options[0]?.value` → `0`. The query is correct and the filter applies.
2. `FilterChip`'s internal state collapses to `''`.
3. `Select.Value` (`hasValue = !!value`) therefore renders the "Select value" placeholder.

Net effect: the chip reads as unset while a `0` filter is active. The same coercion blanked the `Input` for `defaultFilterValue: 0` on `number` and `string` columns.

Fix is to use `??` so only `null`/`undefined` fall back to the empty string. `String(0)` → `"0"` then matches the `Select.Item` value, which `Select` already stringifies, so the chip renders the option's label.

`DataTable` renders the same `FilterChip`, so it inherits the fix.

### Deliberately out of scope

Two adjacent issues found while tracing this, left for separate PRs to keep the change minimal:

- Picking a numeric option still emits the string `"0"`, since `Select` stringifies item values. Client-side filtering is unaffected (`select.eq` compares via `String()`), but a server-side consumer with `dataType: 'number'` receives `numberValue: "0"`.
- `useFilters` seeds `multiselect` defaults as `''` rather than `[]`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

`vitest --run` over `filter-chip`, `data-view`, and `data-table` — 333 passed, 1 pre-existing skip (`data-view/__tests__/debug.test.tsx`). No new tests were added for the falsy case.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation (.mdx files) — not applicable, no API change
- [ ] I have added tests that prove my fix is effective or that my feature works — not added

## Related Issues

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
