### PR TITLE
docs: restructure page hierarchy in docs

### DIFF
--- a/apps/www/src/components/docs/sidebar.tsx
+++ b/apps/www/src/components/docs/sidebar.tsx
@@ -25,19 +25,30 @@ function renderNode(node: Node, pathname: string): ReactNode {
     node.children &&
     node.children.length > 0
   ) {
+    // One component documented across several pages. Two things keep it from
+    // disturbing the flat component list it sits in: the index renders as
+    // "Overview" (the group label already names the component, so repeating it
+    // reads as a duplicate row), and the group only opens while the reader is
+    // inside it. `isInside` is folded into the key so entering or leaving the
+    // section remounts the group at the right default, while leaving the
+    // reader free to toggle it by hand once they're there.
+    const isInside = isActiveUrl(node.index.url, pathname);
     return (
       <Sidebar.Group
         label={node.name as string}
-        key={node?.$id}
+        key={`${node?.$id}-${isInside}`}
         leadingIcon={node?.icon}
+        collapsible
+        defaultOpen={isInside}
         classNames={{
           items: styles.items,
           label: styles.label
         }}
       >
-        {/* Render index item first */}
-        {renderNode(node.index, pathname)}
-        {/* Recursively render all children */}
+        <SidebarItem
+          item={{ ...node.index, name: 'Overview' }}
+          pathname={pathname}
+        />
         {node.children.map(child => renderNode(child, pathname))}
       </Sidebar.Group>
     );

--- a/apps/www/src/content/docs/(overview)/getting-started.mdx
+++ b/apps/www/src/content/docs/(overview)/getting-started.mdx
@@ -84,7 +84,7 @@ function Example() {
 }
 ```
 
-## Framework Setup
+## Framework setup
 
 ### Next.js (App Router)
 
@@ -131,7 +131,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
 );
 ```
 
-## Optional: Normalize CSS
+## Optional: normalize CSS
 
 Apsara includes an optional normalize stylesheet that ensures consistent rendering across browsers while preserving useful defaults:
 
@@ -142,7 +142,7 @@ import "@raystack/apsara/style.css";
 
 Import it before the main stylesheet if you choose to use it.
 
-## Importing Icons
+## Importing icons
 
 Apsara exports a set of icons that can be imported separately:
 
@@ -153,7 +153,7 @@ import { SearchIcon, XIcon } from "@raystack/apsara/icons";
 <Button leadingIcon={<SearchIcon />}>Search</Button>
 ```
 
-## Importing Hooks
+## Importing hooks
 
 Utility hooks such as `useCopyToClipboard`, `useDebouncedState`, and `useMouse` are available from a dedicated export:
 
@@ -184,7 +184,7 @@ function ThemeToggle() {
 }
 ```
 
-## Next Steps
+## Next steps
 
 - [Theme Overview](/docs/theme/overview) — Configure colors, spacing, and style variants
 - [Button](/docs/components/button) — Start with a common component

--- a/apps/www/src/content/docs/(overview)/index.mdx
+++ b/apps/www/src/content/docs/(overview)/index.mdx
@@ -62,7 +62,7 @@ Apsara is built with:
 - **[class-variance-authority](https://cva.style/)** — Type-safe component variants
 - **TypeScript** — Full type definitions for all components and props
 
-## Next Steps
+## Next steps
 
 - [Getting Started](/docs/getting-started) — Install Apsara and build your first component
 - [Styling](/docs/styling) — Learn how to style and customize components

--- a/apps/www/src/content/docs/(overview)/styling.mdx
+++ b/apps/www/src/content/docs/(overview)/styling.mdx
@@ -5,7 +5,7 @@ description: How to style and customize Apsara components in your application.
 
 Apsara uses vanilla CSS with CSS custom properties (tokens) for all styling. There is no runtime CSS-in-JS — styles are static, scoped, and predictable. This guide covers the recommended ways to customize components and build your own styled elements.
 
-## Using Design Tokens
+## Using design tokens
 
 Design tokens are CSS custom properties that adapt automatically to the active theme. Always use tokens instead of hard-coded values — this ensures your UI stays consistent and responds to light/dark mode changes.
 
@@ -23,7 +23,7 @@ Design tokens are CSS custom properties that adapt automatically to the active t
 
 See the [Theme](/docs/theme/overview) section for the complete token reference.
 
-## Customizing Components
+## Customizing components
 
 ### With className
 
@@ -44,7 +44,7 @@ import { Button } from "@raystack/apsara";
 }
 ```
 
-### With style Prop
+### With style prop
 
 For one-off adjustments, use the inline `style` prop:
 
@@ -54,7 +54,7 @@ For one-off adjustments, use the inline `style` prop:
 </Flex>
 ```
 
-### With Data Attributes
+### With data attributes
 
 Apsara components built on [Base UI](https://base-ui.com/) expose data attributes that reflect component state. Use these for state-driven styling without JavaScript:
 
@@ -122,7 +122,7 @@ Combine them freely:
 
 Slots also make reliable selectors for tests (`querySelector('[data-slot="search-clear-button"]')`) instead of reaching for hashed CSS-module classes.
 
-#### Styling based on what a component contains
+### Styling based on what a component contains
 
 Because every part carries its own slot, a parent can change its own styling based on which children are present — no prop needed to signal it. CSS's `:has()` reaches into descendants:
 
@@ -156,7 +156,7 @@ This is the same technique as the state-based selectors above (`data-[state=open
 
 Coverage: every Apsara component exposes `data-slot` on every element it renders. Each component's docs page lists its slot names.
 
-## Theming with Data Attributes
+## Theming with data attributes
 
 The `Theme` component sets data attributes on the root `<html>` element. Use these to conditionally style elements based on the active theme:
 
@@ -181,11 +181,11 @@ Available theme attributes:
 | `data-accent-color` | `indigo`, `orange`, `mint` |
 | `data-gray-color` | `gray`, `mauve`, `slate`, `sage` |
 
-## Writing Component Styles
+## Writing component styles
 
 When building custom components in your application, follow these patterns used internally by Apsara:
 
-### Use CSS Modules for Scoping
+### Use CSS modules for scoping
 
 CSS Modules prevent class name collisions and keep styles co-located with components:
 
@@ -221,7 +221,7 @@ export function StatusCard({ status, children }) {
 }
 ```
 
-### Use CVA for Variant Management
+### Use CVA for variant management
 
 Apsara uses [class-variance-authority](https://cva.style/) (CVA) to manage component variants with type safety. This is recommended for components with multiple visual variations:
 
@@ -255,7 +255,7 @@ export function Tag({ size, color, className, children }: TagProps) {
 
 CVA handles merging the base class, variant classes, and any custom `className` passed by consumers.
 
-## Best Practices
+## Best practices
 
 **Use semantic tokens, not primitives.** Prefer `--rs-color-foreground-base-primary` over `--rs-neutral-12`. Semantic tokens automatically adapt across themes; primitives do not carry semantic meaning.
 

--- a/apps/www/src/content/docs/ai-elements/chat-panel/index.mdx
+++ b/apps/www/src/content/docs/ai-elements/chat-panel/index.mdx
@@ -54,6 +54,97 @@ Because floating and minimized rely on `position: fixed`, mount the panel
 near the layout root: an ancestor with `transform`, `filter` or
 `backdrop-filter` would break fixed positioning.
 
+## Usage
+
+### Mode transitions
+
+Switching mode flips the panel between in-flow and `position: fixed`, which no
+CSS property can tween, so the transform bridges the gap: the panel is rendered
+in its new mode already holding the shape it is coming out of, then eased back
+to rest. `transition` picks which shape that is.
+
+**`minimal`** (default) brings the new mode in from its own edge or corner and
+fades it up: the docked sidebar slides in from the edge it docks to, the
+floating window scales and lifts out of its corner, and the bubble grows out of
+its own. `--rs-duration-normal`.
+
+**`morph`** measures the box the panel is leaving and draws the new mode back
+over it — an inverse `translate` and `scale` off its top-left corner — so the
+panel travels and reshapes into its new place, the way a shared-layout
+animation does. Docking and popping out morph outright. The bubble is a tenth
+of the panel's size, so its two pairs cross-fade as well, and the bubble itself
+only travels — scaling it up to the panel's box would stretch its icon for the
+length of the tween. `--rs-duration-moderate`, because there is real distance to
+cover.
+
+Both use `--rs-ease-out`, so a transition is off the mark on its first frame and
+settles into place rather than easing away from a standstill.
+
+<Demo data={transitionDemo} />
+
+Both are skipped under `prefers-reduced-motion: reduce`, and neither runs on
+first paint — the transition needs a mode to have changed. Only the individual
+transform properties (`scale`, `translate`) are transitioned, never `transform`
+itself: dragging writes an inline `transform`, which stays instant, so a drag
+never lags the pointer and ending one never replays the transition.
+
+### Controlled mode
+
+Control `mode` to persist it, or to open the panel from your own UI. The
+floating window here is fixed to the browser viewport — pop it out and drag
+its header.
+
+<Demo data={controlledDemo} />
+
+### Constraining the drag to a container
+
+Dragging is built on [dnd-kit](https://dndkit.com). By default the floating
+window is clamped to the viewport; pass an element (or a ref to one) as
+`dragBoundary` to confine dragging to it instead. The panel keeps
+`position: fixed`, so the boundary only limits where a drag can put it.
+
+<Demo data={boundedDragDemo} />
+
+### Constraining the resize axes
+
+`resize` mirrors the CSS `resize` property: `both` (default), `horizontal`,
+`vertical` or `none`. Only the handles for the allowed axes render. The
+default `maxSize` is the initial floating size, so this demo passes a larger
+one to allow growing.
+
+<Demo data={resizeDemo} />
+
+### Draggable minimized bubble
+
+The minimized bubble can be dragged like the full panel, so it never ends up covering something the user needs.
+
+<Demo data={draggableBubbleDemo} />
+
+### Unread badge on the bubble
+
+Show a count on the bubble while the panel is minimized, so activity is visible without reopening it.
+
+<Demo data={unreadBadgeDemo} />
+
+### Persisting placement
+
+Position and size are controllable for apps that restore the floating window
+across sessions:
+
+```tsx
+<ChatPanel
+  mode={mode}
+  onModeChange={setMode}
+  position={saved.position}
+  onPositionChange={savePosition}
+  size={saved.size}
+  onSizeChange={saveSize}
+  minSize={{ width: 320, height: 400 }}
+>
+  …
+</ChatPanel>
+```
+
 ## API Reference
 
 ### Root
@@ -100,93 +191,6 @@ and `draggable` lets the bubble be dragged around the viewport — a completed
 drag never triggers the restore click.
 
 <auto-type-table path="./props.ts" name="ChatPanelTriggerProps" />
-
-## Mode transitions
-
-Switching mode flips the panel between in-flow and `position: fixed`, which no
-CSS property can tween, so the transform bridges the gap: the panel is rendered
-in its new mode already holding the shape it is coming out of, then eased back
-to rest. `transition` picks which shape that is.
-
-**`minimal`** (default) brings the new mode in from its own edge or corner and
-fades it up: the docked sidebar slides in from the edge it docks to, the
-floating window scales and lifts out of its corner, and the bubble grows out of
-its own. `--rs-duration-normal`.
-
-**`morph`** measures the box the panel is leaving and draws the new mode back
-over it — an inverse `translate` and `scale` off its top-left corner — so the
-panel travels and reshapes into its new place, the way a shared-layout
-animation does. Docking and popping out morph outright. The bubble is a tenth
-of the panel's size, so its two pairs cross-fade as well, and the bubble itself
-only travels — scaling it up to the panel's box would stretch its icon for the
-length of the tween. `--rs-duration-moderate`, because there is real distance to
-cover.
-
-Both use `--rs-ease-out`, so a transition is off the mark on its first frame and
-settles into place rather than easing away from a standstill.
-
-<Demo data={transitionDemo} />
-
-Both are skipped under `prefers-reduced-motion: reduce`, and neither runs on
-first paint — the transition needs a mode to have changed. Only the individual
-transform properties (`scale`, `translate`) are transitioned, never `transform`
-itself: dragging writes an inline `transform`, which stays instant, so a drag
-never lags the pointer and ending one never replays the transition.
-
-## Examples
-
-### Controlled mode
-
-Control `mode` to persist it, or to open the panel from your own UI. The
-floating window here is fixed to the browser viewport — pop it out and drag
-its header.
-
-<Demo data={controlledDemo} />
-
-### Constraining the drag to a container
-
-Dragging is built on [dnd-kit](https://dndkit.com). By default the floating
-window is clamped to the viewport; pass an element (or a ref to one) as
-`dragBoundary` to confine dragging to it instead. The panel keeps
-`position: fixed`, so the boundary only limits where a drag can put it.
-
-<Demo data={boundedDragDemo} />
-
-### Constraining the resize axes
-
-`resize` mirrors the CSS `resize` property: `both` (default), `horizontal`,
-`vertical` or `none`. Only the handles for the allowed axes render. The
-default `maxSize` is the initial floating size, so this demo passes a larger
-one to allow growing.
-
-<Demo data={resizeDemo} />
-
-### Draggable minimized bubble
-
-<Demo data={draggableBubbleDemo} />
-
-### Unread badge on the bubble
-
-<Demo data={unreadBadgeDemo} />
-
-### Persisting placement
-
-Position and size are controllable for apps that restore the floating window
-across sessions:
-
-```tsx
-<ChatPanel
-  mode={mode}
-  onModeChange={setMode}
-  position={saved.position}
-  onPositionChange={savePosition}
-  size={saved.size}
-  onSizeChange={saveSize}
-  minSize={{ width: 320, height: 400 }}
->
-  …
-</ChatPanel>
-```
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/ai-elements/chat/index.mdx
+++ b/apps/www/src/content/docs/ai-elements/chat/index.mdx
@@ -55,6 +55,21 @@ composed by your app — no markdown dependency enters the design system.
 Consumers own messages, streaming and sending; everything here is
 presentational.
 
+## Usage
+
+### Attachments
+
+`Chat.Attachment` renders a file alongside a message. Attachments sit inside the message item, so they scroll and anchor with it.
+
+<Demo data={attachmentDemo} />
+
+### Streaming and turn anchoring
+
+Send a message: it anchors near the top while the reply streams below, and
+the "↓ Latest" pill returns you to the live edge after scrolling up.
+
+<Demo data={streamingDemo} />
+
 ## API Reference
 
 ### Chat
@@ -117,19 +132,6 @@ A presentational attachment preview card for `PromptInput.Header` or message
 bodies. File picking, drag-drop and validation belong to your app.
 
 <auto-type-table path="./props.ts" name="ChatAttachmentProps" />
-
-## Examples
-
-### Attachments
-
-<Demo data={attachmentDemo} />
-
-### Streaming and turn anchoring
-
-Send a message: it anchors near the top while the reply streams below, and
-the "↓ Latest" pill returns you to the live edge after scrolling up.
-
-<Demo data={streamingDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/ai-elements/message/index.mdx
+++ b/apps/www/src/content/docs/ai-elements/message/index.mdx
@@ -30,32 +30,7 @@ anywhere: inside a `Chat` scroller, a comment thread, or a standalone
 transcript. Scroll behavior (visibility tracking, turn anchoring) belongs to
 [Chat](/docs/ai-elements/chat) — wrap a message in `Chat.Item` to opt in.
 
-## API Reference
-
-### Message
-
-One message. `align` drives which side everything sits on.
-
-<auto-type-table path="./props.ts" name="MessageProps" />
-
-Sub-parts are layout slots: `Message.Avatar` (bottom-aligned beside the
-message), `Message.Header` (sender line), `Message.Content` (the body
-column), `Message.Footer` (timestamp line) and `Message.Actions`
-(hover-revealed controls beside the bubble; always visible on touch devices).
-
-### Message.Group
-
-A flex column that pulls consecutive messages from the same sender closer
-together. Render the avatar and footer once — typically on the group's last
-message.
-
-### Message.Bubble
-
-The message surface.
-
-<auto-type-table path="./props.ts" name="MessageBubbleProps" />
-
-## Examples
+## Usage
 
 ### Message anatomy
 
@@ -86,6 +61,31 @@ conventional treatment for assistant replies: the reader's own messages keep a
 bubble, the assistant's read as page content.
 
 <Demo data={ghostDemo} />
+
+## API Reference
+
+### Message
+
+One message. `align` drives which side everything sits on.
+
+<auto-type-table path="./props.ts" name="MessageProps" />
+
+Sub-parts are layout slots: `Message.Avatar` (bottom-aligned beside the
+message), `Message.Header` (sender line), `Message.Content` (the body
+column), `Message.Footer` (timestamp line) and `Message.Actions`
+(hover-revealed controls beside the bubble; always visible on touch devices).
+
+### Message.Group
+
+A flex column that pulls consecutive messages from the same sender closer
+together. Render the avatar and footer once — typically on the group's last
+message.
+
+### Message.Bubble
+
+The message surface.
+
+<auto-type-table path="./props.ts" name="MessageBubbleProps" />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/ai-elements/prompt-input/index.mdx
+++ b/apps/www/src/content/docs/ai-elements/prompt-input/index.mdx
@@ -35,6 +35,157 @@ request. Pass the lifecycle in through `status` and react to `onSubmit` /
 `onStop` — it works with the AI SDK's `useChat`, a custom SSE client, or
 anything else.
 
+## Usage
+
+### Value format
+
+A chip is written as `@[label](type:id)`, using whatever character the trigger
+is:
+
+```
+check @[DataTable](component:data-table) with @[Maya Chen](user:u1)
+```
+
+`value`, `defaultValue` and the first argument of `onValueChange` all use this
+format, so the obvious controlled wiring keeps chips intact:
+
+```tsx
+const [value, setValue] = useState('');
+<PromptInput value={value} onValueChange={setValue} />
+```
+
+Save this string as the user's draft. A few details:
+
+- `]`, `)` and `\` in a label are escaped with `\`, as are `:`, `)` and `\` in
+  a type or id.
+- A line break is written as `\n`.
+- Anything that does not parse stays as plain text — nothing throws, nothing
+  is dropped.
+- Only `value` and `defaultValue` are parsed. Text you type or paste that
+  happens to look like `@[…](…)` stays as-is.
+- Icons and `data` cannot be saved in a string, so restoring a draft needs
+  `resolveMentions` — see [Restoring a draft](#restoring-a-draft).
+
+### Everything the Editor can do
+
+One composer with all of it turned on: a restored draft, a mention menu with
+icons, a badge, a disabled row and sections, a length cap, buttons that drive
+it from code, and a live readout of what you'd get on submit.
+
+<Demo data={editorCapabilitiesDemo} />
+
+Things worth trying in it:
+
+- **Chips behave like one character.** Backspace deletes a whole chip, arrow
+  keys step past it, and clicking one selects it.
+- **Undo and redo** with Cmd/Ctrl+Z and Cmd/Ctrl+Shift+Z. Inserting a chip
+  undoes in one step.
+- **Copy a chip and paste it back** — it comes back as a chip, id intact.
+  Paste it into a plain text field and you get `@Maya Chen`.
+- **Paste formatted text** from a doc or a webpage and it arrives as plain
+  text. The editor has no bold, headings or lists to paste into.
+- **Shift+Enter** adds a line break; Enter sends.
+- **The length cap** counts a chip as its label and applies to pasted text
+  too, so you can't paste past it.
+- **Multi-word search:** type `@maya ch` — the space keeps searching. Keep
+  typing past the point where nothing matches and the menu gives up and leaves
+  your text alone.
+- **Escape** closes the menu and leaves what you typed as plain text. Delete a
+  character and it comes back.
+
+### Mentions
+
+Typing `@` opens a menu at the cursor. Picking an item drops a chip into the
+text, followed by a space. The chip deletes in one press, arrow keys step over
+it, and a message that is nothing but a chip still sends.
+
+The chip itself shows the item's icon and label — not the `@`. The trigger is
+kept in the text you get on submit (`@Maya Chen`), where the mention boundary
+has to survive being read by a model.
+
+Sections appear in the order their `group` first shows up in your data, so you
+control the order by ordering `items`. Items without a `group` come first, and
+a section with no matches disappears.
+
+<Demo data={mentionsDemo} />
+
+### Async mentions and restoring a draft
+
+`onSearch` runs about 150 ms after the user stops typing and gets an
+`AbortSignal` you can pass to `fetch`. Out-of-date responses are ignored,
+loading rows show while a request is out, and a failed request shows the empty
+state.
+
+A query can contain spaces so multi-word names stay searchable. Once a query
+with a space stops matching anything, the menu closes and the text is left
+alone.
+
+### Restoring a draft
+
+A chip loaded from `defaultValue` starts with just its label, since a saved
+string can't carry an icon or `data`. Pass `resolveMentions` to look those up
+and fill them in — it also refreshes the label if the entity was renamed.
+Lookups are batched and cached. If one fails or comes back empty, the chip
+simply stays label-only; it is never removed.
+
+<Demo data={mentionsAsyncDemo} />
+
+### Inserting a mention from code
+
+`actionsRef` gives you `focus`, `clear`, `getValue` and `insertMention`.
+`insertMention` inserts at the cursor, or at the end if the editor isn't
+focused. `ref` still points at the `<form>`.
+
+<Demo data={insertMentionDemo} />
+
+### Attachments in the header
+
+Attachment previews are presentational (`Chat.Attachment`); file picking,
+drag-drop and uploads belong to your app.
+
+<Demo data={attachmentsDemo} />
+
+### Status
+
+`status` reflects the request lifecycle your app manages:
+
+- **`idle`** — the resting state; the submit button shows the send arrow and
+  disables itself while the composer is empty.
+- **`submitted`** — the request is sent but nothing has streamed back yet;
+  the button shows a spinner, Enter/submit is blocked, and clicking calls
+  `onStop`.
+- **`streaming`** — tokens are arriving; the button flips to a stop square
+  that calls `onStop`, and submit stays blocked.
+- **`error`** — the request failed; the composer returns to a submittable
+  state (send arrow) so the user can retry. Render your error message
+  outside the composer.
+
+<Demo data={statusDemo} />
+
+### Controlled value
+
+Control `value` to sync the draft elsewhere — persistence, slash-command
+menus, mention pickers.
+
+<Demo data={controlledDemo} />
+
+### Disabled
+
+`disabled` stops typing and submitting while a request is in flight, without clearing what the user already wrote.
+
+<Demo data={disabledDemo} />
+
+### When the composer counts as empty
+
+A composer counts as empty when it has no chips and its text is only
+whitespace. The submit button, the `data-empty` attribute and the placeholder
+all use that same rule, so they always agree:
+
+- A message that is only a chip is not empty and sends.
+- Whitespace on its own is empty.
+- Leading and trailing whitespace is trimmed off the submitted message,
+  including the space added after a chip. Chips are never trimmed.
+
 ## API Reference
 
 ### Root
@@ -116,155 +267,6 @@ composer is empty, shows a spinner while `status="submitted"`, and flips to a
 stop square that calls `onStop` while `status="streaming"`.
 
 <auto-type-table path="./props.ts" name="PromptInputSubmitProps" />
-
-## Value format
-
-A chip is written as `@[label](type:id)`, using whatever character the trigger
-is:
-
-```
-check @[DataTable](component:data-table) with @[Maya Chen](user:u1)
-```
-
-`value`, `defaultValue` and the first argument of `onValueChange` all use this
-format, so the obvious controlled wiring keeps chips intact:
-
-```tsx
-const [value, setValue] = useState('');
-<PromptInput value={value} onValueChange={setValue} />
-```
-
-Save this string as the user's draft. A few details:
-
-- `]`, `)` and `\` in a label are escaped with `\`, as are `:`, `)` and `\` in
-  a type or id.
-- A line break is written as `\n`.
-- Anything that does not parse stays as plain text — nothing throws, nothing
-  is dropped.
-- Only `value` and `defaultValue` are parsed. Text you type or paste that
-  happens to look like `@[…](…)` stays as-is.
-- Icons and `data` cannot be saved in a string, so restoring a draft needs
-  `resolveMentions` — see [Restoring a draft](#restoring-a-draft).
-
-## Examples
-
-### Everything the Editor can do
-
-One composer with all of it turned on: a restored draft, a mention menu with
-icons, a badge, a disabled row and sections, a length cap, buttons that drive
-it from code, and a live readout of what you'd get on submit.
-
-<Demo data={editorCapabilitiesDemo} />
-
-Things worth trying in it:
-
-- **Chips behave like one character.** Backspace deletes a whole chip, arrow
-  keys step past it, and clicking one selects it.
-- **Undo and redo** with Cmd/Ctrl+Z and Cmd/Ctrl+Shift+Z. Inserting a chip
-  undoes in one step.
-- **Copy a chip and paste it back** — it comes back as a chip, id intact.
-  Paste it into a plain text field and you get `@Maya Chen`.
-- **Paste formatted text** from a doc or a webpage and it arrives as plain
-  text. The editor has no bold, headings or lists to paste into.
-- **Shift+Enter** adds a line break; Enter sends.
-- **The length cap** counts a chip as its label and applies to pasted text
-  too, so you can't paste past it.
-- **Multi-word search:** type `@maya ch` — the space keeps searching. Keep
-  typing past the point where nothing matches and the menu gives up and leaves
-  your text alone.
-- **Escape** closes the menu and leaves what you typed as plain text. Delete a
-  character and it comes back.
-
-### Mentions
-
-Typing `@` opens a menu at the cursor. Picking an item drops a chip into the
-text, followed by a space. The chip deletes in one press, arrow keys step over
-it, and a message that is nothing but a chip still sends.
-
-The chip itself shows the item's icon and label — not the `@`. The trigger is
-kept in the text you get on submit (`@Maya Chen`), where the mention boundary
-has to survive being read by a model.
-
-Sections appear in the order their `group` first shows up in your data, so you
-control the order by ordering `items`. Items without a `group` come first, and
-a section with no matches disappears.
-
-<Demo data={mentionsDemo} />
-
-### Async mentions and restoring a draft
-
-`onSearch` runs about 150 ms after the user stops typing and gets an
-`AbortSignal` you can pass to `fetch`. Out-of-date responses are ignored,
-loading rows show while a request is out, and a failed request shows the empty
-state.
-
-A query can contain spaces so multi-word names stay searchable. Once a query
-with a space stops matching anything, the menu closes and the text is left
-alone.
-
-#### Restoring a draft
-
-A chip loaded from `defaultValue` starts with just its label, since a saved
-string can't carry an icon or `data`. Pass `resolveMentions` to look those up
-and fill them in — it also refreshes the label if the entity was renamed.
-Lookups are batched and cached. If one fails or comes back empty, the chip
-simply stays label-only; it is never removed.
-
-<Demo data={mentionsAsyncDemo} />
-
-### Inserting a mention from code
-
-`actionsRef` gives you `focus`, `clear`, `getValue` and `insertMention`.
-`insertMention` inserts at the cursor, or at the end if the editor isn't
-focused. `ref` still points at the `<form>`.
-
-<Demo data={insertMentionDemo} />
-
-### Attachments in the header
-
-Attachment previews are presentational (`Chat.Attachment`); file picking,
-drag-drop and uploads belong to your app.
-
-<Demo data={attachmentsDemo} />
-
-### Status
-
-`status` reflects the request lifecycle your app manages:
-
-- **`idle`** — the resting state; the submit button shows the send arrow and
-  disables itself while the composer is empty.
-- **`submitted`** — the request is sent but nothing has streamed back yet;
-  the button shows a spinner, Enter/submit is blocked, and clicking calls
-  `onStop`.
-- **`streaming`** — tokens are arriving; the button flips to a stop square
-  that calls `onStop`, and submit stays blocked.
-- **`error`** — the request failed; the composer returns to a submittable
-  state (send arrow) so the user can retry. Render your error message
-  outside the composer.
-
-<Demo data={statusDemo} />
-
-### Controlled value
-
-Control `value` to sync the draft elsewhere — persistence, slash-command
-menus, mention pickers.
-
-<Demo data={controlledDemo} />
-
-### Disabled
-
-<Demo data={disabledDemo} />
-
-## When is the composer empty?
-
-A composer counts as empty when it has no chips and its text is only
-whitespace. The submit button, the `data-empty` attribute and the placeholder
-all use that same rule, so they always agree:
-
-- A message that is only a chip is not empty and sends.
-- Whitespace on its own is empty.
-- Leading and trailing whitespace is trimmed off the submitted message,
-  including the space added after a chip. Chips are never trimmed.
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/ai-elements/reasoning/index.mdx
+++ b/apps/www/src/content/docs/ai-elements/reasoning/index.mdx
@@ -28,6 +28,21 @@ Built on `Collapsible`. Drive `streaming` from your transport; everything
 here is presentational and works anywhere — inside a
 [Message](/docs/ai-elements/message) body, a `Chat` scroller, or on its own.
 
+## Usage
+
+### Streaming
+
+Drive `streaming` from your transport; the trigger label and open state
+follow along.
+
+<Demo data={streamingDemo} />
+
+### Custom trigger label
+
+Replace the default trigger text when "Reasoning" is not the right word for what the model is doing.
+
+<Demo data={customTriggerDemo} />
+
 ## API Reference
 
 ### Reasoning
@@ -52,19 +67,6 @@ The collapsible panel holding the steps.
 A labelled row with optional indented detail.
 
 <auto-type-table path="./props.ts" name="ReasoningStepProps" />
-
-## Examples
-
-### Streaming
-
-Drive `streaming` from your transport; the trigger label and open state
-follow along.
-
-<Demo data={streamingDemo} />
-
-### Custom trigger label
-
-<Demo data={customTriggerDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/accordion/index.mdx
+++ b/apps/www/src/content/docs/components/accordion/index.mdx
@@ -29,6 +29,32 @@ import { Accordion } from '@raystack/apsara'
 </Accordion>
 ```
 
+## Usage
+
+### Single vs multiple
+
+`single` (the default) closes the open item when another opens. `multiple` lets any number stay open at once.
+
+<Demo data={typeDemo} />
+
+### Controlled
+
+Pass `value` with `onValueChange` to own which item is open — needed when something outside the accordion has to open or close a section.
+
+<Demo data={controlledDemo} />
+
+### Disabled items
+
+Individual accordion items can be disabled using the `disabled` prop.
+
+<Demo data={disabledDemo} />
+
+### Custom Content
+
+The accordion content can contain any React elements, allowing for rich layouts and complex content.
+
+<Demo data={customContentDemo} />
+
 ## API Reference
 
 ### Root
@@ -68,35 +94,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `accordion-trigger-icon` | The chevron icon inside the trigger |
 | `accordion-content` | The collapsible panel for an item |
 | `accordion-content-body` | The padded `<div>` that holds the panel content |
-
-## Examples
-
-### Single vs Multiple
-
-The Accordion component supports two modes:
-
-- **Single** (default): Only one item can be open at a time. Set `multiple={false}` or omit the prop.
-- **Multiple**: Multiple items can be open simultaneously. Set `multiple={true}`.
-
-<Demo data={typeDemo} />
-
-### Controlled
-
-You can control the accordion's state by providing `value` and `onValueChange` props.
-
-<Demo data={controlledDemo} />
-
-### Disabled Items
-
-Individual accordion items can be disabled using the `disabled` prop.
-
-<Demo data={disabledDemo} />
-
-### Custom Content
-
-The accordion content can contain any React elements, allowing for rich layouts and complex content.
-
-<Demo data={customContentDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/alert-dialog/index.mdx
+++ b/apps/www/src/content/docs/components/alert-dialog/index.mdx
@@ -31,6 +31,32 @@ import { AlertDialog } from '@raystack/apsara'
 </AlertDialog>
 ```
 
+## Usage
+
+### Controlled
+
+Pass `open` with `onOpenChange` to own the state — needed when something other than the trigger has to close the dialog, such as a request completing.
+
+<Demo data={controlledDemo} />
+
+### Composing with Menu
+
+Open an alert dialog from a menu item. Since the trigger is outside the `AlertDialog.Root`, use the controlled `open` / `onOpenChange` props.
+
+<Demo data={menuDemo} />
+
+### Discard changes
+
+A common pattern for confirming destructive navigation. Both actions use `AlertDialog.Close` to dismiss the dialog.
+
+<Demo data={discardDemo} />
+
+### Nested alert dialogs
+
+You can nest alert dialogs for multi-step confirmation flows. When a nested alert dialog opens, the parent dialog automatically scales down and becomes slightly transparent.
+
+<Demo data={nestedDemo} />
+
 ## API Reference
 
 ### Root
@@ -95,32 +121,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `alert-dialog-body` | The `AlertDialog.Body` container |
 | `alert-dialog-description` | The `AlertDialog.Description` element |
 | `alert-dialog-footer` | The `AlertDialog.Footer` row |
-
-## Examples
-
-### Controlled
-
-Example of a controlled alert dialog with custom state management.
-
-<Demo data={controlledDemo} />
-
-### Composing with Menu
-
-Open an alert dialog from a menu item. Since the trigger is outside the `AlertDialog.Root`, use the controlled `open` / `onOpenChange` props.
-
-<Demo data={menuDemo} />
-
-### Discard Changes
-
-A common pattern for confirming destructive navigation. Both actions use `AlertDialog.Close` to dismiss the dialog.
-
-<Demo data={discardDemo} />
-
-### Nested Alert Dialogs
-
-You can nest alert dialogs for multi-step confirmation flows. When a nested alert dialog opens, the parent dialog automatically scales down and becomes slightly transparent.
-
-<Demo data={nestedDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/amount/index.mdx
+++ b/apps/www/src/content/docs/components/amount/index.mdx
@@ -30,6 +30,68 @@ import { Amount } from '@raystack/apsara'
 <Amount />
 ```
 
+## Usage
+
+### Basic
+
+Pass a `value` and a `currency` code. Amount formats it for the active locale using `Intl.NumberFormat`, and renders in tabular numbers so columns of figures line up.
+
+<Demo data={basicDemo} />
+
+### Currency variants
+
+`currency` takes any ISO 4217 code. The symbol, its position, and the decimal and grouping separators all follow the currency and locale rather than being hard-coded.
+
+<Demo data={currencyDemo} />
+
+### Currency display
+
+How the currency is written: `symbol` (the default, `$`), `code` (`USD`), or `name` (`US dollars`).
+
+<Demo data={currencyDisplayDemo} />
+
+### Number without currency
+
+Render only the formatted number, without any currency symbol, code, or name. Locale-driven separators and decimal places are preserved.
+
+<Demo data={hideCurrencyDemo} />
+
+### Minor units
+
+Set `valueInMinorUnits` when your API returns integer cents, paise, or fils. Amount divides by the currency's own exponent — 100 for USD, 1 for JPY — so you never hard-code the divisor.
+
+<Demo data={valueInMinorUnitsDemo} />
+
+### Locale
+
+`locale` overrides the browser locale for one value. Useful when an invoice must render in the customer's locale rather than the viewer's.
+
+<Demo data={localeDemo} />
+
+### Whole units
+
+`hideDecimals` rounds to whole units. Use it in dense tables and summary figures where the fraction adds noise rather than precision.
+
+<Demo data={hideDecimalsDemo} />
+
+### Digit grouping
+
+Thousands separators are on by default. Set `groupDigits={false}` for identifiers and reference numbers, where grouping would misread as a quantity.
+
+<Demo data={groupDigitsDemo} />
+
+### Large numbers
+
+For numbers larger than JavaScript's safe integer limit (2^53 - 1), pass the value as a `string` (supports decimals) or a `bigint` (integer-only). BigInt values are always treated as already in major units, so `valueInMinorUnits` is ignored for them.
+
+<Demo data={largeNumbersDemo} />
+
+### With Text
+
+Amount renders a `span`, so it composes inside `Text` and inherits size, weight, and colour from it.
+
+<Demo data={withTextDemo} />
+
 ## API Reference
 
 Formats and displays monetary values with locale and currency support.
@@ -43,52 +105,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | Slot | Element |
 |------|---------|
 | `amount` | The root `<span>` element |
-
-## Examples
-
-### Basic
-
-<Demo data={basicDemo} />
-
-### Currency Variants
-
-<Demo data={currencyDemo} />
-
-### valueInMinorUnits
-
-<Demo data={valueInMinorUnitsDemo} />
-
-### locale
-
-<Demo data={localeDemo} />
-
-### hideDecimals
-
-<Demo data={hideDecimalsDemo} />
-
-### currencyDisplay
-
-<Demo data={currencyDisplayDemo} />
-
-### hideCurrency
-
-Render only the formatted number, without any currency symbol, code, or name. Locale-driven separators and decimal places are preserved.
-
-<Demo data={hideCurrencyDemo} />
-
-### groupDigits
-
-<Demo data={groupDigitsDemo} />
-
-### Large Numbers
-
-For numbers larger than JavaScript's safe integer limit (2^53 - 1), pass the value as a `string` (supports decimals) or a `bigint` (integer-only). BigInt values are always treated as already in major units, so `valueInMinorUnits` is ignored for them.
-
-<Demo data={largeNumbersDemo} />
-
-### With Text
-
-<Demo data={withTextDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/announcement-bar/index.mdx
+++ b/apps/www/src/content/docs/components/announcement-bar/index.mdx
@@ -18,6 +18,14 @@ import { AnnouncementBar } from '@raystack/apsara'
 <AnnouncementBar />
 ```
 
+## Usage
+
+### Variant
+
+Variants convey the tone of the announcement. Default is `normal`; use `error` for urgent notices and `gradient` for promotional messages.
+
+<Demo data={variantsDemo} />
+
 ## API Reference
 
 Renders a dismissible banner for announcements and alerts.
@@ -36,14 +44,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `announcement-bar-action` | The action `<button>` (when `actionLabel` or `actionIcon` is set) |
 | `announcement-bar-action-label` | The action button's text label |
 | `announcement-bar-action-icon` | Wrapper around the action icon (when `actionIcon` is set) |
-
-## Examples
-
-### Variant
-
-Variants convey the tone of the announcement. Default is `normal`; use `error` for urgent notices and `gradient` for promotional messages.
-
-<Demo data={variantsDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/avatar/index.mdx
+++ b/apps/www/src/content/docs/components/avatar/index.mdx
@@ -32,6 +32,44 @@ import { Avatar, AvatarGroup, getAvatarColor } from '@raystack/apsara'
 </AvatarGroup>
 ```
 
+## Usage
+
+### Variant
+
+Choose between soft and solid variants to control the visual weight and emphasis of the avatar in your interface.
+
+<Demo data={variantDemo} />
+
+### Size
+
+`size` is a number in pixels rather than a named scale, so an avatar can match whatever line height or row it sits in.
+
+<Demo data={sizesDemo} />
+
+### Color
+
+Avatar comes with a range of predefined colors including both base and extended color options to match your design system.
+
+<Demo data={colorsDemo} />
+
+### Radius
+
+Choose between small and full border radius styles to match your design preferences.
+
+<Demo data={radiusDemo} />
+
+### With Image
+
+Avatar can display user images with graceful fallback to initials when images fail to load or aren't available.
+
+<Demo data={imageDemo} />
+
+### With generated colors
+
+use `getAvatarColor` utility to generate colors based on a string.
+
+<Demo data={generatedColorDemo} />
+
 ## API Reference
 
 ### Avatar
@@ -57,44 +95,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `avatar-fallback` | The fallback shown before the image loads or on error |
 | `avatar-group` | The root `<div>` of an `AvatarGroup` |
 | `avatar-group-item` | Wrapper around each avatar in the group, including the overflow avatar |
-
-## Examples
-
-### Variant
-
-Choose between soft and solid variants to control the visual weight and emphasis of the avatar in your interface.
-
-<Demo data={variantDemo} />
-
-### Size
-
-The Avatar component supports 13 different sizes to accommodate various layout requirements and design needs.
-
-<Demo data={sizesDemo} />
-
-### Color
-
-Avatar comes with a range of predefined colors including both base and extended color options to match your design system.
-
-<Demo data={colorsDemo} />
-
-### Radius
-
-Choose between small and full border radius styles to match your design preferences.
-
-<Demo data={radiusDemo} />
-
-### With Image
-
-Avatar can display user images with graceful fallback to initials when images fail to load or aren't available.
-
-<Demo data={imageDemo} />
-
-### With Generated Colors
-
-use `getAvatarColor` utility to generate colors based on a string.
-
-<Demo data={generatedColorDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/badge/index.mdx
+++ b/apps/www/src/content/docs/components/badge/index.mdx
@@ -24,6 +24,26 @@ import { Badge } from '@raystack/apsara'
 <Badge />
 ```
 
+## Usage
+
+### Variant
+
+Choose between different variants to convey different meanings or importance levels. Default variant is `accent`.
+
+<Demo data={variantDemo} />
+
+### Size
+
+Three sizes. `regular` is the default; `small` and `micro` fit inside table rows and beside dense labels.
+
+<Demo data={sizesDemo} />
+
+### With icon
+
+Badges can include an icon to provide additional visual context. By default there is no icon.
+
+<Demo data={iconDemo} />
+
 ## API Reference
 
 Renders a small label for status, count, or category indication.
@@ -39,26 +59,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `badge` | The root `<span>` element |
 | `badge-icon` | Wrapper around `icon` (when set) |
 | `badge-screen-reader-text` | Visually hidden text (when `screenReaderText` is set) |
-
-## Examples
-
-### Variant
-
-Choose between different variants to convey different meanings or importance levels. Default variant is `accent`.
-
-<Demo data={variantDemo} />
-
-### Size
-
-The Badge component supports three sizes to accommodate various layout requirements. Default size is `small`.
-
-<Demo data={sizesDemo} />
-
-### With Icon
-
-Badges can include an icon to provide additional visual context. By default there is no icon.
-
-<Demo data={iconDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/breadcrumb/index.mdx
+++ b/apps/www/src/content/docs/components/breadcrumb/index.mdx
@@ -34,6 +34,58 @@ import { Breadcrumb } from '@raystack/apsara'
 </Breadcrumb>
 ```
 
+## Usage
+
+### Size
+
+Two sizes. Use the smaller one when the trail sits in a toolbar rather than above a page title.
+
+<Demo data={sizeDemo} />
+
+### Separator
+
+Customize the separator between breadcrumb items using the `separator` prop.
+
+<Demo data={separatorDemo} />
+
+### Ellipsis
+
+Use the `Breadcrumb.Ellipsis` component to truncate the breadcrumb trail when you need to display a large number of items in a limited space.
+
+<Demo data={ellipsisDemo} />
+
+### Icons
+
+Breadcrumb items can include icons via `leadingIcon` (before the label) or `trailingIcon` (after the label), either alongside text or as standalone elements.
+
+<Demo data={iconsDemo} />
+
+### Dropdown
+
+Breadcrumb items can include dropdown menus for additional navigation options. Specify them with the `dropdownItems` prop: each entry is the same props as `<Menu.Item>` (e.g. `children` for the label, `onClick`, `disabled`, `render` for a link such as `<a href="…" />`, etc.). You can also pass `key` for stable list keys.
+
+**Note:** When `dropdownItems` is provided, the `render` and `href` props are ignored.
+
+<Demo data={dropdownDemo} />
+<Demo data={dropdownLinksDemo} />
+
+### Render
+
+Use the `render` prop to render the breadcrumb item as a custom component. Pass a JSX element (e.g. `render={<NextLink />}`) and we will replace the default `<a>` while merging props. By default, items render as `a` tags.
+
+```tsx
+// Correct: set href on the item (it will be forwarded into the rendered element)
+<Breadcrumb.Item href="/" render={<NextLink />}>Home</Breadcrumb.Item>
+```
+
+<Demo data={asDemo} />
+
+### Disabled
+
+Use the `disabled` prop for non-clickable, visually muted items—for example, loading states or segments the user does not have access to. Disabled items render as a span with `aria-disabled="true"` and do not navigate.
+
+<Demo data={disabledDemo} />
+
 ## API Reference
 
 ### Root
@@ -96,58 +148,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `breadcrumb-dropdown-item` | An entry in the dropdown menu |
 | `breadcrumb-separator` | `Breadcrumb.Separator` |
 | `breadcrumb-ellipsis` | `Breadcrumb.Ellipsis` |
-
-## Examples
-
-### Size
-
-The Breadcrumb component supports different sizes to accommodate various design requirements. Specify the size using the `size` prop.
-
-<Demo data={sizeDemo} />
-
-### Separator
-
-Customize the separator between breadcrumb items using the `separator` prop.
-
-<Demo data={separatorDemo} />
-
-### Ellipsis
-
-Use the `Breadcrumb.Ellipsis` component to truncate the breadcrumb trail when you need to display a large number of items in a limited space.
-
-<Demo data={ellipsisDemo} />
-
-### Icons
-
-Breadcrumb items can include icons via `leadingIcon` (before the label) or `trailingIcon` (after the label), either alongside text or as standalone elements.
-
-<Demo data={iconsDemo} />
-
-### Dropdown
-
-Breadcrumb items can include dropdown menus for additional navigation options. Specify them with the `dropdownItems` prop: each entry is the same props as `<Menu.Item>` (e.g. `children` for the label, `onClick`, `disabled`, `render` for a link such as `<a href="…" />`, etc.). You can also pass `key` for stable list keys.
-
-**Note:** When `dropdownItems` is provided, the `render` and `href` props are ignored.
-
-<Demo data={dropdownDemo} />
-<Demo data={dropdownLinksDemo} />
-
-### Render
-
-Use the `render` prop to render the breadcrumb item as a custom component. Pass a JSX element (e.g. `render={<NextLink />}`) and we will replace the default `<a>` while merging props. By default, items render as `a` tags.
-
-```tsx
-// Correct: set href on the item (it will be forwarded into the rendered element)
-<Breadcrumb.Item href="/" render={<NextLink />}>Home</Breadcrumb.Item>
-```
-
-<Demo data={asDemo} />
-
-### Disabled
-
-Use the `disabled` prop for non-clickable, visually muted items—for example, loading states or segments the user does not have access to. Disabled items render as a span with `aria-disabled="true"` and do not navigate.
-
-<Demo data={disabledDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/button/demo.ts
+++ b/apps/www/src/content/docs/components/button/demo.ts
@@ -53,7 +53,7 @@ export const colorsDemo = {
       name: 'Solid',
       code: `
       <Flex gap={9}>
-        <Button color="success">Accent</Button>
+        <Button color="accent">Accent</Button>
         <Button color="danger">Danger</Button>
         <Button color="neutral">Neutral</Button>
         <Button color="success">Success</Button>
@@ -63,7 +63,7 @@ export const colorsDemo = {
       name: 'Outline',
       code: `
       <Flex gap={9}>
-        <Button variant="outline" color="success">Accent</Button>
+        <Button variant="outline" color="accent">Accent</Button>
         <Button variant="outline" color="danger">Danger</Button>
         <Button variant="outline" color="neutral">Neutral</Button>
         <Button variant="outline" color="success">Success</Button>
@@ -73,7 +73,7 @@ export const colorsDemo = {
       name: 'Ghost',
       code: `
       <Flex gap={9}>
-        <Button variant="ghost" color="success">Accent</Button>
+        <Button variant="ghost" color="accent">Accent</Button>
         <Button variant="ghost" color="danger">Danger</Button>
         <Button variant="ghost" color="neutral">Neutral</Button>
         <Button variant="ghost" color="success">Success</Button>
@@ -83,7 +83,7 @@ export const colorsDemo = {
       name: 'Text',
       code: `
       <Flex gap={9}>
-        <Button variant="text" color="success">Accent</Button>
+        <Button variant="text" color="accent">Accent</Button>
         <Button variant="text" color="danger">Danger</Button>
         <Button variant="text" color="neutral">Neutral</Button>
         <Button variant="text" color="success">Success</Button>
@@ -122,5 +122,13 @@ export const iconsDemo = {
     <Button variant="solid" color="accent" leadingIcon={<>I</>}>With leading icon</Button>
     <Button variant="solid" color="accent" trailingIcon={<>O</>}>With trailing icon</Button>
     <Button variant="solid" color="accent" leadingIcon={<>I</>} trailingIcon={<>O</>}>With both icons</Button>
+  </Flex>`
+};
+
+export const renderDemo = {
+  type: 'code',
+  code: `<Flex gap={9} align="center">
+    <Button render={<a href="/docs/components/link" />}>Rendered as a link</Button>
+    <Button variant="outline" render={<a href="/docs/components/link" />}>Outline link</Button>
   </Flex>`
 };

--- a/apps/www/src/content/docs/components/button/index.mdx
+++ b/apps/www/src/content/docs/components/button/index.mdx
@@ -12,6 +12,7 @@ import {
   disabledDemo,
   loadingDemo,
   iconsDemo,
+  renderDemo,
 } from "./demo.ts";
 
 <Demo data={playground} />
@@ -25,6 +26,52 @@ import { Button } from '@raystack/apsara'
 
 <Button />
 ```
+
+## Usage
+
+### Variant
+
+Four styles, in descending order of emphasis. Use `solid` for the one primary action on a screen, `outline` for secondary actions beside it, and `ghost` or `text` for actions that sit inside dense UI where a filled button would shout. Default is `solid`.
+
+<Demo data={variantsDemo} />
+
+### Color
+
+Color carries meaning, not decoration. `danger` for destructive actions, `success` for confirmations, `neutral` for actions that shouldn't compete for attention, `accent` for everything else. Default is `accent`.
+
+<Demo data={colorsDemo} />
+
+### Size
+
+Two sizes. `normal` is the default and fits most layouts. Use `small` inside toolbars, table rows, and other dense surfaces.
+
+<Demo data={sizesDemo} />
+
+### With icons
+
+Pass `leadingIcon`, `trailingIcon`, or both. A leading icon reinforces the action; a trailing icon usually signals what happens next, like an arrow for navigation or a chevron for a menu.
+
+<Demo data={iconsDemo} />
+
+### Loading
+
+`loading` swaps the content for a spinner and blocks further clicks, so an in-flight action can't be fired twice. Add `loaderText` to say what's happening — useful when the wait is longer than a second or two.
+
+<Demo data={loadingDemo} />
+
+### Disabled
+
+`disabled` stops the button responding to any interaction. Default is `false`.
+
+<Demo data={disabledDemo} />
+
+### Render as another element
+
+`render` swaps the underlying element while keeping the button's styling and behaviour. Use it for links that should look like buttons, so the browser still gives you middle-click, right-click, and open-in-new-tab.
+
+<Demo data={renderDemo} />
+
+When the rendered element isn't a real `<button>`, `nativeButton` defaults to `false` so the correct role and keyboard handling are applied.
 
 ## API Reference
 
@@ -43,43 +90,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `button-trailing-icon` | Wrapper around `trailingIcon` (when set and not loading) |
 | `button-loader` | The loading spinner (when `loading`) |
 | `button-loader-text` | Wrapper around `loaderText` (when `loading` with `loaderText`) |
-
-## Examples
-
-### Variant
-
-Variants allow you to customize the button's style, making it visually distinctive and suitable for different purposes. Default is `solid`.
-
-<Demo data={variantsDemo} />
-
-### Color
-
-Colors help convey the purpose and importance of actions. The color prop only affects solid and outline variants. Default is `accent`.
-
-<Demo data={colorsDemo} />
-### Size
-
-The Button component offers two size options. Default size is `normal`.
-
-<Demo data={sizesDemo} />
-
-### Disabled
-
-The Button component provides a "disabled" state, which prevents the button from responding to any user actions. Default is `false`.
-
-<Demo data={disabledDemo} />
-
-### Loading
-
-The Button component offers inbuilt loading states. Loading state is used to signify an ongoing process after the user has clicked on the button.
-
-<Demo data={loadingDemo} />
-
-### With leading and trailing icons
-
-The button component accepts optional leading and/or trailing icons.
-
-<Demo data={iconsDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/calendar/index.mdx
+++ b/apps/www/src/content/docs/components/calendar/index.mdx
@@ -29,6 +29,44 @@ import { Calendar, RangePicker, DatePicker } from '@raystack/apsara'
 <DatePicker />
 ```
 
+## Usage
+
+### Layout and appearance
+
+Number of months, dropdown nav, loading state, footer.
+
+<Demo data={calendarDemo} />
+
+### Behaviour and data
+
+Tooltips, disabled days, timezone, controlled month navigation.
+
+<Demo data={calendarBehaviorDemo} />
+
+### Custom date information
+
+You can display custom components above each date using the `dateInfo` prop. The keys should be date strings in `"dd-MM-yyyy"` format, and the values are React components that will be rendered above the date number.
+
+<Demo data={dateInfoDemo} />
+
+### Range picker
+
+Selects a date range across two inputs. The grid uses a state machine that branches on the current `from` / `to`:
+
+- **Empty** — first click sets `from` and advances focus to the end input.
+- **Only `from` set** — clicking a later date completes the range and closes the popover; clicking an earlier date resets `from`.
+- **Both set** — clicking again restarts: the new date becomes `from`, `to` clears.
+
+`onSelect` fires on every step (the shape is `{ from?: Date; to?: Date }` — partial during interaction). Gate on `range.to` if you only want the completed-range event.
+
+<Demo data={rangePickerDemo} />
+
+### Date picker
+
+Single-date selection with a typable input. The popover opens on focus; pressing Enter, blurring, or clicking outside commits the value and fires `onSelect`.
+
+<Demo data={datePickerDemo} />
+
 ## API Reference
 
 ### Calendar
@@ -78,46 +116,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `range-picker-positioner` | The popover positioner for the RangePicker |
 | `range-picker-content` | The RangePicker popover content that holds the calendar |
 | `range-picker-footer` | The footer below the calendar (when `footer` is set) |
-
-## Examples
-
-### Calendar
-
-#### Layout & appearance
-
-Number of months, dropdown nav, loading state, footer.
-
-<Demo data={calendarDemo} />
-
-#### Behavior & data
-
-Tooltips, disabled days, timezone, controlled month navigation.
-
-<Demo data={calendarBehaviorDemo} />
-
-#### Custom date information
-
-You can display custom components above each date using the `dateInfo` prop. The keys should be date strings in `"dd-MM-yyyy"` format, and the values are React components that will be rendered above the date number.
-
-<Demo data={dateInfoDemo} />
-
-### Range Picker
-
-Selects a date range across two inputs. The grid uses a state machine that branches on the current `from` / `to`:
-
-- **Empty** — first click sets `from` and advances focus to the end input.
-- **Only `from` set** — clicking a later date completes the range and closes the popover; clicking an earlier date resets `from`.
-- **Both set** — clicking again restarts: the new date becomes `from`, `to` clears.
-
-`onSelect` fires on every step (the shape is `{ from?: Date; to?: Date }` — partial during interaction). Gate on `range.to` if you only want the completed-range event.
-
-<Demo data={rangePickerDemo} />
-
-### Date Picker
-
-Single-date selection with a typable input. The popover opens on focus; pressing Enter, blurring, or clicking outside commits the value and fires `onSelect`.
-
-<Demo data={datePickerDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/callout/index.mdx
+++ b/apps/www/src/content/docs/components/callout/index.mdx
@@ -25,6 +25,40 @@ import { Callout } from '@raystack/apsara'
 <Callout />
 ```
 
+## Usage
+
+### Type
+
+Type carries the meaning: `grey` for neutral information, and the semantic types for success, warning, danger, and accent. Pick the type from what the message means, not from the colour you want.
+
+<Demo data={typeDemo} />
+
+### Outline
+
+`solid` (the default) fills the callout. `outline` draws a border instead — quieter, for a page that already has several filled surfaces.
+
+<Demo data={outlineDemo} />
+
+### High contrast
+
+`highContrast` deepens the text and background so the callout holds up against a busy or coloured page.
+
+<Demo data={highContrastDemo} />
+
+### Dismissible
+
+Set `dismissible` and pass `onDismiss` to add a close button. Use it for messages the reader can act on and clear, not for errors that still need fixing.
+consumer controls removal (the callout stays mounted); when it is omitted, the
+callout hides itself.
+
+<Demo data={dismissibleDemo} />
+
+### With action
+
+The Callout component can include an action button:
+
+<Demo data={actionDemo} />
+
 ## API Reference
 
 Renders a highlighted message block for tips, warnings, or information.
@@ -47,40 +81,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `callout-actions` | Wrapper `<div>` for the action and dismiss button |
 | `callout-action` | Wrapper around the action (when an action is provided) |
 | `callout-dismiss` | The dismiss (close) button (when `dismissible`) |
-
-## Examples
-
-### Type
-
-The Callout component offers different type options. You can customize the visual style using the `type` prop:
-
-<Demo data={typeDemo} />
-
-### Outline
-
-The Callout component can be rendered with or without an outline border:
-
-<Demo data={outlineDemo} />
-
-### High Contrast
-
-The Callout component supports high contrast mode for better visibility:
-
-<Demo data={highContrastDemo} />
-
-### Dismissible
-
-The Callout component can be made dismissible. When `onDismiss` is provided, the
-consumer controls removal (the callout stays mounted); when it is omitted, the
-callout hides itself.
-
-<Demo data={dismissibleDemo} />
-
-### With Action
-
-The Callout component can include an action button:
-
-<Demo data={actionDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/checkbox/index.mdx
+++ b/apps/www/src/content/docs/components/checkbox/index.mdx
@@ -28,47 +28,17 @@ Use `Checkbox.Group` to manage shared state across multiple checkboxes:
 </Checkbox.Group>
 ```
 
-## API Reference
-
-### Root
-
-Renders a toggleable checkbox input.
-
-<auto-type-table path="./props.ts" name="CheckboxProps" />
-
-### Group
-
-Groups multiple checkboxes and manages their shared checked state via a `string[]` value.
-
-<auto-type-table path="./props.ts" name="CheckboxGroupProps" />
-
-### Slots
-
-Every rendered part carries a stable `data-slot` attribute for [styling and testing](/docs/styling#with-data-slot):
-
-| Slot | Element |
-|------|---------|
-| `checkbox` | The checkbox control itself |
-| `checkbox-indicator` | The indicator inside the control |
-| `checkbox-icon` | The check or indeterminate icon (when checked or indeterminate) |
-| `checkbox-group` | The `Checkbox.Group` container |
-
-## Examples
+## Usage
 
 ### States
 
-The Checkbox component supports multiple states to represent different selection conditions:
-
-- Unchecked: Default state
-- Checked: Selected state
-- Indeterminate: Partial selection state
-- Disabled: Disabled state
+A checkbox can be checked, unchecked, or `indeterminate` — the third state for a parent whose children are only partly selected.
 
 <Demo data={statesExamples} />
 
-### Size Variants
+### Size variants
 
-The Checkbox component comes in two sizes: `large` (default) and `small`.
+Two sizes. `large` is the default; `small` fits table rows and dense lists.
 
 <Demo data={sizeExamples} />
 
@@ -95,6 +65,31 @@ Disable the entire group to prevent user interaction.
 Use a parent checkbox with `allValues` to toggle all items at once.
 
 <Demo data={parentDemo} />
+
+## API Reference
+
+### Root
+
+Renders a toggleable checkbox input.
+
+<auto-type-table path="./props.ts" name="CheckboxProps" />
+
+### Group
+
+Groups multiple checkboxes and manages their shared checked state via a `string[]` value.
+
+<auto-type-table path="./props.ts" name="CheckboxGroupProps" />
+
+### Slots
+
+Every rendered part carries a stable `data-slot` attribute for [styling and testing](/docs/styling#with-data-slot):
+
+| Slot | Element |
+|------|---------|
+| `checkbox` | The checkbox control itself |
+| `checkbox-indicator` | The indicator inside the control |
+| `checkbox-icon` | The check or indeterminate icon (when checked or indeterminate) |
+| `checkbox-group` | The `Checkbox.Group` container |
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/chip/index.mdx
+++ b/apps/www/src/content/docs/components/chip/index.mdx
@@ -25,6 +25,41 @@ import { Chip } from "@raystack/apsara";
 <Chip />
 ```
 
+## Usage
+
+### Variant
+
+Choose between outline and filled variants to match your design needs.
+
+<Demo data={variantsDemo} />
+
+### Size
+
+Two sizes. `large` is the default; `small` fits inside inputs and table cells.
+
+- `small`: Compact size with less padding
+- `large`: More spacious with increased padding
+
+<Demo data={sizesDemo} />
+
+### Color
+
+Choose between neutral and accent styles to control the visual emphasis.
+
+<Demo data={colorDemo} />
+
+### With icons
+
+Chips can include leading and trailing icons to provide additional context or actions.
+
+<Demo data={iconsDemo} />
+
+### Dismissible
+
+Chips can be made dismissible by adding the isDismissible prop and an onDismiss handler.
+
+<Demo data={dismissableDemo} />
+
 ## API Reference
 
 Renders a compact element for tags, labels, or attributes.
@@ -42,41 +77,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `chip-trailing-icon` | Wrapper around `trailingIcon` (when set and not dismissible) |
 | `chip-dismiss` | The dismiss button (when `isDismissible`) |
 | `chip-dismiss-icon` | The dismiss icon (when `isDismissible`) |
-
-## Examples
-
-### Variant
-
-Choose between outline and filled variants to match your design needs.
-
-<Demo data={variantsDemo} />
-
-### Size
-
-The Chip component comes in two sizes:
-
-- `small`: Compact size with less padding
-- `large`: More spacious with increased padding
-
-<Demo data={sizesDemo} />
-
-### Color
-
-Choose between neutral and accent styles to control the visual emphasis.
-
-<Demo data={colorDemo} />
-
-### With Icons
-
-Chips can include leading and trailing icons to provide additional context or actions.
-
-<Demo data={iconsDemo} />
-
-### Dismissible
-
-Chips can be made dismissible by adding the isDismissible prop and an onDismiss handler.
-
-<Demo data={dismissableDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/code-block/index.mdx
+++ b/apps/www/src/content/docs/components/code-block/index.mdx
@@ -39,6 +39,47 @@ import { CodeBlock } from '@raystack/apsara'
 </CodeBlock>
 ```
 
+## Usage
+
+### Basic usage
+
+The most basic usage using `CodeBlock` with `CodeBlock.Code` for displaying code content with a floating copy button.
+
+<Demo data={basicDemo} />
+
+### With header
+
+Add a structured header with labels and controls using `CodeBlock.Header`, `CodeBlock.Label`, and `CodeBlock.CopyButton` for better organization and user experience.
+
+<Demo data={withHeaderDemo} />
+
+### Language switcher
+
+Support multiple programming languages by including multiple `CodeBlock.Code` components with different language values.
+Use `CodeBlock.LanguageSelect` to provide a dropdown for users to switch between languages. The component automatically displays the code block matching the selected language value, which can be controlled programmatically using the `value` and `onValueChange` props.
+
+<Demo data={languageSwitcherDemo} />
+
+### No line numbers
+
+Hide line numbers by setting the `hideLineNumbers` prop to `true` on the root `CodeBlock` component for a cleaner appearance.
+
+<Demo data={noLineNumbersDemo} />
+
+### Collapsible code
+
+For long code snippets, use the `maxLines` prop to create collapsible code blocks. When the code exceeds the specified number of lines, a `CodeBlock.CollapseTrigger` button appears, allowing users to expand or collapse the content.
+
+<Demo data={collapsibleDemo} />
+
+### Copy button variants
+
+The `CodeBlock.CopyButton` component offers two placement options:
+- **Floating**: Overlays on the code block using `variant="floating"`
+- **Inline**: Positioned within the header alongside other controls
+
+<Demo data={copyButtonDemo} />
+
 ## API Reference
 
 ### Root
@@ -115,47 +156,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `code-block-collapse-trigger` | The show/hide button (when `maxLines` is exceeded) |
 | `code-block-language-select-trigger` | The language select trigger button |
 | `code-block-language-select-value` | The selected language value inside the trigger |
-
-## Examples
-
-### Basic Usage
-
-The most basic usage using `CodeBlock` with `CodeBlock.Code` for displaying code content with a floating copy button.
-
-<Demo data={basicDemo} />
-
-### With Header
-
-Add a structured header with labels and controls using `CodeBlock.Header`, `CodeBlock.Label`, and `CodeBlock.CopyButton` for better organization and user experience.
-
-<Demo data={withHeaderDemo} />
-
-### Language Switcher
-
-Support multiple programming languages by including multiple `CodeBlock.Code` components with different language values.
-Use `CodeBlock.LanguageSelect` to provide a dropdown for users to switch between languages. The component automatically displays the code block matching the selected language value, which can be controlled programmatically using the `value` and `onValueChange` props.
-
-<Demo data={languageSwitcherDemo} />
-
-### No Line Numbers
-
-Hide line numbers by setting the `hideLineNumbers` prop to `true` on the root `CodeBlock` component for a cleaner appearance.
-
-<Demo data={noLineNumbersDemo} />
-
-### Collapsible Code
-
-For long code snippets, use the `maxLines` prop to create collapsible code blocks. When the code exceeds the specified number of lines, a `CodeBlock.CollapseTrigger` button appears, allowing users to expand or collapse the content.
-
-<Demo data={collapsibleDemo} />
-
-### Copy Button Variants
-
-The `CodeBlock.CopyButton` component offers two placement options:
-- **Floating**: Overlays on the code block using `variant="floating"`
-- **Inline**: Positioned within the header alongside other controls
-
-<Demo data={copyButtonDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/collapsible/index.mdx
+++ b/apps/www/src/content/docs/components/collapsible/index.mdx
@@ -27,6 +27,26 @@ import { Collapsible } from '@raystack/apsara'
 </Collapsible>
 ```
 
+## Usage
+
+### Controlled
+
+Pass `open` with `onOpenChange` to own the state, so a button elsewhere on the page can expand the section.
+
+<Demo data={controlledDemo} />
+
+### Default open
+
+Use `defaultOpen` to have the panel initially expanded.
+
+<Demo data={defaultOpenDemo} />
+
+### Disabled
+
+`disabled` freezes the collapsible in its current state — use it while content is still loading rather than hiding the section outright.
+
+<Demo data={disabledDemo} />
+
 ## API Reference
 
 ### Root
@@ -56,26 +76,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `collapsible` | The root element |
 | `collapsible-trigger` | The button that toggles the panel |
 | `collapsible-panel` | The collapsible content panel |
-
-## Examples
-
-### Controlled
-
-You can control the collapsible state by providing `open` and `onOpenChange` props.
-
-<Demo data={controlledDemo} />
-
-### Default Open
-
-Use `defaultOpen` to have the panel initially expanded.
-
-<Demo data={defaultOpenDemo} />
-
-### Disabled
-
-The collapsible can be disabled to prevent user interaction.
-
-<Demo data={disabledDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/color-picker/index.mdx
+++ b/apps/www/src/content/docs/components/color-picker/index.mdx
@@ -30,6 +30,32 @@ import { ColorPicker } from '@raystack/apsara'
 </ColorPicker>
 ```
 
+## Usage
+
+### Basic usage
+
+An uncontrolled picker. Pass `defaultValue` for the starting colour and read changes from `onValueChange`.
+
+<Demo data={basicDemo} />
+
+### Copy to clipboard
+
+Pass the `copyable` prop on `ColorPicker.Input` to render a copy-to-clipboard button in the input's trailing slot. The button copies the formatted color string in the active mode (e.g. `#FF0000`, `rgb(...)`, or `oklch(...)`) and shows a brief confirmation icon after a successful copy.
+
+<Demo data={copyableDemo} />
+
+### OKLCH mode
+
+The picker stores color internally in OKLCH. In `hex`, `rgb`, and `hsl` modes the area pad is the familiar HSL saturation × brightness square and the hue slider runs in HSL hue — so the picker behaves like a traditional color picker and only emits colors representable in the chosen format. Pass an `oklch(...)` string as `defaultValue` and set `defaultMode='oklch'` to switch to a chroma × lightness plane covering the full P3 gamut; the hue slider then runs in OKLCH hue, where equal steps correspond to equal perceptual changes.
+
+<Demo data={oklchDemo} />
+
+### Popover integration
+
+The `ColorPicker` can be embedded within a `Popover` component to create a more interactive and space-efficient color selection experience.
+
+<Demo data={popoverDemo} />
+
 ## API Reference
 
 ### Root
@@ -80,32 +106,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `color-picker-input` | The read-only color value input |
 | `color-picker-mode` | The mode select trigger |
 | `color-picker-mode-content` | The mode select dropdown content (when open) |
-
-## Examples
-
-### Basic Usage
-
-<Demo data={basicDemo} />
-
-### Copy to Clipboard
-
-Pass the `copyable` prop on `ColorPicker.Input` to render a copy-to-clipboard button in the input's trailing slot. The button copies the formatted color string in the active mode (e.g. `#FF0000`, `rgb(...)`, or `oklch(...)`) and shows a brief confirmation icon after a successful copy.
-
-<Demo data={copyableDemo} />
-
-### OKLCH Mode
-
-The picker stores color internally in OKLCH. In `hex`, `rgb`, and `hsl` modes the area pad is the familiar HSL saturation × brightness square and the hue slider runs in HSL hue — so the picker behaves like a traditional color picker and only emits colors representable in the chosen format. Pass an `oklch(...)` string as `defaultValue` and set `defaultMode='oklch'` to switch to a chroma × lightness plane covering the full P3 gamut; the hue slider then runs in OKLCH hue, where equal steps correspond to equal perceptual changes.
-
-<Demo data={oklchDemo} />
-
-### Popover Integration
-
-The `ColorPicker` can be embedded within a `Popover` component to create a more interactive and space-efficient color selection experience.
-
-<Demo data={popoverDemo} />
-
-## Utilities
 
 ### formatColor
 

--- a/apps/www/src/content/docs/components/combobox/index.mdx
+++ b/apps/www/src/content/docs/components/combobox/index.mdx
@@ -30,6 +30,44 @@ import { Combobox } from "@raystack/apsara";
 </Combobox>
 ```
 
+## Usage
+
+### Basic
+
+A simple combobox with search filtering built in. Type to filter options.
+
+<Demo data={basicDemo} />
+
+### With icons
+
+You can pass the `leadingIcon` prop to `Combobox.Item` to display icons before item text.
+
+<Demo data={iconDemo} />
+
+### With Field
+
+Wrap the Combobox with [Field](/docs/components/field) to add a label, description, and error handling.
+
+<Demo data={withFieldDemo} />
+
+### Groups and separators
+
+Organize items into groups with labels and visual separators. Groups and labels are automatically hidden when the user is searching.
+
+<Demo data={groupDemo} />
+
+### Multiple selection
+
+Pass the `multiple` prop to enable multi-select. Selected values appear as chips in the input. Items display checkboxes in multiple mode.
+
+<Demo data={multipleDemo} />
+
+### Controlled
+
+Use `value` and `onValueChange` for controlled behavior.
+
+<Demo data={controlledDemo} />
+
 ## API Reference
 
 ### Root Props
@@ -94,44 +132,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `combobox-item` | A selectable option row |
 | `combobox-item-text` | The text label inside an item (when its children is a string) |
 | `combobox-item-icon` | The leading icon inside an item (when `leadingIcon` is set) |
-
-## Examples
-
-### Basic
-
-A simple combobox with search filtering built in. Type to filter options.
-
-<Demo data={basicDemo} />
-
-### With Icons
-
-You can pass the `leadingIcon` prop to `Combobox.Item` to display icons before item text.
-
-<Demo data={iconDemo} />
-
-### With Field
-
-Wrap the Combobox with [Field](/docs/components/field) to add a label, description, and error handling.
-
-<Demo data={withFieldDemo} />
-
-### Groups and Separators
-
-Organize items into groups with labels and visual separators. Groups and labels are automatically hidden when the user is searching.
-
-<Demo data={groupDemo} />
-
-### Multiple Selection
-
-Pass the `multiple` prop to enable multi-select. Selected values appear as chips in the input. Items display checkboxes in multiple mode.
-
-<Demo data={multipleDemo} />
-
-### Controlled
-
-Use `value` and `onValueChange` for controlled behavior.
-
-<Demo data={controlledDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/command/index.mdx
+++ b/apps/www/src/content/docs/components/command/index.mdx
@@ -45,6 +45,46 @@ import { Command } from "@raystack/apsara";
 `Command` can also be rendered inline (without a dialog) — useful for embedding a
 persistent command menu in a page or surface.
 
+## Usage
+
+### Inline
+
+A command menu rendered inline, without a dialog. Use this when the command menu is a permanent surface on the page.
+
+<Demo data={inlineDemo} />
+
+### Groups and separators
+
+Organise items into groups with labels and visual separators. Groups, labels, and separators are hidden automatically while searching.
+
+<Demo data={groupedDemo} />
+
+### With icons
+
+Pass a `leadingIcon` on `Command.Item` to render an icon before the label.
+
+<Demo data={withIconsDemo} />
+
+### Keyboard shortcut
+
+Bind a keyboard shortcut (e.g. `⌘K`) to toggle the command palette open.
+
+<Demo data={shortcutDemo} />
+
+### Controlled
+
+Control the input value by passing `value` and `onValueChange`.
+
+<Demo data={controlledDemo} />
+
+### Items prop
+
+By default, `Command` filters `Command.Item` children based on the input value — the same behavior as our [Combobox](/docs/components/combobox). No `items` prop is required. Matching is case-insensitive and looks at both the `value` prop and the item's text content.
+
+Pass the `items` prop to opt out of this built-in behavior and delegate filtering to Base UI's internal logic (or your own `filter` function). `Command.Content` then accepts a render function that receives each item.
+
+<Demo data={itemsDemo} />
+
 ## API Reference
 
 ### Root
@@ -128,46 +168,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `command-dialog-trigger` | `Command.DialogTrigger` |
 | `command-dialog-viewport` | Viewport wrapper for the dialog popup |
 | `command-dialog-content` | `Command.DialogContent` popup |
-
-## Examples
-
-### Inline
-
-A command menu rendered inline, without a dialog. Use this when the command menu is a permanent surface on the page.
-
-<Demo data={inlineDemo} />
-
-### Groups and Separators
-
-Organise items into groups with labels and visual separators. Groups, labels, and separators are hidden automatically while searching.
-
-<Demo data={groupedDemo} />
-
-### With Icons
-
-Pass a `leadingIcon` on `Command.Item` to render an icon before the label.
-
-<Demo data={withIconsDemo} />
-
-### Keyboard Shortcut
-
-Bind a keyboard shortcut (e.g. `⌘K`) to toggle the command palette open.
-
-<Demo data={shortcutDemo} />
-
-### Controlled
-
-Control the input value by passing `value` and `onValueChange`.
-
-<Demo data={controlledDemo} />
-
-### Items prop
-
-By default, `Command` filters `Command.Item` children based on the input value — the same behavior as our [Combobox](/docs/components/combobox). No `items` prop is required. Matching is case-insensitive and looks at both the `value` prop and the item's text content.
-
-Pass the `items` prop to opt out of this built-in behavior and delegate filtering to Base UI's internal logic (or your own `filter` function). `Command.Content` then accepts a render function that receives each item.
-
-<Demo data={itemsDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/container/index.mdx
+++ b/apps/www/src/content/docs/components/container/index.mdx
@@ -22,6 +22,20 @@ import { Container } from '@raystack/apsara'
 <Container />
 ```
 
+## Usage
+
+### Size
+
+The `size` prop caps the container's max-width. The default is `none`, which lets content span the full width of the parent.
+
+<Demo data={sizeDemo} />
+
+### Align
+
+The `align` prop positions the container within its parent — left, center, or right. Default is `center`.
+
+<Demo data={alignDemo} />
+
 ## API Reference
 
 Renders a centered content wrapper with max-width constraints.
@@ -35,20 +49,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | Slot | Element |
 |------|---------|
 | `container` | The container `<div>` |
-
-## Examples
-
-### Size
-
-The `size` prop caps the container's max-width. The default is `none`, which lets content span the full width of the parent.
-
-<Demo data={sizeDemo} />
-
-### Align
-
-The `align` prop positions the container within its parent — left, center, or right. Default is `center`.
-
-<Demo data={alignDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/context-menu/index.mdx
+++ b/apps/www/src/content/docs/components/context-menu/index.mdx
@@ -31,6 +31,42 @@ import { ContextMenu } from '@raystack/apsara'
 </ContextMenu>
 ```
 
+## Usage
+
+### Basic usage
+
+A simple context menu with basic functionality. Right-click the trigger area to open.
+
+<Demo data={basicDemo} />
+
+### With icons
+
+You can add icons to the menu items. Supports both leading and trailing icons.
+
+<Demo data={iconsDemo} />
+
+### With groups and labels
+
+Organize related menu items into sections with descriptive headers.
+
+<Demo data={customDemo} />
+
+### Submenu
+
+Use `ContextMenu.Submenu`, `ContextMenu.SubmenuTrigger`, and `ContextMenu.SubmenuContent` to create nested menus with multiple levels.
+
+<Demo data={submenuDemo} />
+
+### Autocomplete
+
+To enable autocomplete, pass the `autocomplete` prop to the ContextMenu root element. Each menu instance will manage its own autocomplete behavior.
+
+By default (`autocompleteMode="auto"`), items are automatically filtered as the user types. The filter matches against the item's `value` prop or its `children` text content.
+
+For submenus, you can independently enable autocomplete by passing `autocomplete` to `ContextMenu.Submenu`.
+
+<Demo data={autocompleteDemo} />
+
 ## API Reference
 
 The ContextMenu component is composed of several parts, each with their own props.
@@ -126,42 +162,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `menu-subtrigger` | `ContextMenu.SubmenuTrigger` (shared with `Menu`'s internals) |
 | `menu-cell-leading-icon` | Leading icon inside an item or submenu trigger (when provided; shared with `Menu`'s internals) |
 | `menu-cell-trailing-icon` | Trailing icon inside an item or submenu trigger (when provided; shared with `Menu`'s internals) |
-
-## Examples
-
-### Basic Usage
-
-A simple context menu with basic functionality. Right-click the trigger area to open.
-
-<Demo data={basicDemo} />
-
-### With Icons
-
-You can add icons to the menu items. Supports both leading and trailing icons.
-
-<Demo data={iconsDemo} />
-
-### With Groups and Labels
-
-Organize related menu items into sections with descriptive headers.
-
-<Demo data={customDemo} />
-
-### Submenu
-
-Use `ContextMenu.Submenu`, `ContextMenu.SubmenuTrigger`, and `ContextMenu.SubmenuContent` to create nested menus with multiple levels.
-
-<Demo data={submenuDemo} />
-
-### Autocomplete
-
-To enable autocomplete, pass the `autocomplete` prop to the ContextMenu root element. Each menu instance will manage its own autocomplete behavior.
-
-By default (`autocompleteMode="auto"`), items are automatically filtered as the user types. The filter matches against the item's `value` prop or its `children` text content.
-
-For submenus, you can independently enable autocomplete by passing `autocomplete` to `ContextMenu.Submenu`.
-
-<Demo data={autocompleteDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/copy-button/index.mdx
+++ b/apps/www/src/content/docs/components/copy-button/index.mdx
@@ -22,6 +22,20 @@ import { CopyButton } from "@raystack/apsara";
 <CopyButton />
 ```
 
+## Usage
+
+### Size
+
+Like IconButton, CopyButton supports sizes 1 through 4. Default is `2`.
+
+<Demo data={sizesDemo} />
+
+### States
+
+CopyButton inherits all IconButton states. A disabled button ignores clicks and never triggers a copy.
+
+<Demo data={stateDemo} />
+
 ## API Reference
 
 The CopyButton component extends IconButton props and accepts the following additional props
@@ -41,20 +55,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `copy-button-copy-icon` | The copy icon |
 | `copy-button-check-icon` | The check icon shown after copying |
 | `copy-button-status` | Visually hidden live region announcing "Copied" |
-
-## Examples
-
-### Size
-
-Like IconButton, CopyButton supports sizes 1 through 4. Default is `2`.
-
-<Demo data={sizesDemo} />
-
-### States
-
-CopyButton inherits all IconButton states. A disabled button ignores clicks and never triggers a copy.
-
-<Demo data={stateDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/dataview/index.mdx
+++ b/apps/www/src/content/docs/components/dataview/index.mdx
@@ -1,35 +1,30 @@
 ---
 title: DataView
-description: A unified data primitive whose query state drives swappable renderers. List, custom, multi-view — one filter/sort/group/search model.
+description: A unified data primitive whose query state drives swappable renderers. List, timeline, custom — one filter/sort/group/search model.
 source: packages/raystack/components/data-view
 ---
 
 import {
   tablePreview,
   searchPreview,
-  listPreview,
   multiViewPreview,
   emptyZeroPreview,
   customPreview,
-  virtualizedPreview,
-  groupingPreview,
-  virtualizedGroupingPreview,
-  loadingPreview,
   perViewFieldsPreview,
-  rowSelectionPreview,
-  timelinePreview,
-  timelineSortValueLanePreview,
-  timelineGroupingPreview,
-  timelinePointPreview,
 } from "./demo.ts";
 
 <Demo data={tablePreview} />
 
 ## Overview
 
-`DataView` owns the data layer — query state (filters, sort, group, search), client/server mode, row model derivation — and lets you pick the renderer that draws it. The same `<DataView>` can host a table, a list, or a free-form view, switchable at runtime without losing query state.
+`DataView` owns the data layer — query state (filters, sort, group, search), client or server mode, and row model derivation. It doesn't draw anything itself. You pick the renderer that does, and the same `<DataView>` can host a table, a list, or a free-form view, switchable at runtime without losing query state.
 
-In scope today: `DataView.List` (table + list presentations), `DataView.Timeline` (cards positioned on a continuous time axis — full guide in [Timeline](#timeline)), and `DataView.Custom` (escape hatch for cards, kanban, gallery, etc.).
+This page covers what every renderer shares. The renderers have their own pages:
+
+- **[List](/docs/components/dataview/list)** — table and list presentations.
+- **[Timeline](/docs/components/dataview/timeline)** — cards on a continuous time axis.
+
+`DataView.Custom` is the escape hatch for everything else — cards, kanban, gallery — and is covered below.
 
 ## Anatomy
 
@@ -60,11 +55,11 @@ import {
 </DataView>
 ```
 
-## Core ideas
+## Usage
 
-### Fields vs columns
+### Fields and columns
 
-`fields` is renderer-agnostic metadata declared **once on the root** — filter capability, sort capability, group capability, visibility, group-header presentation. Cell/header renderers live on the **renderer's** column spec (e.g. `DataView.List`'s `columns`).
+`fields` is renderer-agnostic metadata declared **once on the root** — filter capability, sort capability, group capability, visibility, group-header presentation. Cell and header renderers live on the **renderer's** column spec instead, such as `DataView.List`'s `columns`.
 
 ```ts
 const fields: DataViewField<Person>[] = [
@@ -80,12 +75,34 @@ const tableColumns: DataViewListColumn<Person>[] = [
 ];
 ```
 
-### Empty vs zero state
+The split is what lets one set of filters, sorts, and toggles drive every renderer. Declare capability once on the root; declare presentation per renderer.
 
-Empty/zero is computed once on context (`isEmptyState`, `isZeroState`) and exposed as sibling components.
+### Search
 
-- **Zero state** — no data, no active query. The "first-use" surface. Toolbar is hidden automatically.
-- **Empty state** — no rows visible because filters/search/sort exclude them all. Toolbar stays visible so the user can correct it.
+`DataView.Search` writes the input to `query.search`, which feeds TanStack's `globalFilter` — rows are filtered across every field as the user types. Drop it into the toolbar wherever you want it; in client mode no extra wiring is needed. Type a name, email, or team below to filter the rows.
+
+<Demo data={searchPreview} />
+
+By default search auto-disables in the zero state (no data and no active query) and re-enables the moment the user types. Pass `autoDisableInZeroState={false}` to keep it always enabled, or `disabled` to control it yourself. In server mode, read `query.search` in `onTableQueryChange` and filter on the backend.
+
+### Display properties
+
+Column visibility is a **single global map** on context. `DataView.List` honours it for free — TanStack column visibility hides the grid track. For free-form renderers, wrap fields in `DataView.DisplayAccess`:
+
+```tsx
+<DataView.DisplayAccess accessorKey="email">
+  <Text>{row.email}</Text>
+</DataView.DisplayAccess>
+```
+
+`accessorKey`s not present in `fields` default to visible, so typos don't silently break renders.
+
+### Empty and zero states
+
+Empty and zero are computed once on context (`isEmptyState`, `isZeroState`) and exposed as sibling components.
+
+- **Zero state** — no data, no active query. The first-use surface. The toolbar is hidden automatically.
+- **Empty state** — no rows visible because filters, search, or sort exclude them all. The toolbar stays visible so the user can correct it.
 
 ```tsx
 <DataView.EmptyState>
@@ -97,18 +114,15 @@ Empty/zero is computed once on context (`isEmptyState`, `isZeroState`) and expos
 <DataView.ClearFilters />
 ```
 
-Renderers return `null` when `!hasData` — siblings render the messaging.
+Renderers return `null` when `!hasData` — the siblings render the messaging.
+
+<Demo data={emptyZeroPreview} />
 
 ### Clear filters
 
-When rows are hidden by filters, `DataView.List` automatically renders a flat
-footer summarising the hidden count with a **Clear Filters** action — the
-default treatment. `DataView.ClearFilters` is a separate sibling entry that
-surfaces the same action as a **bordered panel** in the empty state (a query
-returned no rows). It reads context, resets `filters`/`search` on click, and
-renders nothing outside the empty state — so place it once alongside
-`DataView.List`, separate from `DataView.EmptyState`, and it self-manages
-visibility.
+When rows are hidden by filters, `DataView.List` automatically renders a flat footer summarising the hidden count with a **Clear Filters** action. That's the default treatment.
+
+`DataView.ClearFilters` is a separate sibling that surfaces the same action as a **bordered panel** in the empty state, when a query returns no rows at all. It reads context, resets `filters` and `search` on click, and renders nothing outside the empty state. Place it once alongside your renderer, separate from `DataView.EmptyState`, and it manages its own visibility.
 
 ```tsx
 <DataView.List variant="table" columns={tableColumns} />
@@ -118,17 +132,68 @@ visibility.
 <DataView.ClearFilters />
 ```
 
-### Display Properties (column visibility)
+### Multi-view
 
-Visibility is a **single global map** on context. `DataView.List` honours it for free (TanStack column visibility hides the grid track). For free-form renderers, wrap fields in `DataView.DisplayAccess`:
+Pass `views` and give each renderer a `name`. `DataView.DisplayControls` hosts the view switcher at the top of its popover automatically — give each view an optional `leadingIcon` to show alongside its label. Query state (filters, sort, search, visibility) persists across switches.
+
+<Demo data={multiViewPreview} />
+
+### Per-view fields
+
+Each renderer accepts an optional `fields` prop. It **fully replaces** the root `fields` for that view's active session — filter chips, sort menu, and Display Properties reflect the override while the view is active. The common pattern is to spread the root fields and tweak the few that differ.
+
+<Demo data={perViewFieldsPreview} />
 
 ```tsx
-<DataView.DisplayAccess accessorKey="email">
-  <Text>{row.email}</Text>
-</DataView.DisplayAccess>
+const listFields = fields.map((f) =>
+  f.accessorKey === "email" ? { ...f, hideable: false, defaultHidden: true } : f,
+);
+
+<DataView.List name="list" variant="list" columns={listColumns} fields={listFields} />;
 ```
 
-`accessorKey`s not present in `fields` default to visible, so typos don't silently break renders.
+### Custom renderer
+
+`DataView.Custom` exposes the full context as a render prop. Use it for cards, kanban, gallery, map, or any non-tabular presentation. Wrap fields in `DataView.DisplayAccess` so the single Display Properties toggle reaches them.
+
+<Demo data={customPreview} />
+
+### Server mode
+
+In client mode `DataView` derives everything locally: filter predicates, sort, grouping, and search all run over the `data` array you pass. Set `mode="server"` and that work moves to your backend. The local TanStack table goes manual, `onTableQueryChange` fires whenever the query changes, and it's on you to fetch matching rows and pass them back down.
+
+```tsx
+<DataView
+  mode="server"
+  data={page.rows}
+  isLoading={loading}
+  totalRowCount={page.total}
+  query={query}
+  onTableQueryChange={(q) => setQuery(q)}
+  onLoadMore={() => fetchNext()}
+>
+  …
+</DataView>
+```
+
+`onTableQueryChange` hands you the full [query object](#query) every time any part of it changes — a filter chip, a sort, a grouping choice, a keystroke in search. Translate it to your API's parameters and refetch.
+
+`totalRowCount` is what the "hidden by filters" footer counts against. Without it the footer can't tell how many rows your filters excluded, since the client only ever sees the current page.
+
+Group order, labels, and counts still come from the root's `groupData` output, so sections match across renderers without a mode-specific path. Sorting is the one place a silent mismatch is possible: rows arrive in whatever order your backend returned them, so a backend that ignores the `sort` it was handed produces a correctly filtered view in an arbitrary order, with nothing logged to say so.
+
+Grouping stays `group_by: string[]` on the wire in both modes. To group by something that isn't a raw accessor — "by week of `created_at`", "by first letter" — supply a resolver on the root. The resolved key is what lands in `query.group_by`, so your backend receives a stable string it can switch on, and the same code works unchanged in client mode.
+
+```tsx
+<DataView
+  groupByResolvers={{
+    name_first_letter: (row) => row.name.charAt(0).toUpperCase(),
+  }}
+  // query.group_by = ["name_first_letter"]
+/>
+```
+
+Fetching itself is renderer-shaped. [List](/docs/components/dataview/list#loading) pages through an infinite-scroll sentinel; [Timeline](/docs/components/dataview/timeline#loading-by-visible-range) fetches by visible time window instead.
 
 ## API Reference
 
@@ -146,39 +211,13 @@ Visibility is a **single global map** on context. `DataView.List` honours it for
 
 ### Query
 
+The shape `query` accepts and `onTableQueryChange` hands back. In [server mode](#server-mode) this is the contract your backend implements.
+
 <auto-type-table path="./props.ts" name="DataViewQuery" />
 
 ### View spec
 
 <auto-type-table path="./props.ts" name="ViewSpec" />
-
-### DataView.List
-
-<auto-type-table path="./props.ts" name="DataViewListProps" />
-
-#### Column
-
-<auto-type-table path="./props.ts" name="DataViewListColumn" />
-
-### DataView.Timeline
-
-<auto-type-table path="./props.ts" name="DataViewTimelineProps" />
-
-#### Card context
-
-Passed as the second argument to `renderCard`.
-
-<auto-type-table path="./props.ts" name="TimelineCardContext" />
-
-#### Marker
-
-<auto-type-table path="./props.ts" name="TimelineMarker" />
-
-#### Actions
-
-The imperative handle received through `actionsRef`.
-
-<auto-type-table path="./props.ts" name="TimelineActions" />
 
 ### DataView.Custom
 
@@ -204,39 +243,13 @@ The popover housing the view switcher, Ordering, Grouping, and Display Propertie
 
 ### DataView.ClearFilters
 
-A context-driven "Clear Filters" affordance for the empty state. Place it as a sibling of `DataView.List` (separate from `DataView.EmptyState`); it renders a bordered panel when a query returns no rows and nothing otherwise. The flat footer for the data state is rendered automatically by `DataView.List`.
+A context-driven "Clear Filters" affordance for the empty state. Place it as a sibling of your renderer, separate from `DataView.EmptyState`. It renders a bordered panel when a query returns no rows, and nothing otherwise. The flat footer for the data state is rendered automatically by `DataView.List`.
 
 <auto-type-table path="./props.ts" name="DataViewClearFiltersProps" />
 
 ### Slots
 
-Every rendered part carries a stable `data-slot` attribute for [styling and testing](/docs/styling#with-data-slot). Filter chips inside `DataView.Filters` expose the [FilterChip slots](/docs/components/filter-chip#slots); `DataView.Search` exposes the [Search slots](/docs/components/search#slots).
-
-**List**
-
-| Slot | Element |
-|------|---------|
-| `data-view-list` | Scroll container |
-| `data-view-list-grid` | The grid carrying the table/list role |
-| `data-view-list-header` | Header row group |
-| `data-view-list-header-row` | Header row |
-| `data-view-list-header-cell` | Header cell |
-| `data-view-list-body` | Row container |
-| `data-view-list-row` | Data row |
-| `data-view-list-cell` | Cell (data and loader rows) |
-| `data-view-list-group-header` | Group header (incl. the sticky anchor) |
-| `data-view-list-loader-row` | Skeleton row while `isLoading` |
-| `data-view-list-sentinel` | Infinite-scroll sentinel |
-
-Header cells, body cells, and loader cells also carry `data-column="{accessorKey}"`, so a single column can be targeted without a per-column `classNames` entry:
-
-```css
-/* Right-align every cell in the "amount" column, header included */
-[data-slot="data-view-list-cell"][data-column="amount"],
-[data-slot="data-view-list-header-cell"][data-column="amount"] {
-  text-align: right;
-}
-```
+Every rendered part carries a stable `data-slot` attribute for [styling and testing](/docs/styling#with-data-slot). Filter chips inside `DataView.Filters` expose the [FilterChip slots](/docs/components/filter-chip#slots); `DataView.Search` exposes the [Search slots](/docs/components/search#slots). Renderer slots live on the [List](/docs/components/dataview/list#slots) and [Timeline](/docs/components/dataview/timeline#slots) pages.
 
 **Toolbar and filters**
 
@@ -266,24 +279,6 @@ Header cells, body cells, and loader cells also carry `data-column="{accessorKey
 | `data-view-display-properties` / `-label` / `-list` / `-chip` | Display Properties section and its parts |
 | `data-view-view-switcher` / `-tab` | View switcher tabs |
 
-**Timeline**
-
-| Slot | Element |
-|------|---------|
-| `data-view-timeline` | Scroll container |
-| `data-view-timeline-axis` | Sticky axis |
-| `data-view-timeline-axis-band` / `-band-label` | Month/year band and its label |
-| `data-view-timeline-axis-tick` | Axis tick |
-| `data-view-timeline-axis-marker` | Today/custom marker badge on the axis |
-| `data-view-timeline-axis-cursor` | Hover cursor badge on the axis |
-| `data-view-timeline-canvas` | Card canvas |
-| `data-view-timeline-card` | Card positioning wrapper |
-| `data-view-timeline-gridline` | Vertical gridline |
-| `data-view-timeline-marker` | Marker line on the canvas |
-| `data-view-timeline-cursor` | Hover cursor line on the canvas |
-| `data-view-timeline-group-layer` / `-group-slot` / `-group-header` / `-group-header-label` | Group band layer and its parts |
-| `data-view-timeline-footer` | Sticky footer |
-
 **States**
 
 | Slot | Element |
@@ -291,334 +286,13 @@ Header cells, body cells, and loader cells also carry `data-column="{accessorKey
 | `data-view-empty-state` | `DataView.EmptyState` container |
 | `data-view-zero-state` | `DataView.ZeroState` container |
 
-## Examples
-
-### Search
-
-`DataView.Search` writes the input to `query.search`, which feeds TanStack's `globalFilter` — rows are filtered across every field as the user types. Drop it into the toolbar wherever you want it; in client mode no extra wiring is needed. Type a name, email, or team below to filter the rows.
-
-<Demo data={searchPreview} />
-
-By default search auto-disables in the zero state (no data and no active query) and re-enables the moment the user types. Pass `autoDisableInZeroState={false}` to keep it always enabled, or `disabled` to control it yourself. In server mode, read `query.search` in `onTableQueryChange` and filter on the backend.
-
-### List variant
-
-`DataView.List` ships two presentations behind one renderer. Use `variant="list"` for card-style rows; the default `1fr` middle column with `auto` end columns gives you the familiar justify-between layout.
-
-<Demo data={listPreview} />
-
-### Multi-view
-
-Pass `views` + give each renderer a `name`. `DataView.DisplayControls` hosts the view switcher at the top of its popover automatically — give each view an optional `leadingIcon` to show alongside its label. Query state — filters, sort, search, visibility — persists across switches.
-
-<Demo data={multiViewPreview} />
-
-### Empty / zero state
-
-<Demo data={emptyZeroPreview} />
-
-### Custom renderer
-
-`DataView.Custom` exposes the full context as a render prop. Use it for cards, kanban, gallery, map, or any non-tabular presentation. Wrap fields in `DataView.DisplayAccess` so the single Display Properties toggle reaches them.
-
-<Demo data={customPreview} />
-
-### Virtualized list
-
-For large datasets, pass `virtualized` to `DataView.List`. The parent must have a fixed height — only the rows in view are rendered. Rows auto-measure after paint, so variable-height content (avatars, wrapped text, badges) just works. `estimatedRowHeight` is an optional hint used only until the first measurement.
-
-<Demo data={virtualizedPreview} />
-
-### Grouping with sticky header
-
-Group rows by any `groupable` field. `stickyGroupHeader` pins the active group label directly under the column headers while you scroll past that group's rows. Pick a different field from `DisplayControls` → Grouping at runtime — the wire format stays `group_by: string[]`.
-
-<Demo data={groupingPreview} />
-
-In virtualized mode, a single sticky-anchor element swaps its content as the user scrolls past each group's offset. The natural group header at the active offset is hidden so the anchor doesn't double-render the label, and the lookup uses binary search + `requestAnimationFrame` so the cost stays flat regardless of group count.
-
-<Demo data={virtualizedGroupingPreview} />
-
-### Loading state
-
-While `isLoading` is `true`, `DataView.List` renders `loadingRowCount` skeleton rows at the tail. Behaviour is identical in virtualized and non-virtualized mode, and during initial load (skeletons fill the row pane) as well as during paginated server-mode load-more (skeletons render below the last loaded row).
-
-<Demo data={loadingPreview} />
-
-In server mode, infinite scroll triggers via a single sentinel + `IntersectionObserver` — there are no scroll-distance knobs to tune. While `isLoading` is true the sentinel is suppressed so the consumer's `onLoadMore` isn't fired again during a fetch.
-
-### Per-view fields override
-
-Each renderer accepts an optional `fields` prop. It **fully replaces** the root `fields` for that view's active session — filter chips, sort menu, and Display Properties reflect the override while the view is active. Common pattern: spread root fields and tweak the few that differ.
-
-<Demo data={perViewFieldsPreview} />
-
-```tsx
-const listFields = fields.map((f) =>
-  f.accessorKey === "email" ? { ...f, hideable: false, defaultHidden: true } : f,
-);
-
-<DataView.List name="list" variant="list" columns={listColumns} fields={listFields} />;
-```
-
-### Row selection
-
-DataView doesn't ship a selection toolbar, but the underlying TanStack table instance is exposed via `useDataView()`, so you own the affordance: add a checkbox column to the renderer and float a [`FloatingActions`](/docs/components/floating-actions) bar over the view while rows are selected.
-
-`select` is deliberately **not** declared in `fields` — an accessor with no matching field is an *unmanaged* display column. `DataView.List` always renders it (it never appears in Display Properties, and can't be filtered, sorted, or grouped) and hands the spec a `{ row, table }` context instead of a TanStack cell context. The same applies to row actions and drag handles.
-
-<Demo data={rowSelectionPreview} />
-
-Notes:
-
-- `getRowId` is optional but recommended. Without it, selection falls back to positional keys (`'0'`, `'1'`, … and `'<group>.<index>'` inside a group section). Those come from the `data` array rather than the visible order, so client-side sort, filter, and search are safe — a static dataset needs nothing. What they can't survive is the identity behind a position changing: a refetch or server-mode sort returning rows in a new order moves the selection to whatever now sits at that index, and switching Grouping on or off re-keys the rows, dropping the selection. Pass `getRowId` whenever the data can change under you, and selection follows the row through all of it.
-- Selection state lives on the table instance and is exposed through `useDataView()`. Read it with `table.getSelectedRowModel()`, clear it with `table.resetRowSelection()` (wired to `Chip`'s `onDismiss` above), and mirror it outside the tree with `onRowSelectionChange` on the root if you need it there.
-- The TanStack [row selection API](https://tanstack.com/table/v8/docs/guide/row-selection) is available as documented: `row.getIsSelected()`, `row.toggleSelected()`, `row.getIsSomeSelected()`, `table.getIsAllRowsSelected()`, `getIsSomeRowsSelected()`, `toggleAllRowsSelected()`, `setRowSelection()`, `resetRowSelection()`. The header helpers are computed over the **filtered** rows, so select-all tracks what the user can actually see rather than the whole dataset.
-- The two *handler getters* in that guide — `row.getToggleSelectedHandler()` and `table.getToggleAllRowsSelectedHandler()` — are adapters for a native `<input type="checkbox" onChange>`: they read `event.target.checked`. Apsara's [`Checkbox`](/docs/components/checkbox) reports a boolean through `onCheckedChange`, so the table-level getter throws on `undefined.checked` and the row-level one only works via its "no value means invert" fallback. Call `toggleSelected` / `toggleAllRowsSelected` with the boolean instead, as above.
-- `FloatingActions` defaults to `variant="floating"` (`position: fixed`, bottom-center), so no positioning CSS is needed at the call site. To scope the bar to the view instead of the viewport, give an ancestor `transform`, `filter`, or `contain: paint` so it becomes the containing block for `position: fixed`. Add `padding-bottom` via `classNames.root` if rows would otherwise sit behind the bar.
-- Stop propagation in the checkbox's `onClick` when the root has an `onRowClick` — otherwise ticking a checkbox also activates the row.
-- Grouping works alongside selection. Group header rows are keyed in their own id space and are not selectable — `rowSelection` holds one key per data row, and select-all covers the visible data rows without also flagging the bands. Read the count off `getSelectedRowModel().flatRows` rather than `.rows`: the latter only walks selected *top-level* rows, which is empty while grouping puts every data row one level down.
-
-### Custom group buckets (`groupByResolvers`)
-
-The wire format keeps `group_by: string[]`. To group by something that isn't a raw accessor (e.g. "by week of created_at"), supply a resolver:
-
-```tsx
-<DataView
-  groupByResolvers={{
-    name_first_letter: (row) => row.name.charAt(0).toUpperCase(),
-  }}
-  // query.group_by = ["name_first_letter"]
-/>
-```
-
-### Server mode
-
-```tsx
-<DataView
-  mode="server"
-  data={page.rows}
-  isLoading={loading}
-  totalRowCount={page.total}
-  query={query}
-  onTableQueryChange={(q) => setQuery(q)}
-  onLoadMore={() => fetchNext()}
->
-  …
-</DataView>
-```
-
-In server mode, `onTableQueryChange` fires whenever the query changes. The `DataView.List` shows skeleton loader rows when `isLoading` is true. Filter predicates and sort run on the server — the local TanStack table is manual.
-
-## Timeline
-
-`DataView.Timeline` positions the same row model as cards on a continuous, horizontally scrollable time axis — orders on a delivery schedule, tasks on a Gantt-style plan, releases on a strip. It shares the root's entire data layer: search, filters, grouping, and Display Properties apply to cards exactly as they do to list rows, and it participates in multi-view switching via `name`.
-
-In the demo below: drag the background to pan (with a momentum glide), hover for the snapped date cursor, and use the Today button — wired through `actionsRef` — to jump back. The narrow "B" stub is a span shorter than `minCardWidth`, rendered via `context.collapsed`.
-
-<Demo data={timelinePreview} />
-
-### Cards
-
-The Timeline owns **positioning** — the time scale (date → x, span → width, using real timestamps so variable-length months don't distort placement), lane packing (non-overlapping cards share a lane; `lanePacking` opts out — see [Lane packing](#lane-packing)), the sticky two-tier axis, and scrolling. You own the **card**: `renderCard(row, context)` draws everything visual, the same split as `DataView.List`'s `columns[].cell`.
-
-```tsx
-<DataView.Timeline
-  startField="start"
-  endField="end"
-  renderCard={(row, context) => {
-    // context: { width, collapsed, laneIndex, start, end }
-    if (context.collapsed) return <CompactStub task={row.original} />;
-    return <TaskCard task={row.original} />;
-  }}
-/>
-```
-
-`context.collapsed` flips when the span is narrower than `minCardWidth` (default 60px) — render a compact stub instead of letting the full card clip (point cards never collapse; they size to their content). Wrap card fields in `DataView.DisplayAccess` so the toolbar's Display Properties toggles reach them.
-
-Card height is content-driven, the same contract as `DataView.List` rows: cards auto-measure after paint, each lane sizes to its tallest card, and `estimatedRowHeight` (default 66) is only a layout hint until real heights arrive. Under `virtualized` this inverts — a culled card never reports a height, so measuring would resize lanes as you scroll and shift every lane below them. Lanes there take a fixed `estimatedRowHeight` pitch, and a card taller than it overlaps the lane below instead of growing its own. Give your card an explicit height if you want uniform cards, and keep that height within the pitch if you virtualize. Keep `renderCard` referentially stable (define it outside the component or wrap it in `useCallback`) — cards are memoized against it, and an inline closure forces every visible card to re-render on each scroll frame.
-
-### Point markers
-
-Omit `endField` and rows render as point markers at their date — releases, incidents, audit events. The wrapper sizes to the card's content instead of a time span, and `context.end` is `null`. Because the packer can't measure content, it assumes each point card is `estimatedPointWidth` wide (default 120px) when assigning lanes — set it to roughly your widest point card so nearby markers don't overlap in a lane.
-
-<Demo data={timelinePointPreview} />
-
-### Lane packing
-
-`lanePacking` decides what a lane *means*. All three modes run per group section — a card never shares a lane across sections.
-
-| Mode | A lane is | Use it for |
-| --- | --- | --- |
-| `auto` (default) | a dense chronological track: cards that don't overlap in time share it | fitting many cards into the least vertical space |
-| `one-per-row` | one row | a Gantt chart, where every row needs its own visible track |
-| `one-per-sort-value` | one distinct value of the **sorted-by** field | grouping by a property while keeping the flat single-axis layout |
-
-Under `one-per-sort-value`, rows sharing a value share a lane and are packed by date within it; a value only claims a **sub-lane** where two of its own cards overlap in time. So a timeline sorted by priority shows a High lane, a Medium lane and a Low lane, and only the priority with genuinely concurrent work grows a second row.
-
-The active sort does double duty here: it picks the field lanes are built from *and* orders them, so the Ordering control repositions lanes live and there's no second ordering vocabulary to keep in sync.
-
-<Demo data={timelineSortValueLanePreview} />
-
-```tsx
-<DataView
-  data={tasks}
-  fields={fields}
-  // The sort is the lane definition: sort by rank → one lane per rank value
-  defaultSort={{ name: "rank", order: "asc" }}
-  getRowId={(t) => t.id}>
-  <DataView.Timeline
-    startField="start"
-    endField="end"
-    lanePacking="one-per-sort-value"
-    renderCard={renderCard}
-  />
-</DataView>
-```
-
-- **Rank what doesn't sort naturally.** Sorting `priority` alphabetically gives High, Low, Medium. Carry a numeric `rank` alongside it and sort on that for High, Medium, Low — the lane values are then the ranks, which is invisible unless your card shows them.
-- **Rows with no usable value** — null, `undefined`, `""`, or a non-primitive (which also logs a dev warning) — share one lane, always last, wherever the sort would have put them.
-- **Values are keyed by their string form**, so `1` and `"1"` share a lane. Resolve an object-valued field to a primitive before sorting on it.
-- **No sort, no lanes.** The mode falls back to `auto` if the query carries no sort — `defaultSort` is required on the root, so that's a guard rather than a configuration.
-- **With `group_by` active**, each section gets its own lane set and `context.laneIndex` stays section-relative. Grouping by the sorted field is allowed and simply degenerates: a section already holds one value, so it renders as one lane (plus sub-lanes on overlap).
-
-
-### Grouping
-
-Set `group_by` (from `DataView.DisplayControls` → Grouping, or on the initial `query`) and the timeline splits into **swim-lane sections** stacked under the single shared time axis: a full-width header band per group, that group's cards lane-packed beneath it. Horizontal position stays purely time — grouping reorganizes vertically only.
-
-<Demo data={timelineGroupingPreview} />
-
-```tsx
-// Mark the field groupable; showGroupCount adds the count badge to the band.
-const fields = [
-  { accessorKey: "team", label: "Team", groupable: true, showGroupCount: true },
-  …
-];
-
-<DataView data={tasks} fields={fields} query={{ group_by: ["team"] }} …>
-  <DataView.Timeline startField="start" endField="end" renderCard={renderCard} />
-</DataView>
-```
-
-The timeline consumes the **same group rows** `DataView.List` renders as section headers — the root's `groupData` output — so section order, labels (`groupLabelsMap`), and counts (`groupCountMap`, or the bucket size) match between views, in client and server mode alike. There's no timeline-specific grouping path to keep in sync.
-
-Section order is the field's `groupOrder` where it declares one (`['High', 'Medium', 'Low']` — the ranking sorting can't express), then values it doesn't list in first-occurrence order, with rows that have no value in the last section. A declared value with no rows renders no section.
-
-- **Packing is per section.** A card only ever shares a lane with cards in its own group, and `context.laneIndex` is section-relative (every section starts at lane 0). `lanePacking="one-per-row"` and `"one-per-sort-value"` apply within each section too.
-- **Bands pin while their section is in view.** The active band sticks directly under the time axis and is pushed off by the next section's band; its label sticks to the left edge so it stays readable while you pan to a distant month. Always on — pure CSS, no prop.
-- **Empty sections disappear.** A group whose cards all fall outside an explicit `range` (or that has no valid `startField` values) renders nothing — no band, no empty strip. A band that *does* render shows the full group count, even when some of its cards are culled, matching List.
-- **`showGroupHeaders={false}`** hides the bands but keeps the sections — same semantics as the prop on `DataView.List`. Style a band with `classNames.groupHeader`.
-
-Bands are labels only in this release: no chevron, no collapsing.
-
-### Ordering
-
-Sort can't move a card horizontally — x is locked to the start date — so it reaches the vertical axis only, and only under two of the three packing modes. With `lanePacking="one-per-row"`, row order follows the active sort (within each section when grouped). With `"one-per-sort-value"` it does more than reorder: the sorted-by field *defines* the lanes, so changing the sort field rebuilds them (see [Lane packing](#lane-packing)). Leave the Ordering control visible for both.
-
-Under the default `auto` packing the sort has no visible effect at all — lanes are assigned by dense chronological first-fit — so there, hide the control (`<DataView.DisplayControls hideOrdering />`) or leave `sortable` off the timeline's per-view `fields`.
-
-In `mode="server"` the sort is the backend's to apply: rows arrive already ordered and `one-per-sort-value` takes lane order from that row order, first value seen first. A backend that ignores the `sort` in `onTableQueryChange` therefore produces lanes in whatever order it returned rows, with nothing logged to say so — the lane *membership* is still correct, only the ranking is arbitrary.
-
-### Scale and axis
-
-Four props control the axis, and they compose rather than overlap:
-
-- `scale` — the tick unit: `day` (default), `week`, `month`, or `quarter`.
-- `unitWidth` — pixels per unit (defaults: day 20, week 56, month 96, quarter 140). This is the zoom knob.
-- `tickInterval` — label every Nth unit. Labels never render closer than a collision floor, so a too-dense value degrades gracefully instead of overlapping.
-- `gridlineInterval` — draw a gridline every Nth unit. Purely visual: cards, the today line, and cursor snapping still land on every unit.
-
-The domain defaults to the data extent (plus today and markers) with padding. Pass an explicit `range` to fix the coordinate space — essential for range-window loading below, since the scrollbar then never jumps as data streams in. Rows entirely outside an explicit `range` are culled.
-
-### Today and markers
-
-`today` (default `true`) draws a vertical line with a date badge pinned to the axis, at day precision so server and client renders agree. Pin it to a fixed date with `today={date}` or hide it with `today={false}`. `markers` adds more full-height lines for milestones and deadlines:
-
-```tsx
-<DataView.Timeline
-  markers={[
-    { date: "2026-08-01", label: "Code freeze" },
-    { date: "2026-08-15", label: "Release", variant: "accent" },
-    { date: "2026-08-20", label: "EOL", variant: "danger" },
-  ]}
-/>
-```
-
-### Navigation
-
-`defaultScrollTo` (default `'today'`) sets the initial scroll position: a date, `'today'`, `'start'`, or `'end'`. After mount, navigate imperatively through `actionsRef`:
-
-```tsx
-const timelineActions = useRef<TimelineActions | null>(null);
-
-<DataView.Timeline actionsRef={timelineActions} … />
-
-<Button onClick={() => timelineActions.current?.scrollTo("today")}>
-  Today
-</Button>
-```
-
-`scrollTo(target, { align = "center", behavior = "smooth" })` accepts the same target vocabulary as `defaultScrollTo`. Out-of-domain dates clamp to the nearest domain edge; while the timeline is hidden (inactive view, no data) calls no-op with a dev warning. `getVisibleRange()` returns the visible `[Date, Date]` window (or `null` while hidden) — useful for showing the Today button only when today is off-screen.
-
-Filtering navigates too: when a filter or search change leaves no matching card in the viewport, the timeline scrolls the earliest match into view instead of leaving you parked on empty canvas (a change whose results are already on screen doesn't move the view). Opt out with `scrollToResults={false}`.
-
-### Loading data by visible range
-
-Offset pagination doesn't fit a 2-D time canvas — the natural unit of fetching is the **visible window**. The recommended pattern is client mode + `onVisibleRangeChange`:
-
-1. Fix the coordinate space with an explicit `range` so the scrollbar stays stable while rows stream in.
-2. On `onVisibleRangeChange`, widen the window by a prefetch pad and fetch rows **overlapping** it (`start <= to AND end >= from` — a containment filter drops cards straddling the window edges).
-3. Track requested buckets (e.g. months) in a `Set` so re-entering a window is free, and dedupe merged rows by id — edge-straddling rows come back from both adjacent fetches. On a failed fetch, delete the affected buckets from the `Set` so scrolling back retries them instead of leaving a permanent hole.
-4. Throttle, don't debounce: a debounce waits for scrolling to stop, leaving a gap of missing cards mid-drag.
-
-```tsx
-const [orders, setOrders] = useState<Order[]>([]);
-const [isLoading, setIsLoading] = useState(true); // initial fetch in flight
-
-<DataView
-  data={orders}
-  fields={fields}
-  mode="client" // filters/search run locally against loaded rows
-  isLoading={isLoading}
-  defaultSort={{ name: "start", order: "asc" }}
-  getRowId={(o) => o.id}
->
-  <DataView.Timeline
-    startField="start"
-    endField="end"
-    range={FIXED_RANGE}
-    virtualized
-    onVisibleRangeChange={([from, to]) => throttledLoadWindow(from, to)}
-    renderCard={renderOrderCard}
-  />
-</DataView>
-```
-
-Start with `isLoading={true}` and fire an initial fetch on mount: with no data and no loading flag the timeline renders `null` (the zero state takes over), so `onVisibleRangeChange` would never fire to bootstrap the first window. Keep the row model **cumulative** — the domain is stable, so previously fetched cards stay mounted and scrolling back is instant. Scroll position is anchored by *time*, not pixels: if the domain shifts (a `range` extension, rows prepended by a fetch), the date under the viewport's left edge stays put instead of the content jumping.
-
-### Notes
-
-- **Grouping** renders as swim-lane sections and **sorting** only reaches `lanePacking="one-per-row"` and `"one-per-sort-value"` (where it defines the lanes) — see [Grouping](#grouping) and [Ordering](#ordering). Hide a control that has no meaning for your configuration (`<DataView.DisplayControls hideOrdering />`), or pass the timeline a per-view `fields` override without `sortable`/`groupable`.
-- **`virtualized`** culls both axes: cards, gridlines, tick labels, month bands, and markers render only near the viewport, and the grid and marker lines span the visible window rather than the full canvas height. A frame costs what is on screen rather than what is in the data, so a long domain and deep grouping stay affordable. It defaults to `false` — pass it explicitly. Recommended whenever the domain is long or rows are numerous.
-- **Without `virtualized`, nothing is culled vertically.** Every lane in the domain stays mounted and every card in the visible time window renders, so deep grouping over thousands of rows builds a tall, fully populated canvas. The trade is content-driven lane heights (see [Cards](#cards)), which virtualization gives up.
-- **Interaction** — cards receive row clicks via the root's `onRowClick`; the background supports mouse drag-to-pan with a momentum glide; scrolling past the domain edge won't trigger browser back-swipe. The pane is a focusable, labelled region (`aria-label`, default "Timeline"), so keyboard users can Tab to it and scroll with the arrow keys.
-
 ## Accessibility
 
-- `DataView.List` with `variant="table"` renders real table semantics:
-  `role="table"` on the grid with `rowgroup`, `row`, `columnheader`, and
-  `cell` on its parts. `variant="list"` uses `role="list"` with `listitem`
-  rows instead.
 - When `onRowClick` is set, each row gets `tabIndex={0}` and activates with
-  Enter or Space, matching a native button. Rows keep their structural role
-  (`row`/`listitem`) so cells stay associated with their row, and key presses
-  bubbling up from interactive children (buttons, links in cells) are ignored
-  so they don't also trigger row activation.
-- Skeleton loader rows are marked `aria-busy="true"`; the infinite-scroll
-  sentinel and the duplicate sticky group-header anchor are `aria-hidden` so
-  screen readers don't announce them.
-- The Timeline pane is a focusable, labelled `role="region"` (`aria-label`,
-  default "Timeline") that keyboard users can Tab to and scroll with arrow
-  keys; the card canvas is a `role="list"` with each card as a `listitem`,
-  and decorative gridlines, markers, and the axis are `aria-hidden`.
+  Enter or Space, matching a native button. Rows keep their structural role so
+  cells stay associated with their row, and key presses bubbling up from
+  interactive children (buttons, links in cells) are ignored so they don't also
+  trigger row activation.
+- Renderer-specific semantics are documented on the
+  [List](/docs/components/dataview/list#accessibility) and
+  [Timeline](/docs/components/dataview/timeline#accessibility) pages.

--- a/apps/www/src/content/docs/components/dataview/list.mdx
+++ b/apps/www/src/content/docs/components/dataview/list.mdx
@@ -1,0 +1,154 @@
+---
+title: List
+description: DataView's table and list renderer — two presentations behind one component, with virtualization, grouping, and row selection.
+source: packages/raystack/components/data-view
+---
+
+import {
+  tablePreview,
+  listPreview,
+  virtualizedPreview,
+  groupingPreview,
+  virtualizedGroupingPreview,
+  loadingPreview,
+  rowSelectionPreview,
+} from "./demo.ts";
+
+<Demo data={tablePreview} />
+
+## Overview
+
+`DataView.List` draws the row model as a grid. It ships two presentations behind one renderer — `variant="table"` for column headers and aligned tracks, `variant="list"` for card-style rows — and both read the same [fields, filters, and display properties](/docs/components/dataview) declared on the root.
+
+## Anatomy
+
+```tsx
+import { DataView, DataViewListColumn } from "@raystack/apsara";
+
+<DataView data={data} fields={fields} defaultSort={defaultSort}>
+  <DataView.Toolbar>
+    <DataView.Search />
+    <DataView.Filters />
+    <DataView.DisplayControls />
+  </DataView.Toolbar>
+
+  <DataView.List variant="table" columns={columns} />
+</DataView>
+```
+
+## Usage
+
+### Variant
+
+`variant="table"` is the default: a header row, aligned column tracks, and real table semantics. `variant="list"` drops the header and renders card-style rows — the default `1fr` middle column with `auto` end columns gives you the familiar justify-between layout.
+
+<Demo data={listPreview} />
+
+### Columns
+
+`columns` is the presentation half of the [fields and columns split](/docs/components/dataview#fields-and-columns). Each entry maps an `accessorKey` to a `width` and a `cell` renderer.
+
+```tsx
+const columns: DataViewListColumn<Person>[] = [
+  { accessorKey: "name",  width: "1fr",  cell: ({ row }) => <Text>{row.original.name}</Text> },
+  { accessorKey: "team",  width: "auto", cell: ({ row }) => <Badge>{row.original.team}</Badge> },
+];
+```
+
+An accessor with no matching entry in the root's `fields` is an **unmanaged display column**. `DataView.List` always renders it, it never appears in Display Properties, and it can't be filtered, sorted, or grouped. Checkboxes, row actions, and drag handles all work this way.
+
+### Virtualization
+
+For large datasets, pass `virtualized`. The parent must have a fixed height — only the rows in view are rendered. Rows auto-measure after paint, so variable-height content (avatars, wrapped text, badges) just works. `estimatedRowHeight` is an optional hint used only until the first measurement.
+
+<Demo data={virtualizedPreview} />
+
+### Grouping
+
+Group rows by any `groupable` field. `stickyGroupHeader` pins the active group label directly under the column headers while you scroll past that group's rows. Pick a different field from `DisplayControls` → Grouping at runtime — the wire format stays `group_by: string[]`.
+
+<Demo data={groupingPreview} />
+
+In virtualized mode, a single sticky-anchor element swaps its content as the user scrolls past each group's offset. The natural group header at the active offset is hidden so the anchor doesn't double-render the label, and the lookup uses binary search plus `requestAnimationFrame` so the cost stays flat regardless of group count.
+
+<Demo data={virtualizedGroupingPreview} />
+
+### Loading
+
+While `isLoading` is `true`, `DataView.List` renders `loadingRowCount` skeleton rows at the tail. Behaviour is identical in virtualized and non-virtualized mode, and during initial load (skeletons fill the row pane) as well as during paginated load-more (skeletons render below the last loaded row).
+
+<Demo data={loadingPreview} />
+
+In [server mode](/docs/components/dataview#server-mode), infinite scroll triggers via a single sentinel and an `IntersectionObserver` — there are no scroll-distance knobs to tune. While `isLoading` is true the sentinel is suppressed so your `onLoadMore` isn't fired again during a fetch.
+
+### Row selection
+
+DataView doesn't ship a selection toolbar, but the underlying TanStack table instance is exposed via `useDataView()`, so you own the affordance: add a checkbox column to the renderer and float a [`FloatingActions`](/docs/components/floating-actions) bar over the view while rows are selected.
+
+<Demo data={rowSelectionPreview} />
+
+**Pass `getRowId` whenever the data can change under you.** Without it, selection falls back to positional keys (`'0'`, `'1'`, and `'<group>.<index>'` inside a group section). Those come from the `data` array rather than the visible order, so client-side sort, filter, and search are safe — a static dataset needs nothing. What they can't survive is the identity behind a position changing: a refetch or server-mode sort returning rows in a new order moves the selection to whatever now sits at that index, and switching Grouping on or off re-keys the rows and drops the selection.
+
+**Selection state lives on the table instance.** Read it with `table.getSelectedRowModel()`, clear it with `table.resetRowSelection()`, and mirror it outside the tree with `onRowSelectionChange` on the root if you need it there.
+
+**The TanStack [row selection API](https://tanstack.com/table/v8/docs/guide/row-selection) works as documented** — `row.getIsSelected()`, `row.toggleSelected()`, `row.getIsSomeSelected()`, `table.getIsAllRowsSelected()`, `getIsSomeRowsSelected()`, `toggleAllRowsSelected()`, `setRowSelection()`, `resetRowSelection()`. The header helpers are computed over the **filtered** rows, so select-all tracks what the user can actually see rather than the whole dataset.
+
+**Don't use the two handler getters from that guide.** `row.getToggleSelectedHandler()` and `table.getToggleAllRowsSelectedHandler()` are adapters for a native `<input type="checkbox" onChange>` and read `event.target.checked`. Apsara's [`Checkbox`](/docs/components/checkbox) reports a boolean through `onCheckedChange`, so the table-level getter throws on `undefined.checked` and the row-level one only works via its "no value means invert" fallback. Call `toggleSelected` and `toggleAllRowsSelected` with the boolean instead.
+
+**Positioning the actions bar.** `FloatingActions` defaults to `variant="floating"` (`position: fixed`, bottom-center), so no positioning CSS is needed at the call site. To scope the bar to the view instead of the viewport, give an ancestor `transform`, `filter`, or `contain: paint` so it becomes the containing block for `position: fixed`. Add `padding-bottom` via `classNames.root` if rows would otherwise sit behind the bar.
+
+**Stop propagation in the checkbox's `onClick`** when the root has an `onRowClick`, otherwise ticking a checkbox also activates the row.
+
+**Grouping works alongside selection.** Group header rows are keyed in their own id space and are not selectable — `rowSelection` holds one key per data row, and select-all covers the visible data rows without also flagging the bands. Read the count off `getSelectedRowModel().flatRows` rather than `.rows`: the latter only walks selected *top-level* rows, which is empty while grouping puts every data row one level down.
+
+## API Reference
+
+### DataView.List
+
+<auto-type-table path="./props.ts" name="DataViewListProps" />
+
+### Column
+
+<auto-type-table path="./props.ts" name="DataViewListColumn" />
+
+### Slots
+
+Every rendered part carries a stable `data-slot` attribute for [styling and testing](/docs/styling#with-data-slot). Toolbar, filter, and display-control slots are on the [DataView](/docs/components/dataview#slots) page.
+
+| Slot | Element |
+|------|---------|
+| `data-view-list` | Scroll container |
+| `data-view-list-grid` | The grid carrying the table/list role |
+| `data-view-list-header` | Header row group |
+| `data-view-list-header-row` | Header row |
+| `data-view-list-header-cell` | Header cell |
+| `data-view-list-body` | Row container |
+| `data-view-list-row` | Data row |
+| `data-view-list-cell` | Cell (data and loader rows) |
+| `data-view-list-group-header` | Group header (incl. the sticky anchor) |
+| `data-view-list-loader-row` | Skeleton row while `isLoading` |
+| `data-view-list-sentinel` | Infinite-scroll sentinel |
+
+Header cells, body cells, and loader cells also carry `data-column="{accessorKey}"`, so a single column can be targeted without a per-column `classNames` entry:
+
+```css
+/* Right-align every cell in the "amount" column, header included */
+[data-slot="data-view-list-cell"][data-column="amount"],
+[data-slot="data-view-list-header-cell"][data-column="amount"] {
+  text-align: right;
+}
+```
+
+## Accessibility
+
+- `variant="table"` renders real table semantics: `role="table"` on the grid
+  with `rowgroup`, `row`, `columnheader`, and `cell` on its parts.
+  `variant="list"` uses `role="list"` with `listitem` rows instead.
+- When `onRowClick` is set, each row gets `tabIndex={0}` and activates with
+  Enter or Space, matching a native button. Rows keep their structural role
+  (`row` or `listitem`) so cells stay associated with their row, and key
+  presses bubbling up from interactive children are ignored so they don't also
+  trigger row activation.
+- Skeleton loader rows are marked `aria-busy="true"`; the infinite-scroll
+  sentinel and the duplicate sticky group-header anchor are `aria-hidden` so
+  screen readers don't announce them.

--- a/apps/www/src/content/docs/components/dataview/meta.json
+++ b/apps/www/src/content/docs/components/dataview/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "DataView",
+  "pages": ["list", "timeline"]
+}

--- a/apps/www/src/content/docs/components/dataview/timeline.mdx
+++ b/apps/www/src/content/docs/components/dataview/timeline.mdx
@@ -1,0 +1,290 @@
+---
+title: Timeline
+description: DataView's time-axis renderer — cards positioned on a continuous, scrollable date range with lane packing, swim-lane grouping, and range-window loading.
+source: packages/raystack/components/data-view
+---
+
+import {
+  timelinePreview,
+  timelineSortValueLanePreview,
+  timelineGroupingPreview,
+  timelinePointPreview,
+} from "./demo.ts";
+
+<Demo data={timelinePreview} />
+
+## Overview
+
+`DataView.Timeline` positions the same row model as cards on a continuous, horizontally scrollable time axis — orders on a delivery schedule, tasks on a Gantt-style plan, releases on a strip. It shares the root's entire data layer: search, filters, grouping, and Display Properties apply to cards exactly as they do to list rows, and it participates in multi-view switching via `name`.
+
+In the demo above: drag the background to pan (with a momentum glide), hover for the snapped date cursor, and use the Today button — wired through `actionsRef` — to jump back. The narrow "B" stub is a span shorter than `minCardWidth`, rendered via `context.collapsed`.
+
+## Anatomy
+
+```tsx
+import { DataView, TimelineActions } from "@raystack/apsara";
+
+<DataView data={tasks} fields={fields} defaultSort={defaultSort} getRowId={(t) => t.id}>
+  <DataView.Toolbar>
+    <DataView.Search />
+    <DataView.Filters />
+    <DataView.DisplayControls />
+  </DataView.Toolbar>
+
+  <DataView.Timeline
+    startField="start"
+    endField="end"
+    renderCard={renderCard}
+  />
+</DataView>
+```
+
+## Usage
+
+### Cards
+
+The Timeline owns **positioning** — the time scale (date to x, span to width, using real timestamps so variable-length months don't distort placement), lane packing, the sticky two-tier axis, and scrolling. You own the **card**: `renderCard(row, context)` draws everything visual, the same split as `DataView.List`'s `columns[].cell`.
+
+```tsx
+<DataView.Timeline
+  startField="start"
+  endField="end"
+  renderCard={(row, context) => {
+    // context: { width, collapsed, laneIndex, start, end }
+    if (context.collapsed) return <CompactStub task={row.original} />;
+    return <TaskCard task={row.original} />;
+  }}
+/>
+```
+
+`context.collapsed` flips when the span is narrower than `minCardWidth` (default 60px) — render a compact stub instead of letting the full card clip. Point cards never collapse; they size to their content. Wrap card fields in `DataView.DisplayAccess` so the toolbar's Display Properties toggles reach them.
+
+Card height is content-driven, the same contract as `DataView.List` rows: cards auto-measure after paint, each lane sizes to its tallest card, and `estimatedRowHeight` (default 66) is only a layout hint until real heights arrive. Under `virtualized` this inverts — a culled card never reports a height, so measuring would resize lanes as you scroll and shift every lane below them. Lanes there take a fixed `estimatedRowHeight` pitch, and a card taller than it overlaps the lane below instead of growing its own. Give your card an explicit height if you want uniform cards, and keep that height within the pitch if you virtualize.
+
+Keep `renderCard` referentially stable — define it outside the component or wrap it in `useCallback`. Cards are memoized against it, and an inline closure forces every visible card to re-render on each scroll frame.
+
+### Point markers
+
+Omit `endField` and rows render as point markers at their date — releases, incidents, audit events. The wrapper sizes to the card's content instead of a time span, and `context.end` is `null`. Because the packer can't measure content, it assumes each point card is `estimatedPointWidth` wide (default 120px) when assigning lanes — set it to roughly your widest point card so nearby markers don't overlap in a lane.
+
+<Demo data={timelinePointPreview} />
+
+### Lane packing
+
+`lanePacking` decides what a lane *means*. All three modes run per group section — a card never shares a lane across sections.
+
+| Mode | A lane is | Use it for |
+| --- | --- | --- |
+| `auto` (default) | a dense chronological track: cards that don't overlap in time share it | fitting many cards into the least vertical space |
+| `one-per-row` | one row | a Gantt chart, where every row needs its own visible track |
+| `one-per-sort-value` | one distinct value of the **sorted-by** field | grouping by a property while keeping the flat single-axis layout |
+
+Under `one-per-sort-value`, rows sharing a value share a lane and are packed by date within it; a value only claims a **sub-lane** where two of its own cards overlap in time. So a timeline sorted by priority shows a High lane, a Medium lane and a Low lane, and only the priority with genuinely concurrent work grows a second row.
+
+The active sort does double duty here: it picks the field lanes are built from *and* orders them, so the Ordering control repositions lanes live and there's no second ordering vocabulary to keep in sync.
+
+<Demo data={timelineSortValueLanePreview} />
+
+```tsx
+<DataView
+  data={tasks}
+  fields={fields}
+  // The sort is the lane definition: sort by rank → one lane per rank value
+  defaultSort={{ name: "rank", order: "asc" }}
+  getRowId={(t) => t.id}>
+  <DataView.Timeline
+    startField="start"
+    endField="end"
+    lanePacking="one-per-sort-value"
+    renderCard={renderCard}
+  />
+</DataView>
+```
+
+**Rank what doesn't sort naturally.** Sorting `priority` alphabetically gives High, Low, Medium. Carry a numeric `rank` alongside it and sort on that for High, Medium, Low — the lane values are then the ranks, which is invisible unless your card shows them.
+
+**Rows with no usable value** — null, `undefined`, `""`, or a non-primitive (which also logs a dev warning) — share one lane, always last, wherever the sort would have put them.
+
+**Values are keyed by their string form**, so `1` and `"1"` share a lane. Resolve an object-valued field to a primitive before sorting on it.
+
+**No sort, no lanes.** The mode falls back to `auto` if the query carries no sort. `defaultSort` is required on the root, so that's a guard rather than a configuration.
+
+**With `group_by` active**, each section gets its own lane set and `context.laneIndex` stays section-relative. Grouping by the sorted field is allowed and simply degenerates: a section already holds one value, so it renders as one lane, plus sub-lanes on overlap.
+
+### Grouping
+
+Set `group_by` — from `DataView.DisplayControls` → Grouping, or on the initial `query` — and the timeline splits into **swim-lane sections** stacked under the single shared time axis: a full-width header band per group, with that group's cards lane-packed beneath it. Horizontal position stays purely time; grouping reorganizes vertically only.
+
+<Demo data={timelineGroupingPreview} />
+
+```tsx
+// Mark the field groupable; showGroupCount adds the count badge to the band.
+const fields = [
+  { accessorKey: "team", label: "Team", groupable: true, showGroupCount: true },
+  …
+];
+
+<DataView data={tasks} fields={fields} query={{ group_by: ["team"] }} …>
+  <DataView.Timeline startField="start" endField="end" renderCard={renderCard} />
+</DataView>
+```
+
+The timeline consumes the **same group rows** `DataView.List` renders as section headers — the root's `groupData` output — so section order, labels (`groupLabelsMap`), and counts (`groupCountMap`, or the bucket size) match between views, in client and server mode alike. There's no timeline-specific grouping path to keep in sync.
+
+Section order is the field's `groupOrder` where it declares one (`['High', 'Medium', 'Low']` — the ranking sorting can't express), then values it doesn't list in first-occurrence order, with rows that have no value in the last section. A declared value with no rows renders no section.
+
+**Packing is per section.** A card only ever shares a lane with cards in its own group, and `context.laneIndex` is section-relative — every section starts at lane 0. `lanePacking="one-per-row"` and `"one-per-sort-value"` apply within each section too.
+
+**Bands pin while their section is in view.** The active band sticks directly under the time axis and is pushed off by the next section's band; its label sticks to the left edge so it stays readable while you pan to a distant month. Always on — pure CSS, no prop.
+
+**Empty sections disappear.** A group whose cards all fall outside an explicit `range`, or that has no valid `startField` values, renders nothing — no band, no empty strip. A band that *does* render shows the full group count, even when some of its cards are culled, matching List.
+
+**`showGroupHeaders={false}`** hides the bands but keeps the sections — same semantics as the prop on `DataView.List`. Style a band with `classNames.groupHeader`.
+
+Bands are labels only in this release: no chevron, no collapsing.
+
+### Ordering
+
+Sort can't move a card horizontally — x is locked to the start date — so it reaches the vertical axis only, and only under two of the three packing modes. With `lanePacking="one-per-row"`, row order follows the active sort, within each section when grouped. With `"one-per-sort-value"` it does more than reorder: the sorted-by field *defines* the lanes, so changing the sort field rebuilds them. Leave the Ordering control visible for both.
+
+Under the default `auto` packing the sort has no visible effect at all — lanes are assigned by dense chronological first-fit — so there, hide the control with `<DataView.DisplayControls hideOrdering />`, or leave `sortable` off the timeline's per-view `fields`.
+
+In [server mode](/docs/components/dataview#server-mode) the sort is the backend's to apply: rows arrive already ordered and `one-per-sort-value` takes lane order from that row order, first value seen first. A backend that ignores the `sort` in `onTableQueryChange` therefore produces lanes in whatever order it returned rows, with nothing logged to say so. The lane *membership* is still correct, only the ranking is arbitrary.
+
+### Scale and axis
+
+Four props control the axis, and they compose rather than overlap:
+
+- `scale` — the tick unit: `day` (default), `week`, `month`, or `quarter`.
+- `unitWidth` — pixels per unit (defaults: day 20, week 56, month 96, quarter 140). This is the zoom knob.
+- `tickInterval` — label every Nth unit. Labels never render closer than a collision floor, so a too-dense value degrades gracefully instead of overlapping.
+- `gridlineInterval` — draw a gridline every Nth unit. Purely visual: cards, the today line, and cursor snapping still land on every unit.
+
+The domain defaults to the data extent (plus today and markers) with padding. Pass an explicit `range` to fix the coordinate space — essential for range-window loading, since the scrollbar then never jumps as data streams in. Rows entirely outside an explicit `range` are culled.
+
+### Today and markers
+
+`today` (default `true`) draws a vertical line with a date badge pinned to the axis, at day precision so server and client renders agree. Pin it to a fixed date with `today={date}` or hide it with `today={false}`. `markers` adds more full-height lines for milestones and deadlines:
+
+```tsx
+<DataView.Timeline
+  markers={[
+    { date: "2026-08-01", label: "Code freeze" },
+    { date: "2026-08-15", label: "Release", variant: "accent" },
+    { date: "2026-08-20", label: "EOL", variant: "danger" },
+  ]}
+/>
+```
+
+### Navigation
+
+`defaultScrollTo` (default `'today'`) sets the initial scroll position: a date, `'today'`, `'start'`, or `'end'`. After mount, navigate imperatively through `actionsRef`:
+
+```tsx
+const timelineActions = useRef<TimelineActions | null>(null);
+
+<DataView.Timeline actionsRef={timelineActions} … />
+
+<Button onClick={() => timelineActions.current?.scrollTo("today")}>
+  Today
+</Button>
+```
+
+`scrollTo(target, { align = "center", behavior = "smooth" })` accepts the same target vocabulary as `defaultScrollTo`. Out-of-domain dates clamp to the nearest domain edge; while the timeline is hidden (inactive view, no data) calls no-op with a dev warning. `getVisibleRange()` returns the visible `[Date, Date]` window, or `null` while hidden — useful for showing the Today button only when today is off-screen.
+
+Filtering navigates too: when a filter or search change leaves no matching card in the viewport, the timeline scrolls the earliest match into view instead of leaving you parked on empty canvas. A change whose results are already on screen doesn't move the view. Opt out with `scrollToResults={false}`.
+
+### Virtualization
+
+`virtualized` culls both axes: cards, gridlines, tick labels, month bands, and markers render only near the viewport, and the grid and marker lines span the visible window rather than the full canvas height. A frame costs what is on screen rather than what is in the data, so a long domain and deep grouping stay affordable. It defaults to `false` — pass it explicitly. Recommended whenever the domain is long or rows are numerous.
+
+Without it, nothing is culled vertically. Every lane in the domain stays mounted and every card in the visible time window renders, so deep grouping over thousands of rows builds a tall, fully populated canvas. The trade is content-driven lane heights, which virtualization gives up.
+
+### Loading by visible range
+
+Offset pagination doesn't fit a 2-D time canvas — the natural unit of fetching is the **visible window**. So unlike List, a timeline backed by an API usually stays in **client mode** and fetches through `onVisibleRangeChange` rather than switching to [server mode](/docs/components/dataview#server-mode).
+
+1. Fix the coordinate space with an explicit `range` so the scrollbar stays stable while rows stream in.
+2. On `onVisibleRangeChange`, widen the window by a prefetch pad and fetch rows **overlapping** it (`start <= to AND end >= from`). A containment filter drops cards straddling the window edges.
+3. Track requested buckets, such as months, in a `Set` so re-entering a window is free, and dedupe merged rows by id — edge-straddling rows come back from both adjacent fetches. On a failed fetch, delete the affected buckets from the `Set` so scrolling back retries them instead of leaving a permanent hole.
+4. Throttle, don't debounce. A debounce waits for scrolling to stop, leaving a gap of missing cards mid-drag.
+
+```tsx
+const [orders, setOrders] = useState<Order[]>([]);
+const [isLoading, setIsLoading] = useState(true); // initial fetch in flight
+
+<DataView
+  data={orders}
+  fields={fields}
+  mode="client" // filters/search run locally against loaded rows
+  isLoading={isLoading}
+  defaultSort={{ name: "start", order: "asc" }}
+  getRowId={(o) => o.id}
+>
+  <DataView.Timeline
+    startField="start"
+    endField="end"
+    range={FIXED_RANGE}
+    virtualized
+    onVisibleRangeChange={([from, to]) => throttledLoadWindow(from, to)}
+    renderCard={renderOrderCard}
+  />
+</DataView>
+```
+
+Start with `isLoading={true}` and fire an initial fetch on mount. With no data and no loading flag the timeline renders `null` and the zero state takes over, so `onVisibleRangeChange` would never fire to bootstrap the first window.
+
+Keep the row model **cumulative**. The domain is stable, so previously fetched cards stay mounted and scrolling back is instant. Scroll position is anchored by *time*, not pixels: if the domain shifts — a `range` extension, rows prepended by a fetch — the date under the viewport's left edge stays put instead of the content jumping.
+
+## API Reference
+
+### DataView.Timeline
+
+<auto-type-table path="./props.ts" name="DataViewTimelineProps" />
+
+### Card context
+
+Passed as the second argument to `renderCard`.
+
+<auto-type-table path="./props.ts" name="TimelineCardContext" />
+
+### Marker
+
+<auto-type-table path="./props.ts" name="TimelineMarker" />
+
+### Actions
+
+The imperative handle received through `actionsRef`.
+
+<auto-type-table path="./props.ts" name="TimelineActions" />
+
+### Slots
+
+Every rendered part carries a stable `data-slot` attribute for [styling and testing](/docs/styling#with-data-slot). Toolbar, filter, and display-control slots are on the [DataView](/docs/components/dataview#slots) page.
+
+| Slot | Element |
+|------|---------|
+| `data-view-timeline` | Scroll container |
+| `data-view-timeline-axis` | Sticky axis |
+| `data-view-timeline-axis-band` / `-band-label` | Month/year band and its label |
+| `data-view-timeline-axis-tick` | Axis tick |
+| `data-view-timeline-axis-marker` | Today/custom marker badge on the axis |
+| `data-view-timeline-axis-cursor` | Hover cursor badge on the axis |
+| `data-view-timeline-canvas` | Card canvas |
+| `data-view-timeline-card` | Card positioning wrapper |
+| `data-view-timeline-gridline` | Vertical gridline |
+| `data-view-timeline-marker` | Marker line on the canvas |
+| `data-view-timeline-cursor` | Hover cursor line on the canvas |
+| `data-view-timeline-group-layer` / `-group-slot` / `-group-header` / `-group-header-label` | Group band layer and its parts |
+| `data-view-timeline-footer` | Sticky footer |
+
+## Accessibility
+
+- The Timeline pane is a focusable, labelled `role="region"` (`aria-label`,
+  default "Timeline") that keyboard users can Tab to and scroll with the arrow
+  keys.
+- The card canvas is a `role="list"` with each card as a `listitem`.
+  Decorative gridlines, markers, and the axis are `aria-hidden`.
+- Cards receive row clicks via the root's `onRowClick`. The background supports
+  mouse drag-to-pan with a momentum glide, and scrolling past the domain edge
+  won't trigger browser back-swipe.

--- a/apps/www/src/content/docs/components/dialog/index.mdx
+++ b/apps/www/src/content/docs/components/dialog/index.mdx
@@ -30,6 +30,38 @@ import { Dialog } from '@raystack/apsara'
 </Dialog>
 ```
 
+## Usage
+
+### Controlled Dialog
+
+Pass `open` with `onOpenChange` to own the state — needed when the dialog must close on something other than a click, such as a save completing.
+
+<Demo data={controlledDemo} />
+
+### Custom width and overlay
+
+Example with custom width and overlay styling.
+
+<Demo data={customDemo} />
+
+### With header and body
+
+`Dialog.Header` carries the title and the close control; `Dialog.Body` holds the content. Leave the footer out when the dialog only presents information and closing is the only action.
+
+<Demo data={onlyHeaderDemo} />
+
+### With body and footer
+
+Skip the header when the body opens with its own heading. `Dialog.Footer` pins the actions to the bottom edge, separated from content that scrolls.
+
+<Demo data={onlyFooterDemo} />
+
+### Nested dialogs
+
+You can nest dialogs within one another. When a nested dialog opens, the parent dialog automatically scales down and becomes slightly transparent. The nested dialog's backdrop won't be rendered, allowing you to see the parent dialog behind it.
+
+<Demo data={nestedDemo} />
+
 ## API Reference
 
 ### Root
@@ -101,38 +133,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `dialog-description` | The `Dialog.Description` element |
 | `dialog-footer` | The `Dialog.Footer` row |
 | `dialog-close` | The built-in close button (when `showCloseButton`) |
-
-## Examples
-
-### Controlled Dialog
-
-Example of a controlled dialog with custom state management.
-
-<Demo data={controlledDemo} />
-
-### Custom Width and Overlay
-
-Example with custom width and overlay styling.
-
-<Demo data={customDemo} />
-
-### With Header and Body
-
-Example with header and body.
-
-<Demo data={onlyHeaderDemo} />
-
-### With Body and Footer
-
-Example with header and body.
-
-<Demo data={onlyFooterDemo} />
-
-### Nested Dialogs
-
-You can nest dialogs within one another. When a nested dialog opens, the parent dialog automatically scales down and becomes slightly transparent. The nested dialog's backdrop won't be rendered, allowing you to see the parent dialog behind it.
-
-<Demo data={nestedDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/drawer/index.mdx
+++ b/apps/www/src/content/docs/components/drawer/index.mdx
@@ -27,6 +27,20 @@ import { Drawer } from "@raystack/apsara";
 </Drawer>
 ```
 
+## Usage
+
+### Basic
+
+A drawer slides in from the edge named by `side` and traps focus while open.
+
+<Demo data={basicDemo} />
+
+### Positioning
+
+The Drawer can slide in from different sides of the screen. Swipe-to-dismiss is automatically configured based on the `side` prop.
+
+<Demo data={positionDemo} />
+
 ## API Reference
 
 ### Root
@@ -79,18 +93,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `drawer-body` | The `Drawer.Body` container |
 | `drawer-footer` | The `Drawer.Footer` container |
 
-## Examples
-
-### Basic
-
-<Demo data={basicDemo} />
-
-### Positioning
-
-The Drawer can slide in from different sides of the screen. Swipe-to-dismiss is automatically configured based on the `side` prop.
-
-<Demo data={positionDemo} />
-
 ## Accessibility
 
 - Uses `role="dialog"` with `aria-modal="true"`.
@@ -102,4 +104,3 @@ The Drawer can slide in from different sides of the screen. Swipe-to-dismiss is 
   prop for localisation or context-specific copy (e.g. `"Close settings"`).
 - Respects motion preferences: drawer slide motion is enabled only when
   `prefers-reduced-motion: no-preference`.
-

--- a/apps/www/src/content/docs/components/empty-state/index.mdx
+++ b/apps/www/src/content/docs/components/empty-state/index.mdx
@@ -23,6 +23,14 @@ import { Bell } from 'lucide-react'
 <EmptyState icon={<Bell size={16} strokeWidth={1.5} />} heading="No notifications" />
 ```
 
+## Usage
+
+### Variants
+
+`empty1` (the default) centers everything and stacks the actions vertically — suited to panels, tables, and lists. `empty2` left-aligns the content, uses a larger icon, and places both actions in a row — suited to full-page states.
+
+<Demo data={variantsDemo} />
+
 ## API Reference
 
 Renders a placeholder for empty content areas.
@@ -42,14 +50,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `empty-state-heading` | The heading text (when `heading` is set) |
 | `empty-state-subheading` | The subheading text (when `subHeading` is set) |
 | `empty-state-actions` | Wrapper around the action buttons (`empty2` variant only) |
-
-## Examples
-
-### Variants
-
-`empty1` (the default) centers everything and stacks the actions vertically — suited to panels, tables, and lists. `empty2` left-aligns the content, uses a larger icon, and places both actions in a row — suited to full-page states.
-
-<Demo data={variantsDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/field/index.mdx
+++ b/apps/www/src/content/docs/components/field/index.mdx
@@ -54,6 +54,68 @@ import { Field } from "@raystack/apsara";
 </Field>
 ```
 
+## Usage
+
+### With Input
+
+Use Field to add label, description, and error to an Input.
+
+<Demo data={withInputDemo} />
+
+### With TextArea
+
+Field wraps a TextArea the same way it wraps an Input — the label, description, and error all wire up through the same context.
+
+<Demo data={withTextAreaDemo} />
+
+### With Select
+
+Base UI-based components like Select auto-connect with Field for accessibility.
+
+<Demo data={withSelectDemo} />
+
+### Error state
+
+Pass an error string to show the error message and set the field to invalid state. The description is hidden while an error is shown.
+
+<Demo data={errorDemo} />
+
+### Constraint validation errors
+
+Use `Field.Control` with native attributes and multiple `Field.Error` elements to show targeted messages for each validation constraint.
+
+<Demo data={constraintErrorsDemo} />
+
+### Custom validation
+
+Use the `validate` prop to run custom logic. Return an error string to fail, or `null` to pass. The error renders via `Field.Error match="customError"`.
+
+<Demo data={customValidateDemo} />
+
+### Description
+
+Displays additional context below the control.
+
+<Demo data={descriptionDemo} />
+
+### Required Field
+
+Shows a required indicator next to the label.
+
+<Demo data={requiredDemo} />
+
+### Optional Field
+
+Set `required={false}` to show an "(optional)" indicator next to the label.
+
+<Demo data={optionalDemo} />
+
+### Sub-component API
+
+Use sub-components for built-in constraint validation with custom error matching.
+
+<Demo data={subComponentDemo} />
+
 ## API Reference
 
 ### Root
@@ -112,68 +174,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `field-helper` | Wrapper around the description and error (simple API, when either is set) |
 | `field-description` | The description text (when set) |
 | `field-error` | The error message (when the field is invalid) |
-
-## Examples
-
-### With Input
-
-Use Field to add label, description, and error to an Input.
-
-<Demo data={withInputDemo} />
-
-### With TextArea
-
-Field works with TextArea the same way.
-
-<Demo data={withTextAreaDemo} />
-
-### With Select
-
-Base UI-based components like Select auto-connect with Field for accessibility.
-
-<Demo data={withSelectDemo} />
-
-### Error State
-
-Pass an error string to show the error message and set the field to invalid state. The description is hidden while an error is shown.
-
-<Demo data={errorDemo} />
-
-### Constraint Validation Errors
-
-Use `Field.Control` with native attributes and multiple `Field.Error` elements to show targeted messages for each validation constraint.
-
-<Demo data={constraintErrorsDemo} />
-
-### Custom Validation
-
-Use the `validate` prop to run custom logic. Return an error string to fail, or `null` to pass. The error renders via `Field.Error match="customError"`.
-
-<Demo data={customValidateDemo} />
-
-### Description
-
-Displays additional context below the control.
-
-<Demo data={descriptionDemo} />
-
-### Required Field
-
-Shows a required indicator next to the label.
-
-<Demo data={requiredDemo} />
-
-### Optional Field
-
-Set `required={false}` to show an "(optional)" indicator next to the label.
-
-<Demo data={optionalDemo} />
-
-### Sub-component API
-
-Use sub-components for built-in constraint validation with custom error matching.
-
-<Demo data={subComponentDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/fieldset/index.mdx
+++ b/apps/www/src/content/docs/components/fieldset/index.mdx
@@ -47,6 +47,32 @@ import { Fieldset, Field, Input } from "@raystack/apsara";
 </Fieldset>
 ```
 
+## Usage
+
+### Basic Fieldset
+
+A fieldset grouping related fields with a legend.
+
+<Demo data={basicDemo} />
+
+### Sub-component API
+
+Using `Fieldset.Legend` for custom legend styling.
+
+<Demo data={subComponentDemo} />
+
+### Disabled Fieldset
+
+All fields within a disabled fieldset are disabled.
+
+<Demo data={disabledDemo} />
+
+### Nested fieldsets
+
+Fieldsets can be nested to create logical groupings.
+
+<Demo data={nestedDemo} />
+
 ## API Reference
 
 ### Root
@@ -69,32 +95,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 |------|---------|
 | `fieldset` | The root `<fieldset>` element |
 | `fieldset-legend` | The legend (when a legend is set) |
-
-## Examples
-
-### Basic Fieldset
-
-A fieldset grouping related fields with a legend.
-
-<Demo data={basicDemo} />
-
-### Sub-component API
-
-Using `Fieldset.Legend` for custom legend styling.
-
-<Demo data={subComponentDemo} />
-
-### Disabled Fieldset
-
-All fields within a disabled fieldset are disabled.
-
-<Demo data={disabledDemo} />
-
-### Nested Fieldsets
-
-Fieldsets can be nested to create logical groupings.
-
-<Demo data={nestedDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/filter-chip/index.mdx
+++ b/apps/www/src/content/docs/components/filter-chip/index.mdx
@@ -18,6 +18,48 @@ import { FilterChip } from "@raystack/apsara";
 <FilterChip />
 ```
 
+## Usage
+
+### Input types
+
+FilterChip supports five input types — `select`, `multiselect`, `date`, `string`, and `number` — to handle various filtering needs. `multiselect` takes a `string[]` value and summarizes two or more selections as "N selected".
+
+<Demo data={inputDemo} />
+
+### Select with autocomplete
+
+Use `selectProps` to enable autocomplete search on select and multiselect filter types. This renders a search input inside the dropdown for filtering options.
+
+<Demo data={autocompleteDemo} />
+
+### Date with calendarProps
+
+Use `calendarProps` to forward DatePicker options — `dateFormat`, `timeZone`, `slotProps.calendar`, etc. — to the chip's date control. `value`, `onSelect`, and `defaultValue` are owned by `FilterChip`, and `children` is excluded so the chip's input trigger isn't replaced.
+
+<Demo data={calendarPropsDemo} />
+
+### With leading icon
+
+FilterChip can display an icon before the label to provide visual context.
+
+<Demo data={iconDemo} />
+
+### With remove action
+
+FilterChip can include a remove action to allow users to dismiss the filter.
+
+<Demo data={actionDemo} />
+
+### Custom operations
+
+FilterChip supports custom filter operations through the `operations` prop. When specified, these operations override the default operations that are automatically selected based on the `columnType`.
+
+- When multiple operations are provided, they are rendered as a select dropdown
+- When a single operation is provided, it is displayed as static text
+- If no operations are specified, default operations are used based on the column type
+
+<Demo data={operationsDemo} />
+
 ## API Reference
 
 Renders an interactive chip for filtering content.
@@ -39,48 +81,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `filter-chip-value` | The value control (select trigger, date field, or input wrapper) |
 | `filter-chip-remove` | The remove button (when `onRemove` is set) |
 | `filter-chip-remove-icon` | The icon inside the remove button |
-
-## Examples
-
-### Input Types
-
-FilterChip supports five input types — `select`, `multiselect`, `date`, `string`, and `number` — to handle various filtering needs. `multiselect` takes a `string[]` value and summarizes two or more selections as "N selected".
-
-<Demo data={inputDemo} />
-
-### Select with Autocomplete
-
-Use `selectProps` to enable autocomplete search on select and multiselect filter types. This renders a search input inside the dropdown for filtering options.
-
-<Demo data={autocompleteDemo} />
-
-### Date with calendarProps
-
-Use `calendarProps` to forward DatePicker options — `dateFormat`, `timeZone`, `slotProps.calendar`, etc. — to the chip's date control. `value`, `onSelect`, and `defaultValue` are owned by `FilterChip`, and `children` is excluded so the chip's input trigger isn't replaced.
-
-<Demo data={calendarPropsDemo} />
-
-### With Leading Icon
-
-FilterChip can display an icon before the label to provide visual context.
-
-<Demo data={iconDemo} />
-
-### With Remove Action
-
-FilterChip can include a remove action to allow users to dismiss the filter.
-
-<Demo data={actionDemo} />
-
-### Custom Operations
-
-FilterChip supports custom filter operations through the `operations` prop. When specified, these operations override the default operations that are automatically selected based on the `columnType`.
-
-- When multiple operations are provided, they are rendered as a select dropdown
-- When a single operation is provided, it is displayed as static text
-- If no operations are specified, default operations are used based on the column type
-
-<Demo data={operationsDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/flex/index.mdx
+++ b/apps/www/src/content/docs/components/flex/index.mdx
@@ -22,6 +22,14 @@ import { Flex } from "@raystack/apsara";
 <Flex />
 ```
 
+## Usage
+
+### Nesting
+
+Nest Flex containers to compose a layout: here an outer row — the default direction — holds two columns, each spaced with `gap`.
+
+<Demo data={basicDemo} />
+
 ## API Reference
 
 Renders a flex container for layout.
@@ -35,14 +43,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | Slot | Element |
 |------|---------|
 | `flex` | The flex container (or the element supplied via `render`) |
-
-## Examples
-
-### Basic Usage
-
-Nest Flex containers to compose layouts: here an outer row (the default direction) holds two columns, each spaced with `gap`.
-
-<Demo data={basicDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/floating-actions/index.mdx
+++ b/apps/www/src/content/docs/components/floating-actions/index.mdx
@@ -24,45 +24,13 @@ import { FloatingActions, Chip, Button } from "@raystack/apsara";
 </FloatingActions>
 ```
 
-## API Reference
+## Usage
 
-Built on top of Base UI's [Toolbar](https://base-ui.com/react/components/toolbar) primitive, so keyboard navigation, roving focus, and the `role="toolbar"` semantics come from the primitive.
-
-### Root
-
-The container. Pins itself to the viewport by default (`variant="floating"`) and forwards all `<div>` attributes to the underlying Toolbar primitive.
-
-<auto-type-table path="./props.ts" name="FloatingActionsProps" />
-
-### Group
-
-Cluster related items so that the toolbar treats them as a single navigation unit. Useful when you want a destructive cluster (e.g. "Delete") to read as one section, separated from the rest of the bar by a `Separator`.
-
-<auto-type-table path="./props.ts" name="FloatingActionsGroupProps" />
-
-### Separator
-
-A vertical divider sized to the bar's content. Built on top of [`Separator`](/docs/components/separator).
-
-<auto-type-table path="./props.ts" name="FloatingActionsSeparatorProps" />
-
-### Slots
-
-Every rendered part carries a stable `data-slot` attribute for [styling and testing](/docs/styling#with-data-slot):
-
-| Slot | Element |
-|------|---------|
-| `floating-actions` | The root element |
-| `floating-actions-group` | `FloatingActions.Group` wrapper |
-| `floating-actions-separator` | `FloatingActions.Separator` |
-
-## Variants
+### Variant
 
 `floating` (default) renders with `position: fixed` anchored to the viewport via `side` and `align` — use it when the bar should follow the user as the page scrolls (bulk-selection toolbars, contextual action trays). `inline` opts out of viewport positioning so the bar flows with surrounding content.
 
 <Demo data={variantsDemo} />
-
-## Examples
 
 ### Bulk actions
 
@@ -102,7 +70,39 @@ The floating variant stays pinned to the viewport (or the nearest containing blo
 
 ### Use with DataView
 
-For the row-selection pattern — rendering this bar over a `DataView` and wiring it to selected rows — see [DataView → Row selection](/docs/components/dataview#row-selection).
+For the row-selection pattern — rendering this bar over a `DataView` and wiring it to selected rows — see [DataView.List → Row selection](/docs/components/dataview/list#row-selection).
+
+## API Reference
+
+Built on top of Base UI's [Toolbar](https://base-ui.com/react/components/toolbar) primitive, so keyboard navigation, roving focus, and the `role="toolbar"` semantics come from the primitive.
+
+### Root
+
+The container. Pins itself to the viewport by default (`variant="floating"`) and forwards all `<div>` attributes to the underlying Toolbar primitive.
+
+<auto-type-table path="./props.ts" name="FloatingActionsProps" />
+
+### Group
+
+Cluster related items so that the toolbar treats them as a single navigation unit. Useful when you want a destructive cluster (e.g. "Delete") to read as one section, separated from the rest of the bar by a `Separator`.
+
+<auto-type-table path="./props.ts" name="FloatingActionsGroupProps" />
+
+### Separator
+
+A vertical divider sized to the bar's content. Built on top of [`Separator`](/docs/components/separator).
+
+<auto-type-table path="./props.ts" name="FloatingActionsSeparatorProps" />
+
+### Slots
+
+Every rendered part carries a stable `data-slot` attribute for [styling and testing](/docs/styling#with-data-slot):
+
+| Slot | Element |
+|------|---------|
+| `floating-actions` | The root element |
+| `floating-actions-group` | `FloatingActions.Group` wrapper |
+| `floating-actions-separator` | `FloatingActions.Separator` |
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/form/index.mdx
+++ b/apps/www/src/content/docs/components/form/index.mdx
@@ -34,29 +34,53 @@ import { Form, Field, Input, Button } from "@raystack/apsara";
 </Form>
 ```
 
-## API Reference
+## Usage
 
-<auto-type-table path="./props.ts" name="FormProps" />
+### Basic form
 
-### Slots
+`Form` wires submit handling and validation to the fields inside it. Everything below builds on this shape.
 
-Every rendered part carries a stable `data-slot` attribute for [styling and testing](/docs/styling#with-data-slot):
+<Demo data={basicDemo} />
 
-| Slot | Element |
-|------|---------|
-| `form` | The root `<form>` element |
+### With fields
 
-## Error Handling
+Form with multiple fields using the Field component.
 
-Form supports two approaches to displaying errors, depending on how you build your form.
+<Demo data={withFieldsDemo} />
 
-### Props API (Simple)
+### Wrap interactive controls in Field
+
+Components like **Switch** and **Checkbox** internally register with the Form validation system. They **must** be placed inside a `<Field>` when used within a `<Form>`, even if you don't need a label or error message. Without a Field wrapper, they use a shared default context that interferes with form submission.
+
+```tsx
+{/* Correct */}
+<Field label="Notifications">
+  <Switch checked={value} onCheckedChange={onChange} />
+</Field>
+
+{/* Incorrect - breaks Form validation */}
+<Switch checked={value} onCheckedChange={onChange} />
+```
+
+### Validation modes
+
+Control when validation occurs: `onSubmit` (default), `onBlur`, or `onChange`.
+
+<Demo data={validationModesDemo} />
+
+### Choosing a validation approach
+
+Form provides built-in constraint validation using native HTML attributes (`required`, `type`, `pattern`, etc.) with `Field.Control` and `Field.Error match="..."`. This is the simplest approach when you don't need a form library.
+
+When using React Hook Form or similar, use the **props API** instead: pass `error={errors.field?.message}` to Field and let the library handle validation. Both approaches work with `<Form>`.
+
+### Errors with the props API
 
 Pass error strings directly to the Field `error` prop. This works well with custom validation logic or external form libraries like React Hook Form.
 
 <Demo data={propsApiErrorDemo} />
 
-### Sub-component API (Constraint Validation)
+### Errors with the sub-component API
 
 Use `Field.Control` with native HTML validation attributes and `Field.Error` with `match` to show specific messages for each constraint. The Form handles validation automatically on submit.
 
@@ -76,37 +100,17 @@ Available `match` values correspond to the browser [ValidityState](https://devel
 
 <Demo data={constraintValidationDemo} />
 
-### Custom Validation
+### Custom validation
 
 Use the `validate` prop on Field to run custom logic. Return an error string to fail, or `null` to pass. The error renders via `Field.Error match="customError"`.
 
 <Demo data={customValidationDemo} />
 
-### Server-Side Errors
+### Server-side errors
 
 Pass server validation errors to the Form `errors` prop. Keys must match the `name` prop on each Field. Errors clear automatically when the user modifies the corresponding field.
 
 <Demo data={serverErrorsDemo} />
-
-## Examples
-
-### Basic Form
-
-A simple form with submit handling.
-
-<Demo data={basicDemo} />
-
-### With Fields
-
-Form with multiple fields using the Field component.
-
-<Demo data={withFieldsDemo} />
-
-### Validation Modes
-
-Control when validation occurs: `onSubmit` (default), `onBlur`, or `onChange`.
-
-<Demo data={validationModesDemo} />
 
 ### React Hook Form
 
@@ -114,27 +118,17 @@ Use `register()` for text inputs and `Controller` for custom controls. Pass `err
 
 <Demo data={rhfDemo} />
 
-## Important Notes
+## API Reference
 
-### Wrap interactive controls in Field
+<auto-type-table path="./props.ts" name="FormProps" />
 
-Components like **Switch** and **Checkbox** internally register with the Form validation system. They **must** be placed inside a `<Field>` when used within a `<Form>`, even if you don't need a label or error message. Without a Field wrapper, they use a shared default context that interferes with form submission.
+### Slots
 
-```tsx
-{/* Correct */}
-<Field label="Notifications">
-  <Switch checked={value} onCheckedChange={onChange} />
-</Field>
+Every rendered part carries a stable `data-slot` attribute for [styling and testing](/docs/styling#with-data-slot):
 
-{/* Incorrect - breaks Form validation */}
-<Switch checked={value} onCheckedChange={onChange} />
-```
-
-### Constraint validation vs. external validation
-
-Form provides built-in constraint validation using native HTML attributes (`required`, `type`, `pattern`, etc.) with `Field.Control` and `Field.Error match="..."`. This is the simplest approach when you don't need a form library.
-
-When using React Hook Form or similar, use the **props API** instead: pass `error={errors.field?.message}` to Field and let the library handle validation. Both approaches work with `<Form>`.
+| Slot | Element |
+|------|---------|
+| `form` | The root `<form>` element |
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/grid/index.mdx
+++ b/apps/www/src/content/docs/components/grid/index.mdx
@@ -25,6 +25,14 @@ import { Grid } from "@raystack/apsara";
 </Grid>
 ```
 
+## Usage
+
+### Basic usage
+
+A 2×2 grid defined with numeric `rows` and `columns`. Plain children and `Grid.Item` wrappers can be mixed freely — both flow into cells in order.
+
+<Demo data={basicDemo} />
+
 ## API Reference
 
 ### Root
@@ -47,14 +55,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 |------|---------|
 | `grid` | The grid container (or the element supplied via `render`) |
 | `grid-item` | Each `Grid.Item` element |
-
-## Examples
-
-### Basic Usage
-
-A 2×2 grid defined with numeric `rows` and `columns`. Plain children and `Grid.Item` wrappers can be mixed freely — both flow into cells in order.
-
-<Demo data={basicDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/headline/index.mdx
+++ b/apps/www/src/content/docs/components/headline/index.mdx
@@ -22,6 +22,26 @@ import { Headline } from '@raystack/apsara'
 <Headline />
 ```
 
+## Usage
+
+### Weight
+
+Two weights. `medium` is the default; use `regular` where a headline sits close to body text and shouldn't shout.
+
+<Demo data={weightDemo} />
+
+### Alignment
+
+`align` sets the text alignment inside the heading's box. Default is `left`.
+
+<Demo data={alignDemo} />
+
+### Truncation
+
+Set `truncate` to clip a headline to a single line with an ellipsis when it overflows its container.
+
+<Demo data={truncateDemo} />
+
 ## API Reference
 
 Renders a heading element with configurable size and weight. Use the `render` prop to change the heading level or provide a custom render function.
@@ -35,26 +55,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | Slot | Element |
 |------|---------|
 | `headline` | The heading element (`<h2>` by default, or the element supplied via `render`) |
-
-## Examples
-
-### Alignment
-
-The `align` prop sets the text alignment within the heading's box. Default is `left`.
-
-<Demo data={alignDemo} />
-
-### Weight
-
-Headlines come in two weights. Default is `medium`; use `regular` for a lighter look.
-
-<Demo data={weightDemo} />
-
-### Truncation
-
-Set `truncate` to clip a headline to a single line with an ellipsis when it overflows its container.
-
-<Demo data={truncateDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/icon-button/index.mdx
+++ b/apps/www/src/content/docs/components/icon-button/index.mdx
@@ -18,6 +18,20 @@ import { IconButton } from "@raystack/apsara";
 <IconButton />
 ```
 
+## Usage
+
+### Size
+
+Four steps, 1 through 4. Match the step to the control the button sits beside so their heights agree.
+
+<Demo data={sizeDemo} />
+
+### State
+
+Hover and focus are handled for you. `disabled` is the only state you set, and it removes the button from the tab order.
+
+<Demo data={stateDemo} />
+
 ## API Reference
 
 Renders a button designed for icon-only content.
@@ -33,21 +47,7 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `icon-button` | The root `<button>` element |
 | `icon-button-icon` | Wrapper around the icon content |
 
-## Examples
-
-### Size
-
-The IconButton component offers different size options. You can customize the size using the `size` prop. The available size options are:
-
-<Demo data={sizeDemo} />
-
-### State
-
-The IconButton component has different states: default, hover, and disabled.
-
-<Demo data={stateDemo} />
-
-## Styling
+### Styling
 
 The IconButton uses CSS variables for consistent styling across themes:
 

--- a/apps/www/src/content/docs/components/image/index.mdx
+++ b/apps/www/src/content/docs/components/image/index.mdx
@@ -18,6 +18,26 @@ import { Image } from "@raystack/apsara";
 <Image />
 ```
 
+## Usage
+
+### Object fit
+
+Control how the image fills its container with different object-fit modes.
+
+<Demo data={fitDemo} />
+
+### Border radius
+
+Choose from different border radius styles to match your design.
+
+<Demo data={radiusDemo} />
+
+### Fallback
+
+Handle image loading failures gracefully with fallback images.
+
+<Demo data={fallbackDemo} />
+
 ## API Reference
 
 Renders a responsive image with fallback support.
@@ -31,26 +51,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | Slot | Element |
 |------|---------|
 | `image` | The `<img>` element |
-
-## Examples
-
-### Object Fit
-
-Control how the image fills its container with different object-fit modes.
-
-<Demo data={fitDemo} />
-
-### Border Radius
-
-Choose from different border radius styles to match your design.
-
-<Demo data={radiusDemo} />
-
-### Fallback
-
-Handle image loading failures gracefully with fallback images.
-
-<Demo data={fallbackDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/indicator/index.mdx
+++ b/apps/www/src/content/docs/components/indicator/index.mdx
@@ -18,6 +18,20 @@ import { Indicator } from "@raystack/apsara";
 <Indicator />
 ```
 
+## Usage
+
+### Variant
+
+Five variants that carry meaning: `accent`, `success`, `warning`, `danger`, and `neutral`. Pass `label` to show a count instead of a plain dot.
+
+<Demo data={variantDemo} />
+
+### Label
+
+When no label is provided, the Indicator will show as a dot
+
+<Demo data={labelDemo} />
+
 ## API Reference
 
 Renders a small status dot or label.
@@ -34,20 +48,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `indicator-badge` | The `role="status"` indicator itself |
 | `indicator-label` | The label text (when `label` is set) |
 | `indicator-dot` | The dot (when no `label` is set) |
-
-## Examples
-
-### Variant
-
-The Indicator component supports different variants to convey different states or meanings:
-
-<Demo data={variantDemo} />
-
-### Label
-
-When no label is provided, the Indicator will show as a dot
-
-<Demo data={labelDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/input/index.mdx
+++ b/apps/www/src/content/docs/components/input/index.mdx
@@ -40,6 +40,80 @@ import { Field, Input } from "@raystack/apsara";
 </Field>
 ```
 
+## Usage
+
+### Basic Input
+
+A single-line text input. `placeholder` hints at the expected value; it is not a label and does not replace one.
+
+<Demo data={basicDemo} />
+
+### Size
+
+Input comes in two sizes: small (24px) and large (32px).
+
+<Demo data={sizeDemo} />
+
+### With prefix and suffix
+
+Prefix and suffix sit inside the field for fixed units and protocols — a currency symbol, `https://`, `@`. They are decoration, not part of the value.
+
+<Demo data={prefixDemo} />
+
+### With icons
+
+A leading icon names the field at a glance; a trailing icon usually holds an action, like clear or reveal.
+
+<Demo data={iconDemo} />
+
+### With chips
+
+Input that can display and manage chips/tags.
+
+<Demo data={sizeChipDemo} />
+
+### Interactive chips
+
+Accepts an array of chips, each with a `label` and an optional `onRemove` callback. 
+
+`maxChipsVisible` caps how many are rendered before collapsing the rest into an overflow counter.
+
+```tsx
+chips?: Array<{ label: string; onRemove?: () => void }>;                                                                                       
+maxChipsVisible?: number;  // defaults to 2   
+```
+
+This is purely a presentation layer — it does not manage chip state. The wrapper component owns the array and decides when items are added or removed.
+
+The example below 
+  appends a chip on `Enter`, removes one when its dismiss button is clicked.
+
+<Demo data={interactiveChipDemo} />
+
+### With Field
+
+Use Field to add label, description, and error handling.
+
+<Demo data={withFieldDemo} />
+
+### Controlled
+
+Use `onValueChange` for a callback that receives only the new string value, or `onChange` for the full React change event. Both fire on every keystroke — pick whichever fits your needs.
+
+<Demo data={onValueChangeDemo} />
+
+### Disabled
+
+`disabled` stops interaction and removes the field from the tab order. Use `readOnly` instead when the value still needs to be selectable and copyable.
+
+<Demo data={disabledDemo} />
+
+### Disabled with chips
+
+When disabled, chips become non-interactive and their dismiss buttons are hidden.
+
+<Demo data={disabledChipsDemo} />
+
 ## API Reference
 
 Renders a text input control. For label, description, and error support, use with [Field](/docs/components/field).
@@ -61,80 +135,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `input` | The `<input>` element itself |
 | `input-suffix` | The suffix text (when `suffix`) |
 | `input-trailing-icon` | Wrapper around the trailing icon (when `trailingIcon`) |
-
-## Examples
-
-### Basic Input
-
-A basic input with a placeholder.
-
-<Demo data={basicDemo} />
-
-### With Field
-
-Use Field to add label, description, and error handling.
-
-<Demo data={withFieldDemo} />
-
-### Controlled Value
-
-Use `onValueChange` for a callback that receives only the new string value, or `onChange` for the full React change event. Both fire on every keystroke — pick whichever fits your needs.
-
-<Demo data={onValueChangeDemo} />
-
-### With Prefix/Suffix
-
-Input with prefix and suffix text.
-
-<Demo data={prefixDemo} />
-
-### With Icons
-
-Input with leading and trailing icons.
-
-<Demo data={iconDemo} />
-
-### Interactive Chips
-
-Accepts an array of chips, each with a `label` and an optional `onRemove` callback. 
-
-`maxChipsVisible` caps how many are rendered before collapsing the rest into an overflow counter.
-
-```tsx
-chips?: Array<{ label: string; onRemove?: () => void }>;                                                                                       
-maxChipsVisible?: number;  // defaults to 2   
-```
-
-This is purely a presentation layer — it does not manage chip state. The wrapper component owns the array and decides when items are added or removed.
-
-The example below 
-  appends a chip on `Enter`, removes one when its dismiss button is clicked.
-
-<Demo data={interactiveChipDemo} />
-
-### Disabled State
-
-Input in disabled state.
-
-<Demo data={disabledDemo} />
-
-### Disabled with Chips
-
-When disabled, chips become non-interactive and their dismiss buttons are hidden.
-
-<Demo data={disabledChipsDemo} />
-
-### Size Variants
-
-Input comes in two sizes: small (24px) and large (32px).
-
-<Demo data={sizeDemo} />
-
-### With Chips
-
-Input that can display and manage chips/tags.
-
-<Demo data={sizeChipDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/kbd/index.mdx
+++ b/apps/www/src/content/docs/components/kbd/index.mdx
@@ -33,32 +33,7 @@ import { Kbd } from "@raystack/apsara";
 </Kbd.Group>
 ```
 
-## API Reference
-
-Both parts render a `<kbd>` element and forward any native attributes (`id`, `title`, `aria-label`, …) to it.
-
-### Root
-
-A single keyboard key. Renders a `<kbd>` element.
-
-<auto-type-table path="./props.ts" name="KbdProps" />
-
-### Group
-
-Groups multiple keyboard keys for key combinations.
-
-<auto-type-table path="./props.ts" name="KbdGroupProps" />
-
-### Slots
-
-Every rendered part carries a stable `data-slot` attribute for [styling and testing](/docs/styling#with-data-slot):
-
-| Slot | Element |
-|------|---------|
-| `kbd` | Each individual key |
-| `kbd-group` | The `Kbd.Group` wrapper |
-
-## Examples
+## Usage
 
 ### Single keys
 
@@ -101,6 +76,31 @@ Surface a focus shortcut in a search field. Use a single `ghost` key here — th
 A common use is surfacing a shortcut alongside the action it triggers.
 
 <Demo data={withTooltipDemo} />
+
+## API Reference
+
+Both parts render a `<kbd>` element and forward any native attributes (`id`, `title`, `aria-label`, …) to it.
+
+### Root
+
+A single keyboard key. Renders a `<kbd>` element.
+
+<auto-type-table path="./props.ts" name="KbdProps" />
+
+### Group
+
+Groups multiple keyboard keys for key combinations.
+
+<auto-type-table path="./props.ts" name="KbdGroupProps" />
+
+### Slots
+
+Every rendered part carries a stable `data-slot` attribute for [styling and testing](/docs/styling#with-data-slot):
+
+| Slot | Element |
+|------|---------|
+| `kbd` | Each individual key |
+| `kbd-group` | The `Kbd.Group` wrapper |
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/label/index.mdx
+++ b/apps/www/src/content/docs/components/label/index.mdx
@@ -18,6 +18,21 @@ import { Label } from '@raystack/apsara'
 <Label htmlFor="email">Email</Label>
 ```
 
+## Usage
+
+### Inline with a control
+
+Use `Flex` to place a label next to a Radio or Checkbox.
+
+<Demo data={inlineDemo} />
+
+### Optional indicator
+
+Pass `required={false}` to display an `(optional)` indicator next to the label.
+Override the text via `optionalText`.
+
+<Demo data={optionalDemo} />
+
 ## API Reference
 
 Renders a text label for form elements. Outside of a `Field`, use `Label` to
@@ -37,21 +52,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 |------|---------|
 | `label` | The `<label>` element |
 | `label-indicator` | The optional/required indicator text (when `required={false}`, or `required` with `requiredText`) |
-
-## Examples
-
-### Inline with a control
-
-Use `Flex` to place a label next to a Radio or Checkbox.
-
-<Demo data={inlineDemo} />
-
-### Optional indicator
-
-Pass `required={false}` to display an `(optional)` indicator next to the label.
-Override the text via `optionalText`.
-
-<Demo data={optionalDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/link/index.mdx
+++ b/apps/www/src/content/docs/components/link/index.mdx
@@ -24,31 +24,17 @@ import { Link } from "@raystack/apsara";
 <Link />
 ```
 
-## API Reference
-
-The Link is built over [Text](/docs/components/text#text-props) and accepts all it's props
-
-<auto-type-table path="./props.ts" name="LinkProps" />
-
-### Slots
-
-Every rendered part carries a stable `data-slot` attribute for [styling and testing](/docs/styling#with-data-slot):
-
-| Slot | Element |
-|------|---------|
-| `link` | The anchor element (or the element supplied via `render`) |
-
-## Examples
+## Usage
 
 ### Variant
 
-Choose from different variants.
+Link inherits Text's variants, so a link takes the same semantic colours as the copy around it.
 
 <Demo data={variantDemo} />
 
 ### Size
 
-The Link component supports 10 different sizes.
+Link inherits Text's size scale, so a link matches the text it sits in without extra styling.
 
 <Demo data={sizeDemo} />
 
@@ -73,6 +59,20 @@ import { Link as RouterLink } from "react-router-dom";
 
 <Link render={<RouterLink to="/about" />}>About</Link>
 ```
+
+## API Reference
+
+The Link is built over [Text](/docs/components/text#api-reference) and accepts all it's props
+
+<auto-type-table path="./props.ts" name="LinkProps" />
+
+### Slots
+
+Every rendered part carries a stable `data-slot` attribute for [styling and testing](/docs/styling#with-data-slot):
+
+| Slot | Element |
+|------|---------|
+| `link` | The anchor element (or the element supplied via `render`) |
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/list/index.mdx
+++ b/apps/www/src/content/docs/components/list/index.mdx
@@ -24,6 +24,14 @@ import { List } from "@raystack/apsara";
 </List>
 ```
 
+## Usage
+
+### Basic usage
+
+A `Header` labels the group, then each `Item` pairs a `Label` with its `Value`. Give the labels a shared `min-width` so the values line up in a column.
+
+<Demo data={basicDemo} />
+
 ## API Reference
 
 ### Root
@@ -68,14 +76,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `list-item` | An individual list row (`<li>`) |
 | `list-label` | The `<span>` holding the key text of an item |
 | `list-value` | The `<span>` holding the value text of an item |
-
-## Examples
-
-### Basic Usage
-
-A `Header` labels the group, then each `Item` pairs a `Label` with its `Value`. Give the labels a shared `min-width` so the values line up in a column.
-
-<Demo data={basicDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/menu/index.mdx
+++ b/apps/www/src/content/docs/components/menu/index.mdx
@@ -32,6 +32,52 @@ import { Menu } from '@raystack/apsara'
 </Menu>
 ```
 
+## Usage
+
+### Basic usage
+
+A trigger and a list of items. The menu opens on click and closes on select, Escape, or an outside click.
+
+<Demo data={basicDemo} />
+
+### With icons
+
+You can add icons to the menu items. Supports both leading and trailing icons.
+
+<Demo data={iconsDemo} />
+
+### With groups and labels
+
+Organize related menu items into sections with descriptive headers.
+
+<Demo data={customDemo} />
+
+### Submenu
+
+Use `Menu.Submenu`, `Menu.SubmenuTrigger`, and `Menu.SubmenuContent` to create nested menus with multiple levels.
+
+<Demo data={submenuDemo} />
+
+### Autocomplete
+
+To enable autocomplete, pass the `autocomplete` prop to the Menu root element. Each menu instance will manage its own autocomplete behavior.
+
+By default (`autocompleteMode="auto"`), items are automatically filtered as the user types. The filter matches against the item's `value` prop or its `children` text content.
+
+For submenus, you can independently enable autocomplete by passing `autocomplete` to `Menu.Submenu`.
+
+For more advanced control, set `autocompleteMode="manual"` and implement your own custom filtering logic using the `onInputValueChange` callback.
+
+<Demo data={autocompleteDemo} />
+
+### Linear inspired Menu
+
+This is a Linear-inspired menu component that supports custom filtering and displays nested options. Users can search through all nested items using a single input field.
+
+To closely replicate Linear-style filtering, the filtering logic should include result ranking. Using a utility like [match-sorter](https://www.npmjs.com/package/match-sorter) can help achieve this by sorting filtered results based on relevance.
+
+<Demo data={linearDemo} />
+
 ## API Reference
 
 The Menu component is composed of several parts, each with their own props.
@@ -131,52 +177,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `menu-separator` | `Menu.Separator` |
 | `menu-empty-state` | `Menu.EmptyState` |
 | `menu-subtrigger` | `Menu.SubmenuTrigger` |
-
-## Examples
-
-### Basic Usage
-
-A simple menu with basic functionality.
-
-<Demo data={basicDemo} />
-
-### With Icons
-
-You can add icons to the menu items. Supports both leading and trailing icons.
-
-<Demo data={iconsDemo} />
-
-### With Groups and Labels
-
-Organize related menu items into sections with descriptive headers.
-
-<Demo data={customDemo} />
-
-### Submenu
-
-Use `Menu.Submenu`, `Menu.SubmenuTrigger`, and `Menu.SubmenuContent` to create nested menus with multiple levels.
-
-<Demo data={submenuDemo} />
-
-### Autocomplete
-
-To enable autocomplete, pass the `autocomplete` prop to the Menu root element. Each menu instance will manage its own autocomplete behavior.
-
-By default (`autocompleteMode="auto"`), items are automatically filtered as the user types. The filter matches against the item's `value` prop or its `children` text content.
-
-For submenus, you can independently enable autocomplete by passing `autocomplete` to `Menu.Submenu`.
-
-For more advanced control, set `autocompleteMode="manual"` and implement your own custom filtering logic using the `onInputValueChange` callback.
-
-<Demo data={autocompleteDemo} />
-
-### Linear inspired Menu
-
-This is a Linear-inspired menu component that supports custom filtering and displays nested options. Users can search through all nested items using a single input field.
-
-To closely replicate Linear-style filtering, the filtering logic should include result ranking. Using a utility like [match-sorter](https://www.npmjs.com/package/match-sorter) can help achieve this by sorting filtered results based on relevance.
-
-<Demo data={linearDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/menubar/index.mdx
+++ b/apps/www/src/content/docs/components/menubar/index.mdx
@@ -36,6 +36,20 @@ import { Menu, Menubar } from '@raystack/apsara'
 
 The `Menubar` component wraps multiple `Menu` instances. Menu triggers are automatically styled when inside a Menubar. If you pass a `render` prop to `Menu.Trigger`, the default menubar trigger styling is skipped, allowing full custom rendering.
 
+## Usage
+
+### Vertical
+
+Use the `orientation` prop to render a vertical menubar.
+
+<Demo data={verticalDemo} />
+
+### Autocomplete
+
+Use the `autocomplete` prop on `Menu` to enable search filtering within a menubar menu.
+
+<Demo data={autocompleteDemo} />
+
 ## API Reference
 
 ### Root
@@ -51,20 +65,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | Slot | Element |
 |------|---------|
 | `menubar` | The root element |
-
-## Examples
-
-### Vertical
-
-Use the `orientation` prop to render a vertical menubar.
-
-<Demo data={verticalDemo} />
-
-### Autocomplete
-
-Use the `autocomplete` prop on `Menu` to enable search filtering within a menubar menu.
-
-<Demo data={autocompleteDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/meter/index.mdx
+++ b/apps/www/src/content/docs/components/meter/index.mdx
@@ -26,6 +26,38 @@ import { Meter } from '@raystack/apsara'
 </Meter>
 ```
 
+## Usage
+
+### Variant
+
+`linear` draws a bar, `circular` a ring. Both read the same `value`, `min`, and `max`, so the variant is purely how it looks.
+
+<Demo data={variantDemo} />
+
+### Direct usage
+
+The simplest way to use the meter. When no children are provided, it renders the track automatically.
+
+<Demo data={directUsageDemo} />
+
+### Customization
+
+Customize the track for both variants. For linear, use `height` on the track. For circular, use `width`/`height` on the track to control the overall size and `--rs-meter-track-size` to control the stroke thickness.
+
+<Demo data={customizationDemo} />
+
+### With labels
+
+Compose with `Meter.Label` and `Meter.Value` for additional context.
+
+<Demo data={withLabelsDemo} />
+
+### Custom range
+
+Use `min` and `max` to define custom value ranges.
+
+<Demo data={customRangeDemo} />
+
 ## API Reference
 
 ### Root
@@ -64,38 +96,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `meter-track` | The track (an `<svg>` in the circular variant) |
 | `meter-track-circle` | The background circle (circular variant only) |
 | `meter-indicator` | The filled indicator (a `<circle>` in the circular variant) |
-
-## Examples
-
-### Variant
-
-The meter supports `linear` and `circular` variants.
-
-<Demo data={variantDemo} />
-
-### Direct Usage
-
-The simplest way to use the meter. When no children are provided, it renders the track automatically.
-
-<Demo data={directUsageDemo} />
-
-### Customization
-
-Customize the track for both variants. For linear, use `height` on the track. For circular, use `width`/`height` on the track to control the overall size and `--rs-meter-track-size` to control the stroke thickness.
-
-<Demo data={customizationDemo} />
-
-### With Labels
-
-Compose with `Meter.Label` and `Meter.Value` for additional context.
-
-<Demo data={withLabelsDemo} />
-
-### Custom Range
-
-Use `min` and `max` to define custom value ranges.
-
-<Demo data={customRangeDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/navbar/index.mdx
+++ b/apps/www/src/content/docs/components/navbar/index.mdx
@@ -30,6 +30,32 @@ import { Navbar } from "@raystack/apsara";
 </Navbar>
 ```
 
+## Usage
+
+### Sticky navigation
+
+A sticky navbar stays pinned while the page scrolls. Use it when navigation has to stay reachable on long pages.
+
+<Demo data={stickyDemo} />
+
+### Section layouts
+
+Start, Center, and End are independent — use any combination. The three-column grid keeps Center optically centred even when Start and End differ in width.
+
+<Demo data={sectionsDemo} />
+
+### Hide on scroll
+
+Set `hideOnScroll` to hide the navbar when the user scrolls down and show it when they scroll up. It works with both window scroll and scroll containers (e.g. ScrollArea). The navbar slides out of view with a transition. The slide animation is only visible when the navbar is sticky (or fixed); without it, the navbar simply scrolls away with the content.
+
+<Demo data={hideOnScrollDemo} />
+
+### Labelling sections
+
+Pass `aria-label` to the navbar or to any individual section. Do it when a page has more than one navigation landmark, so screen-reader users can tell them apart.
+
+<Demo data={accessibilityDemo} />
+
 ## API Reference
 
 ### Root
@@ -67,32 +93,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `navbar-start` | `Navbar.Start` section |
 | `navbar-center` | `Navbar.Center` section |
 | `navbar-end` | `Navbar.End` section |
-
-## Examples
-
-### Sticky Navigation
-
-The Navbar can be made sticky to remain visible at the top of the viewport when scrolling.
-
-<Demo data={stickyDemo} />
-
-### Section Layouts
-
-You can use any combination of Start, Center, and End. The navbar uses a 3-column grid so each section renders in its own space; the center remains absolutely centered.
-
-<Demo data={sectionsDemo} />
-
-### Hide on scroll
-
-Set `hideOnScroll` to hide the navbar when the user scrolls down and show it when they scroll up. It works with both window scroll and scroll containers (e.g. ScrollArea). The navbar slides out of view with a transition. The slide animation is only visible when the navbar is sticky (or fixed); without it, the navbar simply scrolls away with the content.
-
-<Demo data={hideOnScrollDemo} />
-
-### Accessibility
-
-The Navbar supports custom ARIA labels for better screen reader support. You can provide descriptive labels for the entire navbar or individual sections.
-
-<Demo data={accessibilityDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/number-field/index.mdx
+++ b/apps/www/src/content/docs/components/number-field/index.mdx
@@ -38,6 +38,46 @@ import { NumberField } from "@raystack/apsara";
 </NumberField>
 ```
 
+## Usage
+
+### Basic
+
+A standalone number field with default controls.
+
+<Demo data={basicDemo} />
+
+### Min / max
+
+`min` and `max` clamp the value. The stepper buttons disable at each end rather than letting the field go out of range.
+
+<Demo data={minMaxDemo} />
+
+### Step
+
+`step` sets how much the arrows and Arrow Up / Arrow Down move the value. Match it to the precision the field actually needs.
+
+<Demo data={stepDemo} />
+
+### Disabled
+
+`disabled` stops interaction and removes the field from the tab order, stepper buttons included.
+
+<Demo data={disabledDemo} />
+
+### Composed with ScrubArea
+
+Full control with scrub area for drag-to-adjust interaction.
+
+<Demo data={composedDemo} />
+
+### Formatted
+
+Number field with currency formatting, powered by `Intl.NumberFormat` internally.
+
+`format` sets what to format (currency, decimals); `locale` sets how it's written. Pin `locale` when the output should be stable across different users. 
+
+<Demo data={formatDemo} />
+
 ## API Reference
 
 ### Root
@@ -93,46 +133,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `number-field-scrub-area-label` | The label inside the scrub area |
 | `number-field-scrub-area-cursor` | The virtual cursor (while scrubbing) |
 | `number-field-scrub-area-cursor-icon` | The default cursor icon (while scrubbing) |
-
-## Examples
-
-### Basic
-
-A standalone number field with default controls.
-
-<Demo data={basicDemo} />
-
-### Min / Max
-
-Number field constrained to a range.
-
-<Demo data={minMaxDemo} />
-
-### Step
-
-Number field with a custom step amount.
-
-<Demo data={stepDemo} />
-
-### Disabled
-
-Number field in disabled state.
-
-<Demo data={disabledDemo} />
-
-### Composed with ScrubArea
-
-Full control with scrub area for drag-to-adjust interaction.
-
-<Demo data={composedDemo} />
-
-### Formatted
-
-Number field with currency formatting, powered by `Intl.NumberFormat` internally.
-
-`format` sets what to format (currency, decimals); `locale` sets how it's written. Pin `locale` when the output should be stable across different users. 
-
-<Demo data={formatDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/otp-field/index.mdx
+++ b/apps/www/src/content/docs/components/otp-field/index.mdx
@@ -38,37 +38,7 @@ import { OTPField } from "@raystack/apsara";
 </OTPField>
 ```
 
-## API Reference
-
-### Root
-
-Groups all parts of the field and manages their state.
-
-<auto-type-table path="./props.ts" name="OTPFieldProps" />
-
-### Input
-
-An individual character slot. Render one per slot (typically using `Array.from`).
-
-<auto-type-table path="./props.ts" name="OTPFieldInputProps" />
-
-### Separator
-
-A visual separator between slot groups, styled to fit between OTP slots.
-
-<auto-type-table path="./props.ts" name="OTPFieldSeparatorProps" />
-
-### Slots
-
-Every rendered part carries a stable `data-slot` attribute for [styling and testing](/docs/styling#with-data-slot):
-
-| Slot | Element |
-|------|---------|
-| `otp-field` | The root container |
-| `otp-field-input` | Each `OTPField.Input` slot |
-| `otp-field-separator` | The `OTPField.Separator` element |
-
-## Examples
+## Usage
 
 ### With separator
 
@@ -90,7 +60,7 @@ Use `validationType` to accept letters, digits, or both. Defaults to `"numeric"`
 
 ### Disabled
 
-Set `disabled` to prevent interaction.
+`disabled` stops interaction across every slot at once, not just the focused one.
 
 <Demo data={disabledDemo} />
 
@@ -123,6 +93,36 @@ Provide `normalizeValue` to restrict input to a custom set of characters. It com
 Compose with `Field` to get an associated label and description.
 
 <Demo data={withFieldDemo} />
+
+## API Reference
+
+### Root
+
+Groups all parts of the field and manages their state.
+
+<auto-type-table path="./props.ts" name="OTPFieldProps" />
+
+### Input
+
+An individual character slot. Render one per slot (typically using `Array.from`).
+
+<auto-type-table path="./props.ts" name="OTPFieldInputProps" />
+
+### Separator
+
+A visual separator between slot groups, styled to fit between OTP slots.
+
+<auto-type-table path="./props.ts" name="OTPFieldSeparatorProps" />
+
+### Slots
+
+Every rendered part carries a stable `data-slot` attribute for [styling and testing](/docs/styling#with-data-slot):
+
+| Slot | Element |
+|------|---------|
+| `otp-field` | The root container |
+| `otp-field-input` | Each `OTPField.Input` slot |
+| `otp-field-separator` | The `OTPField.Separator` element |
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/popover/index.mdx
+++ b/apps/www/src/content/docs/components/popover/index.mdx
@@ -21,6 +21,20 @@ import { Popover } from "@raystack/apsara";
 </Popover>
 ```
 
+## Usage
+
+### Positioning
+
+Control the position and alignment of your popover relative to its trigger.
+
+<Demo data={positionDemo} />
+
+### Alignment
+
+Customize how the popover aligns with its trigger.
+
+<Demo data={alignDemo} />
+
 ## API Reference
 
 ### Root
@@ -49,20 +63,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 |------|---------|
 | `popover-positioner` | Positioner that places the popup |
 | `popover-content` | The popover popup |
-
-## Examples
-
-### Positioning
-
-Control the position and alignment of your popover relative to its trigger.
-
-<Demo data={positionDemo} />
-
-### Alignment
-
-Customize how the popover aligns with its trigger.
-
-<Demo data={alignDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/preview-card/index.mdx
+++ b/apps/www/src/content/docs/components/preview-card/index.mdx
@@ -24,6 +24,26 @@ import { PreviewCard } from "@raystack/apsara";
 </PreviewCard>
 ```
 
+## Usage
+
+### With arrow
+
+Display an arrow pointing to the trigger element.
+
+<Demo data={arrowDemo} />
+
+### Content transitions
+
+When multiple triggers share one card via `createHandle`, wrap content in `Viewport` to animate transitions between them. Content slides in from the direction of the newly hovered trigger.
+
+<Demo data={contentTransitionsDemo} />
+
+### Positioning
+
+Control the position of the preview card relative to its trigger.
+
+<Demo data={positionDemo} />
+
 ## API Reference
 
 ### Root
@@ -60,26 +80,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `preview-card-content` | The preview card popup |
 | `preview-card-viewport` | The `PreviewCard.Viewport` wrapper |
 | `preview-card-arrow` | The arrow (when `showArrow`) |
-
-## Examples
-
-### With Arrow
-
-Display an arrow pointing to the trigger element.
-
-<Demo data={arrowDemo} />
-
-### Content Transitions
-
-When multiple triggers share one card via `createHandle`, wrap content in `Viewport` to animate transitions between them. Content slides in from the direction of the newly hovered trigger.
-
-<Demo data={contentTransitionsDemo} />
-
-### Positioning
-
-Control the position of the preview card relative to its trigger.
-
-<Demo data={positionDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/progress/index.mdx
+++ b/apps/www/src/content/docs/components/progress/index.mdx
@@ -27,6 +27,38 @@ import { Progress } from '@raystack/apsara'
 </Progress>
 ```
 
+## Usage
+
+### Variant
+
+`linear` draws a bar, `circular` a ring. Leave `value` unset for an indeterminate state when you cannot report real progress.
+
+<Demo data={variantDemo} />
+
+### Direct usage
+
+The simplest way to use the progress. When no children are provided, it renders the track automatically.
+
+<Demo data={directUsageDemo} />
+
+### Customization
+
+Customize the track for both variants. For linear, use `height` on the track. For circular, use `width`/`height` on the track to control the overall size and `--rs-progress-track-size` to control the stroke thickness.
+
+<Demo data={customizationDemo} />
+
+### Animated
+
+Use controlled `value` to animate the progress indicator.
+
+<Demo data={animatedDemo} />
+
+### With labels
+
+Compose with `Progress.Label` and `Progress.Value` for additional context.
+
+<Demo data={withLabelsDemo} />
+
 ## API Reference
 
 ### Root
@@ -65,38 +97,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `progress-track` | The track (an `<svg>` in the circular variant) |
 | `progress-track-circle` | The background circle (circular variant only) |
 | `progress-indicator` | The filled indicator (a `<circle>` in the circular variant) |
-
-## Examples
-
-### Variant
-
-The progress supports `linear` and `circular` variants.
-
-<Demo data={variantDemo} />
-
-### Direct Usage
-
-The simplest way to use the progress. When no children are provided, it renders the track automatically.
-
-<Demo data={directUsageDemo} />
-
-### Customization
-
-Customize the track for both variants. For linear, use `height` on the track. For circular, use `width`/`height` on the track to control the overall size and `--rs-progress-track-size` to control the stroke thickness.
-
-<Demo data={customizationDemo} />
-
-### Animated
-
-Use controlled `value` to animate the progress indicator.
-
-<Demo data={animatedDemo} />
-
-### With Labels
-
-Compose with `Progress.Label` and `Progress.Value` for additional context.
-
-<Demo data={withLabelsDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/radio/index.mdx
+++ b/apps/www/src/content/docs/components/radio/index.mdx
@@ -21,6 +21,38 @@ import { Radio } from "@raystack/apsara";
 </Radio.Group>
 ```
 
+## Usage
+
+### Size
+
+Two sizes. `large` is the default; `small` fits dense lists. Set `size` on `Radio.Root` and every item follows.
+
+<Demo data={sizeDemo} />
+
+### Orientation
+
+`vertical` (the default) stacks the options, which scans faster for more than three. `horizontal` suits short binary choices in a row.
+
+<Demo data={orientationDemo} />
+
+### With labels
+
+Radio buttons should always be accompanied by labels for accessibility and usability.
+
+<Demo data={labelDemo} />
+
+### State
+
+Radio buttons support different states to indicate interactivity and selection.
+
+<Demo data={stateDemo} />
+
+### Form example
+
+Radio buttons can be used in forms with proper validation and submission handling.
+
+<Demo data={formDemo} />
+
 ## API Reference
 
 ### Group
@@ -44,38 +76,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `radio-group` | The `Radio.Group` container |
 | `radio` | The radio button itself |
 | `radio-indicator` | The indicator inside the radio button |
-
-## Examples
-
-### State
-
-Radio buttons support different states to indicate interactivity and selection.
-
-<Demo data={stateDemo} />
-
-### Size Variants
-
-The Radio component comes in two sizes: large (default) and small. Set `size` on `Radio.Group` to apply it to every item, or set it on an individual `Radio` to override the group value.
-
-<Demo data={sizeDemo} />
-
-### Orientation
-
-The Radio.Group supports vertical (default) and horizontal orientation to control the layout direction of its items.
-
-<Demo data={orientationDemo} />
-
-### With Labels
-
-Radio buttons should always be accompanied by labels for accessibility and usability.
-
-<Demo data={labelDemo} />
-
-### Form Example
-
-Radio buttons can be used in forms with proper validation and submission handling.
-
-<Demo data={formDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/scroll-area/index.mdx
+++ b/apps/www/src/content/docs/components/scroll-area/index.mdx
@@ -16,6 +16,14 @@ import {
 
 <Demo data={playground} />
 
+## Overview
+
+Both scrollbars are always rendered and appear only when content overflows, so a
+container never jumps as content grows. The scrollbar widens from 4px to 6px on hover, a
+corner element is added automatically when both axes are visible, and scrolling chains to
+the parent page once you reach a boundary. Use the `type` prop to control when scrollbars
+appear.
+
 ## Anatomy
 
 Import and assemble the component:
@@ -25,6 +33,32 @@ import { ScrollArea } from "@raystack/apsara";
 
 <ScrollArea />
 ```
+
+## Usage
+
+### Vertical scrolling
+
+A basic vertical scroll area with a list of items. The scrollbar automatically appears when content overflows vertically.
+
+<Demo data={verticalDemo} />
+
+### Horizontal scrolling
+
+A horizontal scroll area for wide content like tables or card grids. The scrollbar automatically appears when content overflows horizontally.
+
+<Demo data={horizontalDemo} />
+
+### Both scrollbars
+
+When content overflows both vertically and horizontally, both scrollbars appear automatically along with the corner element.
+
+<Demo data={bothScrollbarsDemo} />
+
+### Scrollbar type
+
+Control when the scrollbar appears using the `type` prop.
+
+<Demo data={typeDemo} />
 
 ## API Reference
 
@@ -44,41 +78,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `scroll-area-scrollbar` | A scrollbar track (one per axis) |
 | `scroll-area-thumb` | The draggable thumb inside a scrollbar |
 | `scroll-area-corner` | The corner between scrollbars (when both axes overflow) |
-
-## Examples
-
-### Vertical Scrolling
-
-A basic vertical scroll area with a list of items. The scrollbar automatically appears when content overflows vertically.
-
-<Demo data={verticalDemo} />
-
-### Horizontal Scrolling
-
-A horizontal scroll area for wide content like tables or card grids. The scrollbar automatically appears when content overflows horizontally.
-
-<Demo data={horizontalDemo} />
-
-### Both Scrollbars
-
-When content overflows both vertically and horizontally, both scrollbars appear automatically along with the corner element.
-
-<Demo data={bothScrollbarsDemo} />
-
-### Scrollbar Type
-
-Control when the scrollbar appears using the `type` prop.
-
-<Demo data={typeDemo} />
-
-## Features
-
-- **Automatic Scrollbars**: Both vertical and horizontal scrollbars are always rendered and automatically shown when content overflows
-- **Smooth Scrolling**: Custom scrollbar with smooth transitions
-- **Hover Effects**: Scrollbar expands from 4px to 6px on hover
-- **Auto Corner**: Corner element is automatically added when both scrollbars are visible
-- **Scroll Chaining**: Scroll continues to parent page when reaching container boundaries
-- **Customizable Visibility**: Control when scrollbars appear using the `type` prop
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/search/index.mdx
+++ b/apps/www/src/content/docs/components/search/index.mdx
@@ -18,6 +18,26 @@ import { Search } from "@raystack/apsara";
 <Search />
 ```
 
+## Usage
+
+### Size
+
+Two sizes. `large` is the default; `small` fits a toolbar or a table header.
+
+<Demo data={sizeDemo} />
+
+### Clear Button
+
+The Search component can include a clear button that appears when there is input value.
+
+<Demo data={clearDemo} />
+
+### Controlled value
+
+Use `onValueChange` to receive only the new query string, or `onChange` for the full React change event. The Search component forwards both to the underlying [Input](/docs/components/input).
+
+<Demo data={onValueChangeDemo} />
+
 ## API Reference
 
 Renders a search input field with clear functionality.
@@ -34,26 +54,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `search-input` | The `<input>` element itself |
 | `search-clear` | Wrapper around the clear button (when `showClearButton`) |
 | `search-clear-button` | The clear button (when `showClearButton`) |
-
-## Examples
-
-### Size
-
-The Search component comes in two sizes to fit different design contexts.
-
-<Demo data={sizeDemo} />
-
-### Clear Button
-
-The Search component can include a clear button that appears when there is input value.
-
-<Demo data={clearDemo} />
-
-### Controlled Value
-
-Use `onValueChange` to receive only the new query string, or `onChange` for the full React change event. The Search component forwards both to the underlying [Input](/docs/components/input).
-
-<Demo data={onValueChangeDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/select/index.mdx
+++ b/apps/www/src/content/docs/components/select/index.mdx
@@ -36,6 +36,54 @@ import { Select } from "@raystack/apsara";
 </Select>
 ```
 
+## Usage
+
+### Basic Select
+
+A trigger and a list of items. `Select.Value` renders the current selection in the trigger.
+
+<Demo data={basicDemo} />
+
+### Icon
+
+You can pass `leadingIcon` prop to Select.Item to include items
+
+<Demo data={iconDemo} />
+
+### Size
+
+Two sizes. `medium` is the default; `small` fits toolbars and table filters.
+
+<Demo data={sizeDemo} />
+
+### Variant
+
+`outline` (the default) draws a bordered control. `text` removes the border for use inside a toolbar or beside other text.
+
+<Demo data={variantDemo} />
+
+### With Separator
+
+`Select.Separator` draws a rule between groups of items.
+
+<Demo data={separatorDemo} />
+
+### Multiple selection
+
+To enable multiple selection, pass the `multiple` prop to the Select root element.
+
+When multiple selection is enabled, the value, onValueChange, and defaultValue will be an array of strings.
+
+<Demo data={multipleDemo} />
+
+### Autocomplete
+
+To enable autocomplete, pass the `autocomplete` prop to the Select root element.
+
+By default, only select items are filtered using a simple match. For more advanced control, set `autocompleteMode="manual"` and implement your own custom filtering logic.
+
+<Demo data={autocompleteDemo} />
+
 ## API Reference
 
 ### Root
@@ -105,46 +153,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `select-item` | An individual option row |
 | `select-item-icon` | Leading icon on an item (when set) |
 | `select-item-text` | The text label of an item |
-
-## Examples
-
-### Basic Select
-
-<Demo data={basicDemo} />
-
-### Icon
-
-You can pass `leadingIcon` prop to Select.Item to include items
-
-<Demo data={iconDemo} />
-
-### Size
-
-<Demo data={sizeDemo} />
-
-### Variant
-
-<Demo data={variantDemo} />
-
-### With Separator
-
-<Demo data={separatorDemo} />
-
-### Multiple Selection
-
-To enable multiple selection, pass the `multiple` prop to the Select root element.
-
-When multiple selection is enabled, the value, onValueChange, and defaultValue will be an array of strings.
-
-<Demo data={multipleDemo} />
-
-### Autocomplete
-
-To enable autocomplete, pass the `autocomplete` prop to the Select root element.
-
-By default, only select items are filtered using a simple match. For more advanced control, set `autocompleteMode="manual"` and implement your own custom filtering logic.
-
-<Demo data={autocompleteDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/separator/index.mdx
+++ b/apps/www/src/content/docs/components/separator/index.mdx
@@ -18,6 +18,26 @@ import { Separator } from '@raystack/apsara'
 <Separator />
 ```
 
+## Usage
+
+### Orientation
+
+`horizontal` (the default) draws a full-width rule between stacked content. `vertical` draws a rule between items in a row, and needs a parent with a set height to draw against.
+
+<Demo data={orientationDemo} />
+
+### Size
+
+`size` sets how far the rule runs across its container: `small` a short accent, `half` halfway, `full` (the default) edge to edge.
+
+<Demo data={sizeDemo} />
+
+### Color
+
+Three weights of line. `primary` is the default; drop to `secondary` or `tertiary` where the rule should separate without drawing attention.
+
+<Demo data={colorDemo} />
+
 ## API Reference
 
 Renders a visual divider between content sections.
@@ -31,26 +51,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | Slot | Element |
 |------|---------|
 | `separator` | The separator element |
-
-## Examples
-
-### Color
-
-The Separator component supports three colors.
-
-<Demo data={colorDemo} />
-
-### Size
-
-The Separator component supports three sizes.
-
-<Demo data={sizeDemo} />
-
-### Orientation
-
-Separator can be rendered in both horizontal and vertical orientations.
-
-<Demo data={orientationDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/sidebar/index.mdx
+++ b/apps/www/src/content/docs/components/sidebar/index.mdx
@@ -46,6 +46,118 @@ import { Sidebar } from "@raystack/apsara";
 </Sidebar>
 ```
 
+## Usage
+
+### Position
+
+`left` (the default) or `right`. Put it on the right only when the main content is the thing people arrive for and navigation is secondary.
+
+<Demo data={positionDemo} />
+
+### Variants
+
+Use `variant` to switch the Sidebar surface style:
+
+- `plain` (default): regular surface with side border
+- `floating`: lifted surface with shadow
+- `inset`: transparent surface without border or shadow
+
+<Demo data={variantDemo} />
+
+### Collapsed appearance
+
+Use `collapsible` to choose what the collapsed state looks like. Expanding
+works the same in both modes: the sidebar opens in place and pushes content.
+
+- `"icon"` (default): collapses to an icon rail.
+- `"hidden"`: collapses to a thin strip with no visible content.
+- `"none"`: the sidebar cannot be collapsed at all.
+
+For a responsive layout, drive it from your own breakpoint check:
+
+```tsx
+<Sidebar collapsible={isMobile ? 'hidden' : 'icon'} />
+```
+
+When `collapsible="hidden"` is closed, the strip is just wide enough for the resize handle — reopen by clicking it, or place a `Sidebar.Trigger` as a direct child of `<Sidebar>` (not inside `Header`/`Main`/`Footer`, which are hidden along with everything else) for a clearer affordance, as in the "Hidden" tab below.
+
+<Demo data={collapsedAppearanceDemo} />
+
+### State
+
+The sidebar expands and collapses, animating between the two. Collapsed keeps icons visible so the navigation stays usable at a glance.
+
+<Demo data={stateDemo} />
+
+### Non-collapsible
+
+Set `collapsible="none"` to hide the resize handle and prevent the sidebar from being collapsed or expanded.
+
+<Demo data={collapsibleDemo} />
+
+### Peek on hover
+
+Set `peekOnHover` to temporarily reveal a collapsed sidebar as an overlay
+above the content while the user hovers it, without pushing the content or
+changing the real `open` state — similar to VS Code's auto-hide sidebar.
+Moving the mouse away reverts it; clicking the resize handle or a
+`Sidebar.Trigger` pins it open for real (which does push content, like a
+normal open). Clicking a `Sidebar.Item` just navigates, like normal — it
+doesn't change the open state.
+
+It works with either collapsed appearance. With `"hidden"` there's no icon rail —
+hover the thin strip at the edge to reveal the sidebar, as in the "Hidden"
+tab below.
+
+The peek starts after a short delay (100ms) so it doesn't trigger when the
+mouse just passes over the sidebar. Use `peekDelay` to change it.
+
+<Demo data={peekOnHoverDemo} />
+
+### Custom tooltip message
+
+Item tooltips show the item label when collapsed. Override the message when the label alone is not enough out of context.
+
+<Demo data={tooltipDemo} />
+
+### Hide item tooltips when collapsed
+
+Set `hideItemTooltips` to disable the tooltips the Sidebar adds to navigation items — the label tooltip when collapsed, and the full-text tooltip on clipped labels when expanded. Useful when you show your own tooltips or want a cleaner collapsed state.
+
+<Demo data={hideTooltipDemo} />
+
+### Group with icon
+
+Pass `leadingIcon` to `Sidebar.Group` to render an icon next to the section label.
+
+<Demo data={groupIconDemo} />
+
+### Collapsible group
+
+Enable `collapsible` on `Sidebar.Group` to render the group as an accordion whose items can be shown or hidden. You can also pass `trailingIcon` for section-level actions. Use `defaultOpen` to set the initial expanded state of an uncontrolled group.
+
+Note: this is different from `collapsible` on the Sidebar root, which controls whether the whole sidebar can be collapsed.
+
+<Demo data={collapsibleGroupDemo} />
+
+### Controlled group
+
+Use `open` together with `onOpenChange` on `Sidebar.Group` to control the group's expanded state from outside the component.
+
+<Demo data={controlledGroupDemo} />
+
+### Trigger button
+
+Place `Sidebar.Trigger` anywhere inside the Sidebar (typically `Sidebar.Header`) to add a visible toggle button next to the edge handle. No `open`/`onOpenChange` wiring is required.
+
+<Demo data={triggerDemo} />
+
+### More
+
+Use `Sidebar.More` when you want to keep a section compact and move secondary items into a menu.
+
+<Demo data={moreDemo} />
+
 ## API Reference
 
 ### Root
@@ -159,122 +271,6 @@ Add `data-collapse-hidden` to any element inside the Sidebar to hide it automati
   <span data-collapse-hidden>Extra label, hidden when collapsed</span>
 </Sidebar.Header>
 ```
-
-## Examples
-
-### Position
-
-The Sidebar can be positioned on either the left or right side of the screen.
-
-<Demo data={positionDemo} />
-
-### Variants
-
-Use `variant` to switch the Sidebar surface style:
-
-- `plain` (default): regular surface with side border
-- `floating`: lifted surface with shadow
-- `inset`: transparent surface without border or shadow
-
-<Demo data={variantDemo} />
-
-### State
-
-The Sidebar supports expanded and collapsed states with smooth transitions.
-
-The `data-collapse-hidden` attribute can be used to conditionally hide elements when the sidebar is collapsed.
-
-<Demo data={stateDemo} />
-
-### Collapsed appearance
-
-Use `collapsible` to choose what the collapsed state looks like. Expanding
-works the same in both modes: the sidebar opens in place and pushes content.
-
-- `"icon"` (default): collapses to an icon rail.
-- `"hidden"`: collapses to a thin strip with no visible content.
-- `"none"`: the sidebar cannot be collapsed at all.
-
-For a responsive layout, drive it from your own breakpoint check:
-
-```tsx
-<Sidebar collapsible={isMobile ? 'hidden' : 'icon'} />
-```
-
-When `collapsible="hidden"` is closed, the strip is just wide enough for the resize handle — reopen by clicking it, or place a `Sidebar.Trigger` as a direct child of `<Sidebar>` (not inside `Header`/`Main`/`Footer`, which are hidden along with everything else) for a clearer affordance, as in the "Hidden" tab below.
-
-<Demo data={collapsedAppearanceDemo} />
-
-### Peek on hover
-
-Set `peekOnHover` to temporarily reveal a collapsed sidebar as an overlay
-above the content while the user hovers it, without pushing the content or
-changing the real `open` state — similar to VS Code's auto-hide sidebar.
-Moving the mouse away reverts it; clicking the resize handle or a
-`Sidebar.Trigger` pins it open for real (which does push content, like a
-normal open). Clicking a `Sidebar.Item` just navigates, like normal — it
-doesn't change the open state.
-
-It works with either collapsed appearance. With `"hidden"` there's no icon rail —
-hover the thin strip at the edge to reveal the sidebar, as in the "Hidden"
-tab below.
-
-The peek starts after a short delay (100ms) so it doesn't trigger when the
-mouse just passes over the sidebar. Use `peekDelay` to change it.
-
-<Demo data={peekOnHoverDemo} />
-
-### Custom Tooltip Message
-
-You can customize the tooltip message that appears when hovering over the collapse/expand handle using the `collapseTooltip` prop.
-
-You can use Sidebar as a controlled component to conditionally render different tooltip messages.
-
-<Demo data={tooltipDemo} />
-
-### Non-collapsible
-
-Set `collapsible="none"` to hide the resize handle and prevent the sidebar from being collapsed or expanded.
-
-<Demo data={collapsibleDemo} />
-
-### Hide item tooltips when collapsed
-
-Set `hideItemTooltips` to disable the tooltips the Sidebar adds to navigation items — the label tooltip when collapsed, and the full-text tooltip on clipped labels when expanded. Useful when you show your own tooltips or want a cleaner collapsed state.
-
-<Demo data={hideTooltipDemo} />
-
-### Group with icon
-
-Pass `leadingIcon` to `Sidebar.Group` to render an icon next to the section label.
-
-<Demo data={groupIconDemo} />
-
-### Collapsible Group
-
-Enable `collapsible` on `Sidebar.Group` to render the group as an accordion whose items can be shown or hidden. You can also pass `trailingIcon` for section-level actions. Use `defaultOpen` to set the initial expanded state of an uncontrolled group.
-
-Note: this is different from `collapsible` on the Sidebar root, which controls whether the whole sidebar can be collapsed.
-
-<Demo data={collapsibleGroupDemo} />
-
-### Controlled Group
-
-Use `open` together with `onOpenChange` on `Sidebar.Group` to control the group's expanded state from outside the component.
-
-<Demo data={controlledGroupDemo} />
-
-### Trigger button
-
-Place `Sidebar.Trigger` anywhere inside the Sidebar (typically `Sidebar.Header`) to add a visible toggle button next to the edge handle. No `open`/`onOpenChange` wiring is required.
-
-<Demo data={triggerDemo} />
-
-### More
-
-Use `Sidebar.More` when you want to keep a section compact and move secondary items into a menu.
-
-<Demo data={moreDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/sidepanel/index.mdx
+++ b/apps/www/src/content/docs/components/sidepanel/index.mdx
@@ -20,6 +20,20 @@ import { SidePanel } from "@raystack/apsara";
 </SidePanel>
 ```
 
+## Usage
+
+### Basic usage
+
+A panel with a header and content. `side` puts it on the `left` or `right` of the layout.
+
+<Demo data={basicDemo} />
+
+### Position
+
+`left` or `right`. Match it to the side the panel relates to, so it opens next to the content it acts on.
+
+<Demo data={positionDemo} />
+
 ## API Reference
 
 ### Root
@@ -50,18 +64,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `side-panel-actions` | Header actions group |
 | `side-panel-description` | Header description text (when `description` is set) |
 | `side-panel-section` | `SidePanel.Section` container |
-
-## Examples
-
-### Basic Usage
-
-<Demo data={basicDemo} />
-
-### Position
-
-The SidePanel can be positioned on either the left or right side of the screen.
-
-<Demo data={positionDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/skeleton/index.mdx
+++ b/apps/www/src/content/docs/components/skeleton/index.mdx
@@ -26,30 +26,15 @@ import { Skeleton } from "@raystack/apsara";
 <Skeleton />
 ```
 
-## API Reference
+## Usage
 
-Renders a placeholder loading animation that mimics content layout.
-
-<auto-type-table path="./props.ts" name="SkeletonProps" />
-
-### Slots
-
-Every rendered part carries a stable `data-slot` attribute for [styling and testing](/docs/styling#with-data-slot):
-
-| Slot | Element |
-|------|---------|
-| `skeleton` | The container element |
-| `skeleton-item` | Each skeleton bar (repeated `count` times) |
-
-## Examples
-
-### Basic Usage
+### Basic usage
 
 A simple skeleton loader with fixed dimensions.
 
 <Demo data={basicDemo} />
 
-### Multiple Lines
+### Multiple lines
 
 Create multiple skeleton lines using the count prop.
 
@@ -61,27 +46,27 @@ Group multiple skeletons and share common props using Skeleton.Provider.
 
 <Demo data={providerDemo} />
 
-### Custom Styles
+### Custom styles
 
 Customize the appearance using baseColor and highlightColor.
 
 <Demo data={customStylesDemo} />
 
-### Animation Control
+### Animation control
 
 Control the animation duration or disable it entirely.
 
 <Demo data={animationDemo} />
 
-### Complex Layout
+### Complex layout
 
 Create a card-like loading state by combining multiple skeletons.
 
 <Demo data={cardDemo} />
 
-## Provider Pattern
+### Provider
 
-The Skeleton component supports a Provider pattern that allows you to share common props across multiple skeleton instances:
+`Skeleton.Provider` shares props with every skeleton beneath it, so a group of placeholders can be tuned in one place. Any child can override what it inherits.
 
 ```tsx
 <Skeleton.Provider
@@ -99,6 +84,21 @@ The Skeleton component supports a Provider pattern that allows you to share comm
 ```
 
 All props available on the Skeleton component can be passed to the Provider and will be inherited by child Skeleton components. Individual Skeleton components can override any provider props with their own values.
+
+## API Reference
+
+Renders a placeholder loading animation that mimics content layout.
+
+<auto-type-table path="./props.ts" name="SkeletonProps" />
+
+### Slots
+
+Every rendered part carries a stable `data-slot` attribute for [styling and testing](/docs/styling#with-data-slot):
+
+| Slot | Element |
+|------|---------|
+| `skeleton` | The container element |
+| `skeleton-item` | Each skeleton bar (repeated `count` times) |
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/slider/index.mdx
+++ b/apps/www/src/content/docs/components/slider/index.mdx
@@ -20,6 +20,26 @@ import { Slider, SliderValue } from '@raystack/apsara'
 </Slider>
 ```
 
+## Usage
+
+### Variant
+
+`single` (the default) gives one thumb and a value. `range` gives two thumbs and a `[min, max]` tuple.
+
+<Demo data={variantDemo} />
+
+### Thumb size
+
+Different thumb sizes for various use cases and visual preferences.
+
+<Demo data={thumbSizeDemo} />
+
+### Controlled
+
+A controlled slider that maintains and updates its state through React's useState hook.
+
+<Demo data={controlDemo} />
+
 ## API Reference
 
 ### Root
@@ -48,24 +68,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `slider-thumb-grip-line` | Each grip line (large thumb only) |
 | `slider-label` | The thumb label (when `label`) |
 | `slider-value` | The `Slider.Value` output element |
-
-## Examples
-
-### Variant
-
-<Demo data={variantDemo} />
-
-### Controlled Usage
-
-A controlled slider that maintains and updates its state through React's useState hook.
-
-<Demo data={controlDemo} />
-
-### Thumb Size
-
-Different thumb sizes for various use cases and visual preferences.
-
-<Demo data={thumbSizeDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/spinner/index.mdx
+++ b/apps/www/src/content/docs/components/spinner/index.mdx
@@ -18,6 +18,24 @@ import { Spinner } from "@raystack/apsara";
 <Spinner />
 ```
 
+## Usage
+
+### Size
+
+Six steps, 1 through 6. Pick the one that matches the text or control it sits beside.
+
+The Spinner component offers different size options. You can customize the size of the spinner using the `size` prop. The available size options are:
+
+<Demo data={sizeDemo} />
+
+### Color
+
+`default` inherits `currentColor`, so the spinner takes the colour of the text around it. The other five carry meaning — `accent`, `danger`, `success`, `attention`, `neutral`.
+
+The Spinner component offers 6 color values. `default` prop sets the color to `currentColor` mainly helpful if we want to render the Spinner inside another component like Button. Spinner (with color="default") inherits the foreground color of button text.
+
+<Demo data={colorDemo} />
+
 ## API Reference
 
 Renders a loading spinner animation.
@@ -32,20 +50,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 |------|---------|
 | `spinner` | The root element |
 | `spinner-pole` | Each of the eight spinner poles |
-
-## Examples
-
-### Size
-
-The Spinner component offers different size options. You can customize the size of the spinner using the `size` prop. The available size options are:
-
-<Demo data={sizeDemo} />
-
-### Color
-
-The Spinner component offers 6 color values. `default` prop sets the color to `currentColor` mainly helpful if we want to render the Spinner inside another component like Button. Spinner (with color="default") inherits the foreground color of button text.
-
-<Demo data={colorDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/switch/index.mdx
+++ b/apps/www/src/content/docs/components/switch/index.mdx
@@ -18,6 +18,26 @@ import { Switch } from "@raystack/apsara";
 <Switch />
 ```
 
+## Usage
+
+### Size
+
+Two sizes. `large` is the default; use `small` inside table rows, toolbars, and settings lists where the control sits beside dense text.
+
+<Demo data={sizeDemo} />
+
+### State
+
+A switch can be on, off, or disabled. Use `defaultChecked` for the starting position when you don't need to read the value back.
+
+<Demo data={stateDemo} />
+
+### Controlled
+
+Pass `checked` with `onCheckedChange` to own the state yourself — needed when the value lives in a form, syncs to a server, or drives something else on the page.
+
+<Demo data={controlDemo} />
+
 ## API Reference
 
 Renders a toggleable switch input.
@@ -32,26 +52,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 |------|---------|
 | `switch` | The switch control itself |
 | `switch-thumb` | The sliding thumb |
-
-## Examples
-
-### State
-
-The Switch component supports various states to handle different interaction scenarios.
-
-<Demo data={stateDemo} />
-
-### Size Variants
-
-The Switch component comes in two sizes: large (default) and small.
-
-<Demo data={sizeDemo} />
-
-### Controlled Usage
-
-Use the Switch component in a controlled manner to manage its state externally.
-
-<Demo data={controlDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/table/index.mdx
+++ b/apps/www/src/content/docs/components/table/index.mdx
@@ -29,6 +29,14 @@ import { Table } from "@raystack/apsara";
 </Table>
 ```
 
+## Usage
+
+### Basic usage
+
+Compose a table from its parts: `Header` and `Body` wrap `Row`s, with `Head` for column titles and `Cell` for each value. Table renders static markup — for sorting, filtering, or pagination, use [DataView](/docs/components/dataview).
+
+<Demo data={basicDemo} />
+
 ## API Reference
 
 ### Root
@@ -83,14 +91,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `table-cell` | `<td>` |
 | `table-section-header` | `SectionHeader`'s row |
 | `table-section-header-cell` | `SectionHeader`'s cell |
-
-## Examples
-
-### Basic Usage
-
-Compose a table from its parts: `Header` and `Body` wrap `Row`s, with `Head` for column titles and `Cell` for each value. Table renders static markup — for sorting, filtering, or pagination, use [DataView](/docs/components/dataview).
-
-<Demo data={basicDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/tabs/index.mdx
+++ b/apps/www/src/content/docs/components/tabs/index.mdx
@@ -30,6 +30,38 @@ import { Tabs } from "@raystack/apsara";
 </Tabs>
 ```
 
+## Usage
+
+### Basic usage
+
+A tab list with panels. Set `defaultValue` to the tab that should open first.
+
+<Demo data={basicDemo} />
+
+### With leading icons
+
+Pass `leadingIcon` on a trigger to place an icon before its label.
+
+<Demo data={iconsDemo} />
+
+### Disabled tab
+
+Set `disabled` on a trigger to keep a tab visible but unreachable.
+
+<Demo data={disabledDemo} />
+
+### Variants
+
+Three treatments. `segmented` groups the tabs in a track, `standalone` gives them an underline, and `plain` strips the chrome for dense layouts.
+
+<Demo data={variantsDemo} />
+
+### Sizes
+
+Three sizes. `medium` is the default; use `small` in toolbars and panels.
+
+<Demo data={sizesDemo} />
+
 ## API Reference
 
 ### Root
@@ -68,28 +100,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `tabs-tab` | `Tabs.Tab` button |
 | `tabs-tab-icon` | A tab's leading icon (when `leadingIcon` is set) |
 | `tabs-content` | `Tabs.Content` panel |
-
-## Examples
-
-### Basic Usage
-
-<Demo data={basicDemo} />
-
-### With Leading Icons
-
-<Demo data={iconsDemo} />
-
-### Disabled Tab
-
-<Demo data={disabledDemo} />
-
-### Variants
-
-<Demo data={variantsDemo} />
-
-### Sizes
-
-<Demo data={sizesDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/text/index.mdx
+++ b/apps/www/src/content/docs/components/text/index.mdx
@@ -27,6 +27,50 @@ import { Text } from '@raystack/apsara'
 <Text />
 ```
 
+## Usage
+
+### Variant
+
+Seven semantic colours. `primary` is the default; drop to `secondary` or `tertiary` for supporting text, and use `success`, `danger`, `warning` or `accent` to carry meaning.
+
+<Demo data={variantDemo} />
+
+### Size
+
+Five steps from `micro` to `large`. `regular` is the default and matches body copy.
+
+<Demo data={sizeDemo} />
+
+### Weight
+
+Two weights. `regular` is the default; `medium` lifts a line without making it a heading.
+
+<Demo data={weightDemo} />
+
+### Transform
+
+`capitalize`, `uppercase`, or `lowercase`, applied in CSS so the underlying text stays intact for copy and search.
+
+<Demo data={transformDemo} />
+
+### Line clamp
+
+`lineClamp` truncates to a set number of lines (1–5) with an ellipsis. The text still exists in the DOM, so it stays selectable and searchable.
+
+<Demo data={lineClampDemo} />
+
+### Align
+
+`start` (the default), `center`, `end`, or `justify`. These are logical values, so they follow text direction rather than physical left and right.
+
+<Demo data={alignDemo} />
+
+### Style
+
+`underline`, `strikeThrough`, and `italic` are independent booleans, so they combine.
+
+<Demo data={styleDemo} />
+
 ## API Reference
 
 Use the `render` prop to change the rendered element or provide a custom render function.
@@ -40,36 +84,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | Slot | Element |
 |------|---------|
 | `text` | The text element (`<span>` by default, or the element supplied via `render`) |
-
-## Examples
-
-### Variant
-
-<Demo data={variantDemo} />
-
-### Size
-
-<Demo data={sizeDemo} />
-
-### Weight
-
-<Demo data={weightDemo} />
-
-### Transform
-
-<Demo data={transformDemo} />
-
-### Line Clamp
-
-<Demo data={lineClampDemo} />
-
-### Align
-
-<Demo data={alignDemo} />
-
-### Style
-
-<Demo data={styleDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/textarea/index.mdx
+++ b/apps/www/src/content/docs/components/textarea/index.mdx
@@ -37,6 +37,50 @@ import { Field, TextArea } from "@raystack/apsara";
 </Field>
 ```
 
+## Usage
+
+### Basic usage
+
+A multi-line text input. It grows with `rows` rather than with content, so set a height that fits the answer you expect.
+
+<Demo data={basicDemo} />
+
+### Size
+
+TextArea comes in two sizes: `large` (default) and `small`.
+
+<Demo data={sizeDemo} />
+
+### Visual variants
+
+TextArea supports `default` and `borderless` visual variants.
+
+<Demo data={variantDemo} />
+
+### Custom rows
+
+TextArea defaults to 3 visible rows. Use the `rows` prop to adjust.
+
+<Demo data={rowsDemo} />
+
+### With Field
+
+Use Field to add label, description, and error handling.
+
+<Demo data={withFieldDemo} />
+
+### Controlled
+
+Pass `value` with `onChange` to own the state, the same contract as a native textarea.
+
+<Demo data={controlledDemo} />
+
+### Using `onValueChange`
+
+`onValueChange` is a convenience callback that fires alongside `onChange` and receives just the new string value. Use it when you don't need the full React change event.
+
+<Demo data={onValueChangeDemo} />
+
 ## API Reference
 
 Renders a multi-line text input. For label, description, and error support, use with [Field](/docs/components/field).
@@ -50,50 +94,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | Slot | Element |
 |------|---------|
 | `text-area` | The `<textarea>` element itself |
-
-## Examples
-
-### Basic Usage
-
-A basic TextArea with a placeholder.
-
-<Demo data={basicDemo} />
-
-### With Field
-
-Use Field to add label, description, and error handling.
-
-<Demo data={withFieldDemo} />
-
-### Controlled Usage
-
-Example of TextArea in controlled mode.
-
-<Demo data={controlledDemo} />
-
-### Using `onValueChange`
-
-`onValueChange` is a convenience callback that fires alongside `onChange` and receives just the new string value. Use it when you don't need the full React change event.
-
-<Demo data={onValueChangeDemo} />
-
-### Size Variants
-
-TextArea comes in two sizes: `large` (default) and `small`.
-
-<Demo data={sizeDemo} />
-
-### Visual Variants
-
-TextArea supports `default` and `borderless` visual variants.
-
-<Demo data={variantDemo} />
-
-### Custom Rows
-
-TextArea defaults to 3 visible rows. Use the `rows` prop to adjust.
-
-<Demo data={rowsDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/toast/index.mdx
+++ b/apps/www/src/content/docs/components/toast/index.mdx
@@ -24,6 +24,62 @@ import { Toast, toastManager } from '@raystack/apsara'
 toastManager.add({ title: 'Hello!', type: 'success' })
 ```
 
+## Usage
+
+### Basic Toast
+
+Call `toastManager.add()` with a message. The toast appears in the provider's region and dismisses itself after `timeout`.
+
+<Demo data={basicDemo} />
+
+### Type variants
+
+Use the `type` prop to drive the leading icon color (e.g. green for success, red for error). The toast container itself stays visually neutral regardless of type.
+
+<Demo data={typesDemo} />
+
+### With title and description
+
+Pass `title` and `description` for a two-line toast. The title carries the outcome; the description carries the detail.
+
+<Demo data={descriptionDemo} />
+
+### With leading icon
+
+Each toast `type` ships with a sensible default icon. Pass `leadingIcon` to override it with any React node, or pass `leadingIcon: null` to render no icon at all.
+
+<Demo data={leadingIconDemo} />
+
+### With action button
+
+Use `actionProps` to render an action button inside the toast.
+
+<Demo data={actionDemo} />
+
+### Promise Toast
+
+Track an async operation with automatic loading, success, and error states.
+
+<Demo data={promiseDemo} />
+
+### Positioning
+
+Control where toasts appear on screen with the `position` prop on `Toast.Provider`.
+
+<Demo data={positionDemo} />
+
+### Close and update
+
+Create a toast, then update or close it programmatically using the returned ID.
+
+<Demo data={updateDemo} />
+
+### Dispatching from a component
+
+Use `useToastManager()` inside a component to dispatch toasts and/or read the reactive list of active toasts. The component must be a descendant of `<Toast.Provider>`.
+
+<Demo data={hookDemo} />
+
 ## API Reference
 
 ### Toast.Provider
@@ -106,58 +162,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `toast-action` | The action button (when `actionProps`) |
 | `toast-close` | The close button |
 | `toast-description` | The description (when both title and description are set) |
-
-## Examples
-
-### Basic Toast
-
-<Demo data={basicDemo} />
-
-### Type Variants
-
-Use the `type` prop to drive the leading icon color (e.g. green for success, red for error). The toast container itself stays visually neutral regardless of type.
-
-<Demo data={typesDemo} />
-
-### With Title and Description
-
-<Demo data={descriptionDemo} />
-
-### With Leading Icon
-
-Each toast `type` ships with a sensible default icon. Pass `leadingIcon` to override it with any React node, or pass `leadingIcon: null` to render no icon at all.
-
-<Demo data={leadingIconDemo} />
-
-### With Action Button
-
-Use `actionProps` to render an action button inside the toast.
-
-<Demo data={actionDemo} />
-
-### Promise Toast
-
-Track an async operation with automatic loading, success, and error states.
-
-<Demo data={promiseDemo} />
-
-### Positioning
-
-Control where toasts appear on screen with the `position` prop on `Toast.Provider`.
-
-<Demo data={positionDemo} />
-
-### Close and Update
-
-Create a toast, then update or close it programmatically using the returned ID.
-
-<Demo data={updateDemo} />
-
-### Dispatching from a Component (Hook)
-
-Use `useToastManager()` inside a component to dispatch toasts and/or read the reactive list of active toasts. The component must be a descendant of `<Toast.Provider>`.
-
-<Demo data={hookDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/toggle/index.mdx
+++ b/apps/www/src/content/docs/components/toggle/index.mdx
@@ -29,6 +29,38 @@ Use `Toggle.Group` to manage a set of toggles with shared state:
 </Toggle.Group>
 ```
 
+## Usage
+
+### Group
+
+Use `Toggle.Group` for exclusive or multi-select toggle sets. By default, only one toggle can be pressed at a time.
+
+<Demo data={groupDemo} />
+
+### Multiple selection
+
+Set `multiple` on the group to allow more than one toggle to be pressed simultaneously.
+
+<Demo data={multipleDemo} />
+
+### Size
+
+Four steps, 1 through 4, matching the icon button scale so toggles and buttons line up in the same toolbar.
+
+<Demo data={sizeDemo} />
+
+### Controlled
+
+Pass `pressed` with `onPressedChange` to own the state — needed when the toggle reflects something stored elsewhere.
+
+<Demo data={controlledDemo} />
+
+### Disabled
+
+Disable individual toggles or the entire group.
+
+<Demo data={disabledDemo} />
+
 ## API Reference
 
 ### Root
@@ -52,38 +84,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `toggle` | The toggle button itself |
 | `toggle-content` | The `<span>` wrapping the toggle's children |
 | `toggle-group` | The `Toggle.Group` container |
-
-## Examples
-
-### Group
-
-Use `Toggle.Group` for exclusive or multi-select toggle sets. By default, only one toggle can be pressed at a time.
-
-<Demo data={groupDemo} />
-
-### Multiple Selection
-
-Set `multiple` on the group to allow more than one toggle to be pressed simultaneously.
-
-<Demo data={multipleDemo} />
-
-### Size
-
-The toggle supports four sizes matching the icon button sizes.
-
-<Demo data={sizeDemo} />
-
-### Controlled
-
-Control the pressed state programmatically.
-
-<Demo data={controlledDemo} />
-
-### Disabled
-
-Disable individual toggles or the entire group.
-
-<Demo data={disabledDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/toolbar/index.mdx
+++ b/apps/www/src/content/docs/components/toolbar/index.mdx
@@ -28,6 +28,32 @@ import { Toolbar } from '@raystack/apsara'
 </Toolbar>
 ```
 
+## Usage
+
+### Grouped
+
+Use `Toolbar.Group` to group related buttons.
+
+<Demo data={groupDemo} />
+
+### Vertical
+
+Use the `orientation` prop to render the toolbar vertically.
+
+<Demo data={verticalDemo} />
+
+### Composition
+
+Use the `render` prop to compose with other components.
+
+<Demo data={compositionDemo} />
+
+### Disabled
+
+Disable all toolbar items by setting `disabled` on the root.
+
+<Demo data={disabledDemo} />
+
 ## API Reference
 
 ### Root
@@ -76,32 +102,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `toolbar-button` | `Toolbar.Button` |
 | `toolbar-group` | `Toolbar.Group` wrapper |
 | `toolbar-separator` | `Toolbar.Separator` |
-
-## Examples
-
-### Grouped
-
-Use `Toolbar.Group` to group related buttons.
-
-<Demo data={groupDemo} />
-
-### Vertical
-
-Use the `orientation` prop to render the toolbar vertically.
-
-<Demo data={verticalDemo} />
-
-### Composition
-
-Use the `render` prop to compose with other components.
-
-<Demo data={compositionDemo} />
-
-### Disabled
-
-Disable all toolbar items by setting `disabled` on the root.
-
-<Demo data={disabledDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/tooltip/index.mdx
+++ b/apps/www/src/content/docs/components/tooltip/index.mdx
@@ -20,6 +20,44 @@ import { Tooltip } from "@raystack/apsara";
 </Tooltip.Provider>
 ```
 
+## Usage
+
+### Side
+
+The Tooltip Content component can be positioned in different directions using the `side` prop:
+
+<Demo data={sideDemo} />
+
+### Align
+
+The Tooltip Content component can be aligned in different directions using the `align` prop:
+
+<Demo data={alignDemo} />
+
+### Custom Content
+
+Tooltips can contain custom content using ReactNode:
+
+<Demo data={customDemo} />
+
+### With Provider
+
+`TooltipProvider` sets delay and skip-delay for every tooltip beneath it, so a group of controls opens with one consistent rhythm rather than each tooltip timing itself.
+
+<Demo data={providerDemo} />
+
+### Track cursor
+
+Use `trackCursorAxis` prop on the Root component to make the tooltip follow the cursor:
+
+<Demo data={trackCursorDemo} />
+
+### With arrow
+
+Show the arrow by setting `showArrow={true}` on the Content component:
+
+<Demo data={arrowDemo} />
+
 ## API Reference
 
 ### Root
@@ -57,44 +95,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `tooltip-content` | The tooltip popup |
 | `tooltip-text` | Text wrapper (when children is a string) |
 | `tooltip-arrow` | The arrow (when `showArrow`) |
-
-## Examples
-
-### Side
-
-The Tooltip Content component can be positioned in different directions using the `side` prop:
-
-<Demo data={sideDemo} />
-
-### Align
-
-The Tooltip Content component can be aligned in different directions using the `align` prop:
-
-<Demo data={alignDemo} />
-
-### Custom Content
-
-Tooltips can contain custom content using ReactNode:
-
-<Demo data={customDemo} />
-
-### With Provider
-
-The TooltipProvider component can be used to provide a global configuration for all tooltips in your application.
-
-<Demo data={providerDemo} />
-
-### Track Cursor
-
-Use `trackCursorAxis` prop on the Root component to make the tooltip follow the cursor:
-
-<Demo data={trackCursorDemo} />
-
-### With Arrow
-
-Show the arrow by setting `showArrow={true}` on the Content component:
-
-<Demo data={arrowDemo} />
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/components/tour/index.mdx
+++ b/apps/www/src/content/docs/components/tour/index.mdx
@@ -41,89 +41,7 @@ To compose the card yourself, pass the parts as children:
 </Tour>
 ```
 
-## API Reference
-
-### Tour
-
-The root. Holds the steps and the open/index state, resolves targets, emits
-events, and owns the actions. Renders a context provider — its children default
-to `<Tour.Overlay />` and `<Tour.Content />`.
-
-<auto-type-table path="./props.ts" name="TourProps" />
-
-### Step
-
-Each entry in the `steps` array.
-
-<auto-type-table path="./props.ts" name="TourStep" />
-
-### Tour.Content
-
-The card. Accepts positioning defaults and either static children, a render
-function, or the default layout.
-
-<auto-type-table path="./props.ts" name="TourContentProps" />
-
-### Tour.Overlay
-
-The dimmed backdrop with a spotlight cutout over the target.
-
-<auto-type-table path="./props.ts" name="TourOverlayProps" />
-
-### Tour.Progress
-
-Renders the step counter, e.g. "2 of 5".
-
-<auto-type-table path="./props.ts" name="TourProgressProps" />
-
-### Tour.Title / Tour.Description
-
-Give the card its accessible name and description, falling back to the step's
-`title` and `content`.
-
-### Tour.Next / Tour.Prev / Tour.Skip / Tour.Close
-
-Navigation buttons. Each runs your `onClick` first, then its action
-(`next`, `prev`, `skip`, `stop`). `Tour.Next` finishes the tour past the last
-step.
-
-### Actions
-
-`start`, `next`, `prev`, `go`, `skip`, and `stop`. Reach them through
-`actionsRef`, or anywhere inside `<Tour>` with the `useTour()` hook. `start` is
-the only action that runs while the tour is closed.
-
-<auto-type-table path="./props.ts" name="TourActions" />
-
-### Events
-
-Every lifecycle moment is reported to `onEvent`.
-
-<auto-type-table path="./props.ts" name="TourEvent" />
-
-### Slots
-
-Every rendered part carries a stable `data-slot` attribute for [styling and testing](/docs/styling#with-data-slot):
-
-| Slot | Element |
-|------|---------|
-| `tour-overlay` | `Tour.Overlay` root |
-| `tour-spotlight` | The cut-out spotlight highlight |
-| `tour-spotlight-cover` | The dimmed cover around the spotlight (when a target is resolved) |
-| `tour-overlay-hit` | Click-blocking hit-test strips around the spotlight |
-| `tour-positioner` | Positioning wrapper around the content popup |
-| `tour-content` | `Tour.Content` popup |
-| `tour-arrow` | The pointing arrow (when `showArrow` and not detached) |
-| `tour-step-content` | Wrapper around the active step's card content |
-| `tour-title` | `Tour.Title` |
-| `tour-description` | `Tour.Description` |
-| `tour-progress` | `Tour.Progress` |
-| `tour-next` | `Tour.Next` button |
-| `tour-prev` | `Tour.Prev` button (rendered from the second step onward in the default layout) |
-| `tour-skip` | `Tour.Skip` button |
-| `tour-close` | `Tour.Close` button |
-
-## Examples
+## Usage
 
 ### Controlled with imperative controls
 
@@ -214,6 +132,88 @@ which suits walkthroughs whose consecutive targets sit close together.
 ```
 
 Both collapse to instant swaps under `prefers-reduced-motion: reduce`.
+
+## API Reference
+
+### Tour
+
+The root. Holds the steps and the open/index state, resolves targets, emits
+events, and owns the actions. Renders a context provider — its children default
+to `<Tour.Overlay />` and `<Tour.Content />`.
+
+<auto-type-table path="./props.ts" name="TourProps" />
+
+### Step
+
+Each entry in the `steps` array.
+
+<auto-type-table path="./props.ts" name="TourStep" />
+
+### Tour.Content
+
+The card. Accepts positioning defaults and either static children, a render
+function, or the default layout.
+
+<auto-type-table path="./props.ts" name="TourContentProps" />
+
+### Tour.Overlay
+
+The dimmed backdrop with a spotlight cutout over the target.
+
+<auto-type-table path="./props.ts" name="TourOverlayProps" />
+
+### Tour.Progress
+
+Renders the step counter, e.g. "2 of 5".
+
+<auto-type-table path="./props.ts" name="TourProgressProps" />
+
+### Tour.Title / Tour.Description
+
+Give the card its accessible name and description, falling back to the step's
+`title` and `content`.
+
+### Tour.Next / Tour.Prev / Tour.Skip / Tour.Close
+
+Navigation buttons. Each runs your `onClick` first, then its action
+(`next`, `prev`, `skip`, `stop`). `Tour.Next` finishes the tour past the last
+step.
+
+### Actions
+
+`start`, `next`, `prev`, `go`, `skip`, and `stop`. Reach them through
+`actionsRef`, or anywhere inside `<Tour>` with the `useTour()` hook. `start` is
+the only action that runs while the tour is closed.
+
+<auto-type-table path="./props.ts" name="TourActions" />
+
+### Events
+
+Every lifecycle moment is reported to `onEvent`.
+
+<auto-type-table path="./props.ts" name="TourEvent" />
+
+### Slots
+
+Every rendered part carries a stable `data-slot` attribute for [styling and testing](/docs/styling#with-data-slot):
+
+| Slot | Element |
+|------|---------|
+| `tour-overlay` | `Tour.Overlay` root |
+| `tour-spotlight` | The cut-out spotlight highlight |
+| `tour-spotlight-cover` | The dimmed cover around the spotlight (when a target is resolved) |
+| `tour-overlay-hit` | Click-blocking hit-test strips around the spotlight |
+| `tour-positioner` | Positioning wrapper around the content popup |
+| `tour-content` | `Tour.Content` popup |
+| `tour-arrow` | The pointing arrow (when `showArrow` and not detached) |
+| `tour-step-content` | Wrapper around the active step's card content |
+| `tour-title` | `Tour.Title` |
+| `tour-description` | `Tour.Description` |
+| `tour-progress` | `Tour.Progress` |
+| `tour-next` | `Tour.Next` button |
+| `tour-prev` | `Tour.Prev` button (rendered from the second step onward in the default layout) |
+| `tour-skip` | `Tour.Skip` button |
+| `tour-close` | `Tour.Close` button |
 
 ## Accessibility
 

--- a/apps/www/src/content/docs/theme/colors/index.mdx
+++ b/apps/www/src/content/docs/theme/colors/index.mdx
@@ -5,7 +5,7 @@ description: Overview of the color system and semantic color tokens in Apsara.
 
 Apsara uses a semantic color system that provides meaningful, context-aware colors for your interface. Rather than using fixed color values, semantic tokens represent the intended purpose of a color—such as "primary text" or "danger background"—and automatically resolve to the appropriate value based on the active theme and style. This abstraction allows you to build consistent, themeable interfaces by focusing on what a color represents rather than what it looks like.
 
-## Foreground Colors
+## Foreground colors
 
 Foreground colors are used for text, icons, and other content elements.
 
@@ -31,7 +31,7 @@ Foreground colors are used for text, icons, and other content elements.
   ]}
 />
 
-## Background Colors
+## Background colors
 
 Background colors define surfaces and containers in your interface.
 
@@ -62,7 +62,7 @@ Background colors define surfaces and containers in your interface.
   ]}
 />
 
-## Border Colors
+## Border colors
 
 Border colors define boundaries and separators.
 
@@ -90,7 +90,7 @@ Border colors define boundaries and separators.
   ]}
 />
 
-## Overlay Colors
+## Overlay colors
 
 Overlay colors are used for modals, tooltips, and layered elements.
 
@@ -136,7 +136,7 @@ Overlay colors are used for modals, tooltips, and layered elements.
   ]}
 />
 
-## Visualization Colors
+## Visualization colors
 
 A palette of colors designed for data visualization, charts, and graphs.
 
@@ -161,6 +161,8 @@ A palette of colors designed for data visualization, charts, and graphs.
 />
 
 ## Usage
+
+Reference the tokens directly in CSS. Because they resolve per theme, the same rule works in light and dark without a second declaration.
 
 ```css
 /* Custom status indicator */
@@ -231,7 +233,7 @@ A palette of colors designed for data visualization, charts, and graphs.
 }
 ```
 
-## Best Practices
+## Best practices
 
 - **Use semantic tokens** - Prefer semantic color tokens over raw color values for consistency and theming support
 - **Match foreground with background** - Use corresponding foreground colors when placing text on semantic backgrounds (e.g., `foreground-accent-emphasis` on `background-accent-emphasis`)

--- a/apps/www/src/content/docs/theme/effects/index.mdx
+++ b/apps/www/src/content/docs/theme/effects/index.mdx
@@ -20,7 +20,7 @@ Shadow tokens create elevation and depth, helping users understand the layering 
   ]}
 />
 
-## Blur Effects
+## Blur effects
 
 Blur tokens are used for backdrop effects and creating depth through transparency.
 
@@ -35,6 +35,8 @@ Blur tokens are used for backdrop effects and creating depth through transparenc
 />
 
 ## Usage
+
+Shadow and blur tokens compose with the colour tokens. Reach for a named shadow rather than a hand-rolled `box-shadow` so elevation stays consistent across surfaces.
 
 ```css
 /* Dashboard widget with hover interaction */
@@ -98,7 +100,7 @@ Blur tokens are used for backdrop effects and creating depth through transparenc
 }
 ```
 
-## Best Practices
+## Best practices
 
 - **Use shadows sparingly** - Too many shadows can make interfaces feel cluttered
 - **Match elevation to importance** - Higher elevation shadows for more prominent elements

--- a/apps/www/src/content/docs/theme/icons/index.mdx
+++ b/apps/www/src/content/docs/theme/icons/index.mdx
@@ -210,56 +210,6 @@ provider to reach into it.
   it is worth knowing when you read an import list.
 </Callout>
 
-## API Reference
-
-### Theme props
-
-<auto-type-table path="./props.ts" name="ThemeIconProps" />
-
-### IconOptions
-
-<auto-type-table path="./props.ts" name="IconOptions" />
-
-### IconProvider
-
-`<Theme>` mounts this for you. Use it directly only if you want icon overrides
-without a theme scope. It takes the two halves of `IconOptions` as flat props.
-
-<auto-type-table path="./props.ts" name="IconProviderProps" />
-
-### createIcon
-
-```tsx
-function createIcon(name: string, Default: IconComponent): IconComponent;
-```
-
-Wraps a component as an Apsara icon: base props below the call site,
-`data-icon="<name>"`, and the provider `props`. `name` is any string —
-`IconName` covers only what Apsara ships, and only those keys can be replaced
-through `<Theme icons>`.
-
-### Types
-
-`IconProps` is `Omit<SVGProps<SVGSVGElement>, 'children'>`: every SVG attribute
-React accepts, minus `children`. In practice you pass `width`, `height`,
-`strokeWidth`, `className`, `style` or `color` — see [base props](#base-props).
-
-`IconComponent` is `ComponentType<IconProps>`, so any component with those props
-can stand in for an icon. `IconOverrides` is
-`Partial<Record<IconName, IconComponent>>`, and `IconName` is the union of the 31
-keys, so a typo in an override map is a type error.
-
-```tsx
-import { createIcon } from '@raystack/apsara';
-import type {
-  IconComponent,
-  IconName,
-  IconOptions,
-  IconOverrides,
-  IconProps
-} from '@raystack/apsara';
-```
-
 ## Server components
 
 The icons are client components, and an icon map is an object of functions. A
@@ -321,3 +271,59 @@ files that already import components, where a second import line buys nothing.
 CommonJS cannot tree-shake at all, so there the difference is unconditional:
 `require('@raystack/apsara')` loads every component module, while
 `require('@raystack/apsara/icons')` loads the icons and nothing else.
+
+## API Reference
+
+The types and components behind icon overrides. `createIcon` and the `Theme` icons prop are the two you touch directly.
+
+### Theme props
+
+The `icons` prop on `Theme`.
+
+<auto-type-table path="./props.ts" name="ThemeIconProps" />
+
+### IconOptions
+
+The object `icons` accepts — `components` replaces drawings by key, `props` applies to every icon.
+
+<auto-type-table path="./props.ts" name="IconOptions" />
+
+### IconProvider
+
+`<Theme>` mounts this for you. Use it directly only if you want icon overrides
+without a theme scope. It takes the two halves of `IconOptions` as flat props.
+
+<auto-type-table path="./props.ts" name="IconProviderProps" />
+
+### createIcon
+
+```tsx
+function createIcon(name: string, Default: IconComponent): IconComponent;
+```
+
+Wraps a component as an Apsara icon: base props below the call site,
+`data-icon="<name>"`, and the provider `props`. `name` is any string —
+`IconName` covers only what Apsara ships, and only those keys can be replaced
+through `<Theme icons>`.
+
+### Types
+
+`IconProps` is `Omit<SVGProps<SVGSVGElement>, 'children'>`: every SVG attribute
+React accepts, minus `children`. In practice you pass `width`, `height`,
+`strokeWidth`, `className`, `style` or `color` — see [base props](#base-props).
+
+`IconComponent` is `ComponentType<IconProps>`, so any component with those props
+can stand in for an icon. `IconOverrides` is
+`Partial<Record<IconName, IconComponent>>`, and `IconName` is the union of the 31
+keys, so a typo in an override map is a type error.
+
+```tsx
+import { createIcon } from '@raystack/apsara';
+import type {
+  IconComponent,
+  IconName,
+  IconOptions,
+  IconOverrides,
+  IconProps
+} from '@raystack/apsara';
+```

--- a/apps/www/src/content/docs/theme/overview/index.mdx
+++ b/apps/www/src/content/docs/theme/overview/index.mdx
@@ -80,53 +80,7 @@ Tokens follow two naming patterns:
 - [Typography](/docs/theme/typography) — font families, sizes, weights, and line heights
 - [Effects](/docs/theme/effects) — shadows and blur for depth and elevation
 
-## API Reference
-
-### Theme
-
-The `Theme` component wraps your application and manages theme state. It handles persisting the user's preference to localStorage, syncing with system preferences, and injecting the appropriate CSS variables into the document.
-
-<auto-type-table path="./props.ts" name="ThemeProps" />
-
-### useTheme
-
-The `useTheme` hook provides access to the current theme state and methods to change it. Use this to build theme toggles, read the resolved theme for conditional rendering, or sync with external systems.
-
-```tsx
-import { useTheme } from "@raystack/apsara";
-
-function ThemeToggle() {
-  const { theme, setTheme, resolvedTheme } = useTheme();
-
-  return (
-    <button onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}>
-      Toggle theme
-    </button>
-  );
-}
-```
-
-The hook accepts an optional options object to target a specific scope by its `storageKey` (see [Targeting a specific scope](#targeting-a-specific-scope)):
-
-<auto-type-table path="./props.ts" name="UseThemeOptions" />
-
-And returns:
-
-<auto-type-table path="./props.ts" name="UseThemeProps" />
-
-### ThemeSwitcher
-
-A ready-made icon button that toggles between light and dark. It calls `useTheme` internally, so it must render inside a `Theme` provider. The button is a native `<button>` with a descriptive `aria-label` ("Switch to light theme" / "Switch to dark theme"), so it works with keyboards and screen readers out of the box.
-
-<Demo data={switcherDemo} />
-
-The `size` prop sets the button's width and height in pixels:
-
-<Demo data={switcherSizeDemo} />
-
-<auto-type-table path="./props.ts" name="ThemeSwitcherProps" />
-
-## Framework Integration
+## Framework integration
 
 **HTML Attributes** — `Theme` sets data attributes on the document element for CSS targeting:
 - `data-theme` — current color scheme (`light` | `dark`)
@@ -153,7 +107,7 @@ export default function RootLayout({ children }) {
 
 The `suppressHydrationWarning` is required because the theme script modifies the HTML element before React hydrates.
 
-## Scoped Theming
+## Scoped theming
 
 Themes are not limited to the document root. Any element with a `data-theme` attribute creates an isolated theme scope — descendants resolve every design token from the nearest scoped ancestor. This enables theme preview cards, split-screen comparisons, and dark sidebars in light apps without any extra plumbing.
 
@@ -354,6 +308,8 @@ function PageThemeButton() {
 
 ### Cheat sheet
 
+Every nesting case in one table.
+
 | What you want | What to pass on the nested `Theme` |
 |---|---|
 | Section is purely styled, no own state | Don't nest. There's nothing to scope. |
@@ -363,7 +319,55 @@ function PageThemeButton() {
 | Section persists its own theme across reloads | `storageKey="some-key"` (+ optional `defaultTheme`) |
 | Flip the page theme from inside a scope | `useTheme({ storageKey: "theme" }).setTheme(…)` |
 
-### When to reach for a nested provider vs. the bare attribute
+### Nested provider vs. bare attribute
 
 - Use the **bare `data-theme` attribute** when you're already rendering a custom element and don't want another wrapper. The CSS handles everything — components inside will theme correctly.
 - Use a **nested `Theme`** when you want typed props (`forcedTheme`, `accentColor`, etc.), automatic inheritance of unspecified fields, and `useTheme()` integration.
+
+## API Reference
+
+The provider, the hook, and the ready-made switcher.
+
+### Theme
+
+The `Theme` component wraps your application and manages theme state. It handles persisting the user's preference to localStorage, syncing with system preferences, and injecting the appropriate CSS variables into the document.
+
+<auto-type-table path="./props.ts" name="ThemeProps" />
+
+### useTheme
+
+The `useTheme` hook provides access to the current theme state and methods to change it. Use this to build theme toggles, read the resolved theme for conditional rendering, or sync with external systems.
+
+```tsx
+import { useTheme } from "@raystack/apsara";
+
+function ThemeToggle() {
+  const { theme, setTheme, resolvedTheme } = useTheme();
+
+  return (
+    <button onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}>
+      Toggle theme
+    </button>
+  );
+}
+```
+
+The hook accepts an optional options object to target a specific scope by its `storageKey` (see [Targeting a specific scope](#targeting-a-specific-scope)):
+
+<auto-type-table path="./props.ts" name="UseThemeOptions" />
+
+And returns:
+
+<auto-type-table path="./props.ts" name="UseThemeProps" />
+
+### ThemeSwitcher
+
+A ready-made icon button that toggles between light and dark. It calls `useTheme` internally, so it must render inside a `Theme` provider. The button is a native `<button>` with a descriptive `aria-label` ("Switch to light theme" / "Switch to dark theme"), so it works with keyboards and screen readers out of the box.
+
+<Demo data={switcherDemo} />
+
+The `size` prop sets the button's width and height in pixels:
+
+<Demo data={switcherSizeDemo} />
+
+<auto-type-table path="./props.ts" name="ThemeSwitcherProps" />

--- a/apps/www/src/content/docs/theme/radius/index.mdx
+++ b/apps/www/src/content/docs/theme/radius/index.mdx
@@ -5,11 +5,11 @@ description: Overview of the border radius scale and style variants in Apsara.
 
 Border radius tokens control the roundness of corners throughout your interface. These tokens automatically adjust based on the active style variant—modern style uses sharp, minimal radii while traditional style uses softer, more rounded corners. By using radius tokens instead of fixed values, your custom components will seamlessly adapt when the style changes.
 
-## Radius Scale
+## Radius scale
 
 The radius scale provides 7 tokens for different levels of roundness, from subtle to fully circular.
 
-### Modern Style (Default)
+### Modern style (default)
 
 <TokenTable
   type="radius"
@@ -24,7 +24,7 @@ The radius scale provides 7 tokens for different levels of roundness, from subtl
   ]}
 />
 
-### Traditional Style
+### Traditional style
 
 When using `data-style="traditional"`, the radius values increase for a softer, more rounded appearance.
 
@@ -42,6 +42,8 @@ When using `data-style="traditional"`, the radius values increase for a softer, 
 />
 
 ## Usage
+
+Radius tokens follow the active `style` variant, so a rule written once renders sharper under `modern` and softer under `traditional`.
 
 ```css
 /* Dashboard widget container */
@@ -110,7 +112,7 @@ When using `data-style="traditional"`, the radius values increase for a softer, 
 }
 ```
 
-## Enabling Style Variants
+## Enabling style variants
 
 To switch between modern and traditional styles, set the `data-style` attribute on your root element:
 
@@ -122,7 +124,7 @@ To switch between modern and traditional styles, set the `data-style` attribute 
 <html data-style="traditional">
 ```
 
-## Best Practices
+## Best practices
 
 - **Be consistent** - Use the same radius token for similar elements throughout your application
 - **Match element size** - Use smaller radius values for smaller elements, larger values for containers

--- a/apps/www/src/content/docs/theme/spacing/index.mdx
+++ b/apps/www/src/content/docs/theme/spacing/index.mdx
@@ -32,7 +32,7 @@ Spacing values are derived from a 17-step scale, which provides fine-grained con
   ]}
 />
 
-## Semantic Groupings
+## Semantic groupings
 
 The spacing scale can be organized into semantic groups for easier selection:
 
@@ -46,6 +46,8 @@ The spacing scale can be organized into semantic groups for easier selection:
 />
 
 ## Usage
+
+Use the scale for every gap, pad, and margin. Mixing raw pixels back in is what breaks the rhythm the scale exists to hold.
 
 ```css
 /* Custom card grid layout */
@@ -88,7 +90,7 @@ The spacing scale can be organized into semantic groups for easier selection:
 }
 ```
 
-## Best Practices
+## Best practices
 
 - **Use smaller values (1-5)** for internal component spacing like padding and gaps between inline elements
 - **Use medium values (5-9)** for spacing between related components and within sections

--- a/apps/www/src/content/docs/theme/typography/index.mdx
+++ b/apps/www/src/content/docs/theme/typography/index.mdx
@@ -5,7 +5,7 @@ description: Overview of the typography system and text tokens in Apsara.
 
 Apsara provides a comprehensive typography system with carefully crafted font families, sizes, weights, and spacing. Typography tokens adapt based on the active style variant—modern style uses Inter for a clean, technical aesthetic while traditional style uses Lora and Josefin Sans for a warmer, editorial feel. Using these tokens ensures your text styling remains consistent and automatically adapts to style changes.
 
-## Font Families
+## Font families
 
 Apsara includes three font family categories for different use cases.
 
@@ -18,7 +18,7 @@ Apsara includes three font family categories for different use cases.
   ]}
 />
 
-### Available Fonts
+### Available fonts
 
 <TokenTable
   type="typography"
@@ -31,7 +31,7 @@ Apsara includes three font family categories for different use cases.
   ]}
 />
 
-## Font Weights
+## Font weights
 
 <TokenTable
   type="typography"
@@ -41,7 +41,7 @@ Apsara includes three font family categories for different use cases.
   ]}
 />
 
-## Body Text
+## Body text
 
 Font sizes, line heights, and letter spacing for body content.
 
@@ -66,7 +66,7 @@ Font sizes, line heights, and letter spacing for body content.
   ]}
 />
 
-## Title Text
+## Title text
 
 Font sizes, line heights, and letter spacing for headings and titles.
 
@@ -88,7 +88,7 @@ Font sizes, line heights, and letter spacing for headings and titles.
   ]}
 />
 
-## Monospace Text
+## Monospace text
 
 Font sizes, line heights, and letter spacing for code and technical content.
 
@@ -110,11 +110,11 @@ Font sizes, line heights, and letter spacing for code and technical content.
   ]}
 />
 
-## Style Variants
+## Style variants
 
 Apsara supports different style variants that change typography to match your design preference.
 
-### Traditional Style
+### Traditional style
 
 When using `data-style="traditional"`, the font families change to:
 
@@ -127,6 +127,8 @@ When using `data-style="traditional"`, the font families change to:
 />
 
 ## Usage
+
+Type tokens carry size, weight, and line height together. Set them as a group so a change to the scale reaches every surface at once.
 
 ```css
 /* Dashboard metric display */
@@ -193,7 +195,7 @@ When using `data-style="traditional"`, the font families change to:
 }
 ```
 
-## Best Practices
+## Best practices
 
 - **Use semantic sizing** - Match font sizes to their intended purpose (body, titles, code)
 - **Pair sizes with line heights** - Always use the corresponding line height token for each font size


### PR DESCRIPTION
Docs headings were inconsistent, and on the bigger pages they got in the way. DataView had 40 headings on one page, with Timeline's prop tables 250 lines away from the prose explaining them. Several pages had catch-all sections — `Notes`, `Important Notes`, `Features` — that collected whatever didn't fit elsewhere. And a lot of descriptions just restated their own heading:

> **Color** — The Separator component supports three colors.
> **Size** — The Separator component supports three sizes.

This settles on one section order and applies it across all 87 pages.

## Section order

`Overview` (only when the name doesn't explain it) → `Anatomy` → `Usage` → `API Reference` → `Accessibility`

Three rules underneath it:

- Two heading levels. `h4` only inside API Reference, for a sub-type directly under its parent part.
- A page splits only when a part has its own concepts, its own props and its own examples.
- One `h3` answers one question. Appearance galleries before behaviour recipes.

Usage moves above API Reference. The hero demo is static and the playground sits behind a modal, so nothing above the prop tables shows you how to use the component — you hit a wall of types before a single working example. Anatomy and API Reference also overlap 64% by name, so the old order covered the same ground twice before showing anything new.

## What changed

- **DataView split** into `index` / `list` / `timeline`. Timeline's props now sit with the prose that explains them. Server mode folds into `index` — it has no props of its own, so it doesn't meet the bar for its own page.
- **69 pages reordered.** `Examples` is gone as a heading.
- **Six catch-all `h2`s** moved to where they belong. `form`'s Usage went from 11 jumbled entries to an order that follows how you'd actually build a form.
- **~145 headings** normalised to sentence case, keeping component names, acronyms and code spans intact.
- **~80 descriptions rewritten**, with every value read from `props.ts`.

## Fixes

- Button's `colorsDemo` rendered every "Accent" swatch as `color="success"` — Accent and Success looked identical in all four variant tabs.
- Dialog's "With body and footer" was described as *"Example with header and body."*
- Navbar had `Accessibility` as both an `h3` and an `h2`, which made `#accessibility` ambiguous.
- Two broken anchor links.

## Also in here

Button gets a **"render as another element"** example. The `render` prop shipped with no demo.

`sidebar.tsx` renders a split component as a group that opens only while you're inside it, with the index row labelled "Overview" instead of repeating the component name. It's the only non-content file in the diff.

## Checks

`next build` passes, 187 static pages, all 87 docs routes prerendered. Every internal anchor link resolves. `<Demo>` and `auto-type-table` counts were diffed against `main` on every page to confirm nothing was dropped.