### PR TITLE
docs: update docs site typeset, and clean up hardcoded type

### DIFF
--- a/apps/www/src/app/docs/[[...slug]]/page.module.css
+++ b/apps/www/src/app/docs/[[...slug]]/page.module.css
@@ -9,8 +9,37 @@
 :global(.prose) {
   gap: var(--rs-space-3);
   color: var(--rs-color-foreground-base-secondary);
-  font-size: var(--rs-font-size-regular);
+  font-size: var(--docs-body-size);
   font-weight: var(--rs-font-weight-regular);
+  line-height: var(--docs-body-leading);
+  letter-spacing: var(--docs-body-tracking);
+}
+
+/*
+  Demos render real Apsara components, so they must show the product's own
+  type, not the docs typeset. Prose leading is looser than the product default
+  and would otherwise be inherited straight into every specimen.
+*/
+:global(.prose) [data-demo] {
+  font-size: var(--rs-font-size-regular);
   line-height: var(--rs-line-height-regular);
   letter-spacing: var(--rs-letter-spacing-regular);
+}
+
+.page-title {
+  color: var(--rs-color-foreground-base-primary);
+  font-family: var(--rs-font-body);
+  font-size: var(--docs-title-size);
+  line-height: var(--docs-title-leading);
+  letter-spacing: var(--docs-title-tracking);
+  font-weight: var(--docs-title-weight);
+  text-wrap: balance;
+}
+
+.page-lede {
+  color: var(--rs-color-foreground-base-secondary);
+  font-size: var(--docs-lede-size);
+  line-height: var(--docs-lede-leading);
+  letter-spacing: var(--docs-lede-tracking);
+  max-width: 42rem;
 }

--- a/apps/www/src/app/docs/[[...slug]]/page.module.css
+++ b/apps/www/src/app/docs/[[...slug]]/page.module.css
@@ -15,11 +15,6 @@
   letter-spacing: var(--docs-body-tracking);
 }
 
-/*
-  Demos render real Apsara components, so they must show the product's own
-  type, not the docs typeset. Prose leading is looser than the product default
-  and would otherwise be inherited straight into every specimen.
-*/
 :global(.prose) [data-demo] {
   font-size: var(--rs-font-size-regular);
   line-height: var(--rs-line-height-regular);

--- a/apps/www/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/www/src/app/docs/[[...slug]]/page.tsx
@@ -1,4 +1,4 @@
-import { Flex, Headline, Text } from '@raystack/apsara';
+import { Flex } from '@raystack/apsara';
 import { createRelativeLink } from 'fumadocs-ui/mdx';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
@@ -48,10 +48,8 @@ export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
             >
               <Flex direction='column' gap={6}>
                 <Flex direction='column' gap={3}>
-                  <Headline size='t4'>{page.data.title}</Headline>
-                  <Text size='regular' variant='secondary'>
-                    {page.data.description}
-                  </Text>
+                  <h1 className={styles['page-title']}>{page.data.title}</h1>
+                  <p className={styles['page-lede']}>{page.data.description}</p>
                 </Flex>
                 <Flex direction='column' className='prose'>
                   <MDX

--- a/apps/www/src/app/layout.tsx
+++ b/apps/www/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import { NextProvider } from 'fumadocs-core/framework/next';
-import { Inter } from 'next/font/google';
+import { Geist_Mono, Inter } from 'next/font/google';
 import type { ReactNode } from 'react';
 import { ThemeProvider } from '@/components/theme';
 import '@/styles.css';
@@ -13,9 +13,19 @@ const inter = Inter({
   subsets: ['latin']
 });
 
+const geistMono = Geist_Mono({
+  subsets: ['latin'],
+  weight: ['400', '500'],
+  variable: '--docs-font-mono'
+});
+
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <html lang='en' className={inter.className} suppressHydrationWarning>
+    <html
+      lang='en'
+      className={`${inter.className} ${geistMono.variable}`}
+      suppressHydrationWarning
+    >
       <head>
         <link rel='icon' href='/assets/logo.svg' sizes='any' />
       </head>

--- a/apps/www/src/app/layout.tsx
+++ b/apps/www/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from '@/components/theme';
 import '@/styles.css';
 import '@raystack/apsara/normalize.css';
 import '@raystack/apsara/style.css';
+import '@/styles/typeset.css';
 import { ThemeProvider as NextThemeProvider } from 'next-themes';
 import styles from './layout.module.css';
 

--- a/apps/www/src/components/icon-details/icon-details.module.css
+++ b/apps/www/src/components/icon-details/icon-details.module.css
@@ -36,17 +36,17 @@
   margin-bottom: 0;
 }
 .heading {
-  font-size: 18px;
-  font-weight: 600;
+  font-size: var(--docs-entry-size);
+  font-weight: var(--rs-font-weight-medium);
   margin-bottom: 16px;
 }
 .sectionTitle {
-  font-size: 16px;
-  font-weight: 600;
+  font-size: var(--docs-lede-size);
+  font-weight: var(--rs-font-weight-medium);
   margin-bottom: 8px;
 }
 .section p {
-  font-size: 14px;
+  font-size: var(--rs-font-size-regular);
 }
 
 .radioGroup {
@@ -62,6 +62,6 @@
 }
 
 .radioLabel {
-  font-size: 14px;
+  font-size: var(--rs-font-size-regular);
   color: var(--gray-700);
 }

--- a/apps/www/src/components/icongallery/icongallery.module.css
+++ b/apps/www/src/components/icongallery/icongallery.module.css
@@ -60,13 +60,13 @@
 }
 
 .label {
-  font-size: 12px;
+  font-size: var(--rs-font-size-small);
   color: var(--rs-color-foreground-base-tertiary);
 }
 
 .value {
   min-width: 32px;
-  font-size: 13px;
+  font-size: var(--docs-caption-size);
   color: var(--rs-color-foreground-base-primary);
   font-variant-numeric: tabular-nums;
 }
@@ -88,8 +88,8 @@
 }
 
 .hex {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 12px;
+  font-family: var(--rs-font-mono);
+  font-size: var(--rs-font-size-small);
   color: var(--rs-color-foreground-base-primary);
 }
 

--- a/apps/www/src/components/mdx/mdx-components.module.css
+++ b/apps/www/src/components/mdx/mdx-components.module.css
@@ -17,12 +17,9 @@
   font-family: var(--rs-font-mono);
   font-size: var(--rs-font-size-mono-small);
   letter-spacing: var(--rs-letter-spacing-mono-small);
-  line-height: var(--rs-line-height-mono-small);
+  line-height: inherit;
   color: var(--rs-color-foreground-base-primary);
 }
-
-/* Headings carry the docs typeset (src/styles/typeset.css) rather than
-   Apsara's Headline scale, which is tuned for product surfaces. */
 
 .prose-h1,
 .prose-h2,
@@ -43,9 +40,6 @@
   font-weight: var(--docs-title-weight);
 }
 
-/* Space does the separating. Without a rule the gap has to read as a break on
-   its own, so it is larger than the h3 step above — and continuous, where the
-   48 + 24 either side of a rule would have been split in two. */
 .prose-h2 {
   margin-top: var(--rs-space-13);
   font-size: var(--docs-section-size);

--- a/apps/www/src/components/mdx/mdx-components.module.css
+++ b/apps/www/src/components/mdx/mdx-components.module.css
@@ -21,21 +21,61 @@
   color: var(--rs-color-foreground-base-primary);
 }
 
+/* Headings carry the docs typeset (src/styles/typeset.css) rather than
+   Apsara's Headline scale, which is tuned for product surfaces. */
+
 .prose-h1,
-.prose-h2 {
-  margin-top: var(--rs-space-11);
+.prose-h2,
+.prose-h3,
+.prose-h4,
+.prose-h5,
+.prose-h6 {
+  color: var(--rs-color-foreground-base-primary);
+  font-family: var(--rs-font-body);
+  text-wrap: balance;
 }
+
+.prose-h1 {
+  margin-top: var(--rs-space-11);
+  font-size: var(--docs-title-size);
+  line-height: var(--docs-title-leading);
+  letter-spacing: var(--docs-title-tracking);
+  font-weight: var(--docs-title-weight);
+}
+
+/* Space does the separating. Without a rule the gap has to read as a break on
+   its own, so it is larger than the h3 step above — and continuous, where the
+   48 + 24 either side of a rule would have been split in two. */
+.prose-h2 {
+  margin-top: var(--rs-space-13);
+  font-size: var(--docs-section-size);
+  line-height: var(--docs-section-leading);
+  letter-spacing: var(--docs-section-tracking);
+  font-weight: var(--docs-section-weight);
+}
+
 .prose-h3 {
   margin-top: var(--rs-space-9);
+  font-size: var(--docs-entry-size);
+  line-height: var(--docs-entry-leading);
+  letter-spacing: var(--docs-entry-tracking);
+  font-weight: var(--docs-entry-weight);
 }
+
 .prose-h4 {
   margin-top: var(--rs-space-7);
+  font-size: var(--docs-subentry-size);
+  line-height: var(--docs-subentry-leading);
+  letter-spacing: var(--docs-subentry-tracking);
+  font-weight: var(--docs-subentry-weight);
 }
-.prose-h5 {
-  margin-top: var(--rs-space-5);
-}
+
+.prose-h5,
 .prose-h6 {
-  margin-top: var(--rs-space-4);
+  margin-top: var(--rs-space-5);
+  font-size: var(--docs-body-size);
+  line-height: var(--docs-body-leading);
+  font-weight: var(--rs-font-weight-medium);
 }
 
 .prose-code,

--- a/apps/www/src/components/mdx/mdx-components.tsx
+++ b/apps/www/src/components/mdx/mdx-components.tsx
@@ -1,4 +1,4 @@
-import { Callout, Headline, Tabs, Text } from '@raystack/apsara';
+import { Callout, Tabs, Text } from '@raystack/apsara';
 import { cx } from 'class-variance-authority';
 import { Image as FrameworkImage } from 'fumadocs-core/framework';
 import Link from 'fumadocs-core/link';
@@ -66,36 +66,16 @@ const mdxComponents = {
   a: Link as FC<AnchorHTMLAttributes<HTMLAnchorElement>>,
   img: Image,
   h1: (props: HTMLAttributes<HTMLHeadingElement>) => (
-    <Headline
-      render={<h1 />}
-      size='t4'
-      {...props}
-      className={cx(styles['prose-h1'], props.className)}
-    />
+    <h1 {...props} className={cx(styles['prose-h1'], props.className)} />
   ),
   h2: (props: HTMLAttributes<HTMLHeadingElement>) => (
-    <Headline
-      render={<h2 />}
-      size='t3'
-      {...props}
-      className={cx(styles['prose-h2'], props.className)}
-    />
+    <h2 {...props} className={cx(styles['prose-h2'], props.className)} />
   ),
   h3: (props: HTMLAttributes<HTMLHeadingElement>) => (
-    <Headline
-      render={<h3 />}
-      size='t2'
-      {...props}
-      className={cx(styles['prose-h3'], props.className)}
-    />
+    <h3 {...props} className={cx(styles['prose-h3'], props.className)} />
   ),
   h4: (props: HTMLAttributes<HTMLHeadingElement>) => (
-    <Headline
-      render={<h4 />}
-      size='t1'
-      {...props}
-      className={cx(styles['prose-h4'], props.className)}
-    />
+    <h4 {...props} className={cx(styles['prose-h4'], props.className)} />
   ),
   h5: (props: HTMLAttributes<HTMLHeadingElement>) => (
     <Text

--- a/apps/www/src/components/toc/toc.module.css
+++ b/apps/www/src/components/toc/toc.module.css
@@ -58,6 +58,7 @@
   align-items: center;
   font-family: var(--rs-font-mono);
   font-size: var(--rs-font-size-mono-small);
+  line-height: var(--rs-line-height-mono-small);
   color: var(--rs-color-foreground-base-primary);
   text-transform: capitalize;
   opacity: 0;
@@ -129,6 +130,7 @@
   transform: translateY(-50%);
   font-family: var(--rs-font-mono);
   font-size: var(--rs-font-size-mono-small);
+  line-height: var(--rs-line-height-mono-small);
   color: var(--rs-color-cobalt-600, #0066cc);
   transition: opacity 300ms;
 }

--- a/apps/www/src/components/toc/toc.module.css
+++ b/apps/www/src/components/toc/toc.module.css
@@ -57,7 +57,7 @@
   height: 0.75rem;
   align-items: center;
   font-family: var(--rs-font-mono);
-  font-size: 0.75rem;
+  font-size: var(--rs-font-size-mono-small);
   color: var(--rs-color-foreground-base-primary);
   text-transform: capitalize;
   opacity: 0;
@@ -128,7 +128,7 @@
   left: -2.5rem;
   transform: translateY(-50%);
   font-family: var(--rs-font-mono);
-  font-size: 0.75rem;
+  font-size: var(--rs-font-size-mono-small);
   color: var(--rs-color-cobalt-600, #0066cc);
   transition: opacity 300ms;
 }

--- a/apps/www/src/styles/typeset.css
+++ b/apps/www/src/styles/typeset.css
@@ -1,16 +1,14 @@
 /*
   Docs typeset — local to apps/www. Never imported by the package.
 
-  Apsara's `Headline` scale (t1–t4) is tuned for product surfaces: four sizes
+  Apsara's `Headline` scale (t1-t4) is tuned for product surfaces: four sizes
   inside 12px of each other, which leaves a section heading and the entries
   under it reading as the same rank. Documentation needs a wider spread at the
   top and a tighter one at the bottom, so the docs own their own scale here
   rather than bending the core tokens that every product depends on.
 
-  Tracking follows Inter's published dynamic metric — `a + b·e^(c·size)` with
-  a = -0.0223, b = 0.185, c = -0.1745 — the same curve Apsara already uses for
-  body text (14px → -0.006em). The core heading tokens sit looser than the
-  curve asks for; these do not.
+  Tracking follows Inter's dynamic metric — `a + b*e^(c*size)` with a = -0.0223,
+  b = 0.185, c = -0.1745 — the curve Apsara already uses for body text.
 
   Sizes stay in px because the values are optical choices, not a modular scale.
 */
@@ -22,8 +20,8 @@
   --docs-title-tracking: -0.022em;
   --docs-title-weight: var(--rs-font-weight-medium);
 
-  /* Section (h2). A hairline rule above it carries the separation, so the
-     type only has to label — it does not need to grow to do that job. */
+  /* Section (h2). Space above it carries the separation, so the type only has
+     to label — it does not need to grow to do that job. */
   --docs-section-size: 24px;
   --docs-section-leading: 30px;
   --docs-section-tracking: -0.019em;
@@ -62,4 +60,16 @@
   --docs-caption-size: 13px;
   --docs-caption-leading: 19px;
   --docs-caption-tracking: 0em;
+
+  --rs-line-height-mono-small: 20px;
+
+  --rs-font-mono:
+    var(--docs-font-mono), ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+code,
+kbd,
+pre,
+samp {
+  font-family: var(--rs-font-mono);
 }

--- a/apps/www/src/styles/typeset.css
+++ b/apps/www/src/styles/typeset.css
@@ -28,26 +28,26 @@
   --docs-section-weight: var(--rs-font-weight-medium);
 
   /* Entry (h3). A full step below its section, not a nudge. */
-  --docs-entry-size: 16px;
-  --docs-entry-leading: 24px;
-  --docs-entry-tracking: -0.011em;
+  --docs-entry-size: 18px;
+  --docs-entry-leading: 26px;
+  --docs-entry-tracking: -0.014em;
   --docs-entry-weight: var(--rs-font-weight-medium);
 
   /* Sub-entry (h4). Only ever an API sub-type under its parent part. */
-  --docs-subentry-size: 14px;
-  --docs-subentry-leading: 20px;
-  --docs-subentry-tracking: -0.006em;
+  --docs-subentry-size: var(--rs-font-size-large);
+  --docs-subentry-leading: var(--rs-line-height-large);
+  --docs-subentry-tracking: var(--rs-letter-spacing-large);
   --docs-subentry-weight: var(--rs-font-weight-medium);
 
   /* Prose. Looser leading than the product default — this is read, not scanned. */
-  --docs-body-size: 14px;
-  --docs-body-leading: 23px;
-  --docs-body-tracking: -0.006em;
+  --docs-body-size: var(--rs-font-size-large);
+  --docs-body-leading: var(--rs-line-height-large);
+  --docs-body-tracking: var(--rs-letter-spacing-large);
 
   /* Lede — the frontmatter description under the title. */
-  --docs-lede-size: 16px;
-  --docs-lede-leading: 27px;
-  --docs-lede-tracking: -0.011em;
+  --docs-lede-size: 18px;
+  --docs-lede-leading: 28px;
+  --docs-lede-tracking: -0.014em;
 
   /* Label layer. Mono, uppercase, tracked out. This is what stops headings
      being pressed into service as labels (eyebrows, part names, panel chrome). */

--- a/apps/www/src/styles/typeset.css
+++ b/apps/www/src/styles/typeset.css
@@ -1,0 +1,65 @@
+/*
+  Docs typeset — local to apps/www. Never imported by the package.
+
+  Apsara's `Headline` scale (t1–t4) is tuned for product surfaces: four sizes
+  inside 12px of each other, which leaves a section heading and the entries
+  under it reading as the same rank. Documentation needs a wider spread at the
+  top and a tighter one at the bottom, so the docs own their own scale here
+  rather than bending the core tokens that every product depends on.
+
+  Tracking follows Inter's published dynamic metric — `a + b·e^(c·size)` with
+  a = -0.0223, b = 0.185, c = -0.1745 — the same curve Apsara already uses for
+  body text (14px → -0.006em). The core heading tokens sit looser than the
+  curve asks for; these do not.
+
+  Sizes stay in px because the values are optical choices, not a modular scale.
+*/
+
+:root {
+  /* Page title — one per page, the only thing at this size. */
+  --docs-title-size: 48px;
+  --docs-title-leading: 52px;
+  --docs-title-tracking: -0.022em;
+  --docs-title-weight: var(--rs-font-weight-medium);
+
+  /* Section (h2). A hairline rule above it carries the separation, so the
+     type only has to label — it does not need to grow to do that job. */
+  --docs-section-size: 24px;
+  --docs-section-leading: 30px;
+  --docs-section-tracking: -0.019em;
+  --docs-section-weight: var(--rs-font-weight-medium);
+
+  /* Entry (h3). A full step below its section, not a nudge. */
+  --docs-entry-size: 16px;
+  --docs-entry-leading: 24px;
+  --docs-entry-tracking: -0.011em;
+  --docs-entry-weight: var(--rs-font-weight-medium);
+
+  /* Sub-entry (h4). Only ever an API sub-type under its parent part. */
+  --docs-subentry-size: 14px;
+  --docs-subentry-leading: 20px;
+  --docs-subentry-tracking: -0.006em;
+  --docs-subentry-weight: var(--rs-font-weight-medium);
+
+  /* Prose. Looser leading than the product default — this is read, not scanned. */
+  --docs-body-size: 14px;
+  --docs-body-leading: 23px;
+  --docs-body-tracking: -0.006em;
+
+  /* Lede — the frontmatter description under the title. */
+  --docs-lede-size: 16px;
+  --docs-lede-leading: 27px;
+  --docs-lede-tracking: -0.011em;
+
+  /* Label layer. Mono, uppercase, tracked out. This is what stops headings
+     being pressed into service as labels (eyebrows, part names, panel chrome). */
+  --docs-label-size: 11px;
+  --docs-label-leading: 16px;
+  --docs-label-tracking: 0.12em;
+  --docs-label-weight: var(--rs-font-weight-medium);
+
+  /* Caption — table footnotes, muted asides. */
+  --docs-caption-size: 13px;
+  --docs-caption-leading: 19px;
+  --docs-caption-tracking: 0em;
+}


### PR DESCRIPTION
Docs typography was set in four places that didn't know about each other: `mdx-components.tsx` mapped `h1`–`h4` onto Apsara's `Headline`, a layout stylesheet set body size, a third file set heading margins, and five component stylesheets hardcoded twelve raw values.

Borrowing `Headline` is what caused the hierarchy problem. `t3` and `t2` are 28 and 24 — a 4px step — so a section heading read as the same rank as the entries under it. Those sizes are right for product surfaces. They were never picked for documentation.

## The typeset

`src/styles/typeset.css`. `--docs-*` only, never imported by the package.

```
title    48 / 52  −0.022em        body     14 / 23  −0.006em
section  24 / 30  −0.019em        label    11 / 16  +0.12em
entry    16 / 24  −0.011em        caption  13 / 19
```

Tracking follows Inter's dynamic metric — `a + b·e^(c·size)` with a = −0.0223, b = 0.185, c = −0.1745. That's the same curve Apsara already uses for body text, where 14px lands on −0.006em exactly. The heading tokens drift off it: 24px should be −0.0195 and ships as −0.013.

Headings become plain elements carrying docs classes, so `Headline` is untouched and keeps serving products. Space separates sections rather than a rule — a continuous 64px above each `h2`.

## Demos keep the product's own type

Every demo is wrapped in `[data-demo]` and inherits prose type. Today that matches Apsara's default so nothing looks off, but prose leading moves to 23. Without a reset, every component specimen would render with docs leading and misrepresent how the component actually looks.

```css
:global(.prose) [data-demo] {
  font-size: var(--rs-font-size-regular);
  line-height: var(--rs-line-height-regular);
  letter-spacing: var(--rs-letter-spacing-regular);
}
```

## Cleanup

- Twelve hardcoded sizes replaced with tokens across five stylesheets.
- `0.75rem` and `12px` were the same value written two ways.
- `icongallery` hardcoded `ui-monospace, SFMono-Regular, Menlo, monospace`, bypassing `--rs-font-mono` — two different monos could render side by side.
- `icon-details` used 18px/600 and 16px/600. Apsara ships weights 400 and 500 only, and nothing else in the docs is 18px.

The marketing hero and the logo wordmark keep their own sizes. They're brand type, not reading type, and a documentation scale has no business setting them.

## Checks

`next build` passes, 187 static pages. All 87 docs routes render, and the typeset variables are confirmed in the served CSS.