### PR TITLE
fix(grid): keep `area` from being cleared by empty longhands

### DIFF
--- a/packages/raystack/components/grid/__tests__/grid.test.tsx
+++ b/packages/raystack/components/grid/__tests__/grid.test.tsx
@@ -1,8 +1,10 @@
 import { render } from '@testing-library/react';
+import { ReactElement } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import gapStyles from '~/shared/gap/gap.module.css';
 import { Grid } from '../grid';
 import styles from '../grid.module.css';
+import { GridItem } from '../grid-item';
 
 describe('Grid', () => {
   describe('Basic Rendering', () => {
@@ -199,6 +201,68 @@ describe('Grid', () => {
       );
       const grid = container.querySelector('[data-testid="test-grid"]');
       expect(grid).toBeInTheDocument();
+    });
+  });
+
+  describe('Item', () => {
+    const itemOf = (ui: ReactElement) =>
+      render(ui).container.querySelector(
+        '[data-slot="grid-item"]'
+      ) as HTMLElement;
+
+    it('places an item with area', () => {
+      expect(itemOf(<GridItem area='nav'>nav</GridItem>)).toHaveStyle({
+        gridArea: 'nav'
+      });
+    });
+
+    it('keeps area when a custom style is also passed', () => {
+      const item = itemOf(
+        <GridItem area='nav' style={{ padding: '8px' }}>
+          nav
+        </GridItem>
+      );
+      expect(item).toHaveStyle({ gridArea: 'nav', padding: '8px' });
+    });
+
+    it('renders start and end lines', () => {
+      expect(
+        itemOf(
+          <GridItem colStart={2} colEnd={4} rowStart={1} rowEnd={3}>
+            cell
+          </GridItem>
+        )
+      ).toHaveStyle({
+        gridColumnStart: '2',
+        gridColumnEnd: '4',
+        gridRowStart: '1',
+        gridRowEnd: '3'
+      });
+    });
+
+    it('renders spans', () => {
+      expect(
+        itemOf(
+          <GridItem colSpan={3} rowSpan={2}>
+            cell
+          </GridItem>
+        )
+      ).toHaveStyle({ gridColumn: 'span 3', gridRow: 'span 2' });
+    });
+
+    it('renders self alignment', () => {
+      expect(
+        itemOf(
+          <GridItem justifySelf='center' alignSelf='end'>
+            cell
+          </GridItem>
+        )
+      ).toHaveStyle({ justifySelf: 'center', alignSelf: 'end' });
+    });
+
+    it('sets no grid properties when no positioning props are given', () => {
+      const item = itemOf(<GridItem>cell</GridItem>);
+      expect(item.getAttribute('style')).toBeNull();
     });
   });
 });

--- a/packages/raystack/components/grid/grid-item.tsx
+++ b/packages/raystack/components/grid/grid-item.tsx
@@ -1,4 +1,5 @@
 import { mergeProps, useRender } from '@base-ui/react';
+import { CSSProperties } from 'react';
 import { AlignType } from './types';
 
 type GridItemProps = useRender.ComponentProps<'div'> & {
@@ -28,18 +29,23 @@ export function GridItem({
   ref,
   ...props
 }: GridItemProps) {
-  const gridItemStyle = {
-    gridArea: area,
-    gridColumnStart: colStart,
-    gridColumnEnd: colEnd,
-    gridRowStart: rowStart,
-    gridRowEnd: rowEnd,
-    gridColumn: colSpan ? `span ${colSpan}` : undefined,
-    gridRow: rowSpan ? `span ${rowSpan}` : undefined,
-    justifySelf,
-    alignSelf,
-    ...style
-  };
+  // `gridArea` is a shorthand. React writes `undefined` entries as an empty
+  // value, and clearing any grid longhand after it also clears the shorthand,
+  // so only the properties that were actually set are passed through.
+  const gridItemStyle = Object.fromEntries(
+    Object.entries({
+      gridArea: area,
+      gridColumnStart: colStart,
+      gridColumnEnd: colEnd,
+      gridRowStart: rowStart,
+      gridRowEnd: rowEnd,
+      gridColumn: colSpan ? `span ${colSpan}` : undefined,
+      gridRow: rowSpan ? `span ${rowSpan}` : undefined,
+      justifySelf,
+      alignSelf,
+      ...style
+    }).filter(([, value]) => value !== undefined)
+  ) as CSSProperties;
 
   const gridItemProps = { 'data-slot': 'grid-item', style: gridItemStyle };
 


### PR DESCRIPTION
`<Grid.Item area="nav">` had no effect. The item rendered with no grid placement at all.

## Cause

`Grid.Item` built its inline style like this:

```js
{
  gridArea: area,
  gridColumnStart: colStart,
  gridColumnEnd: colEnd,
  gridRowStart: rowStart,
  gridRowEnd: rowEnd,
  gridColumn: colSpan ? `span ${colSpan}` : undefined,
  gridRow: rowSpan ? `span ${rowSpan}` : undefined,
  ...
}
```

`grid-area` is a shorthand for the four line properties. React writes a style key set to `undefined` as an empty value, and clearing a grid longhand also clears the shorthand that was set before it. So passing only `area` set `grid-area`, then the six `undefined` longhands that follow wiped it back off.

`colSpan` and `rowSpan` always worked because they sit last in the object, with nothing after them to clear.

## Fix

Build the style object from the properties that were actually set, so nothing is written as empty.

## Testing

jsdom does not model the shorthand reset. The old and new code serialise identically there, so no unit test can catch this — I confirmed that by reverting the fix and watching the suite still pass. Verified in Chrome instead: an item with `area="nav"` inside a three-row `templateAreas` grid now measures 140x154 and spans all three rows, where before it collapsed into a single cell.

`Grid.Item` had no tests at all, so this adds coverage for `area`, start and end lines, spans, and self alignment. They document the behaviour rather than guard this specific regression.

Full package suite passes: 2713 tests.