### PR TITLE
docs: improve content and punctuation

### DIFF
--- a/apps/www/src/app/docs/[[...slug]]/page.module.css
+++ b/apps/www/src/app/docs/[[...slug]]/page.module.css
@@ -65,7 +65,7 @@
   /*
     The rail's inner edge, matching the one on the sidebar. It starts below the
     navbar rather than at the top of the screen, because above that line the
-    navbar is one strip running the width of the article — there is nothing
+    navbar is one strip running the width of the article, and there is nothing
     there for the rule to divide.
   */
   border-left: var(--docs-rule);

--- a/apps/www/src/app/examples/page.tsx
+++ b/apps/www/src/app/examples/page.tsx
@@ -8,7 +8,7 @@ export const metadata = {
  * Bare examples landing page.
  *
  * `/examples` is a manual-QA harness for trying Apsara components in a
- * full-page context — the kind of thing the small doc demos can't show.
+ * full-page context, the kind of thing the small doc demos can't show.
  * It is not linked from the public site.
  *
  * To add an example, drop a new route folder next to this file, e.g.

--- a/apps/www/src/app/examples/timeline-stress/page.tsx
+++ b/apps/www/src/app/examples/timeline-stress/page.tsx
@@ -20,7 +20,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
  * readout counts what is actually in the DOM and times the frames the browser
  * spends while scrolling, which is the number jsdom cannot produce.
  *
- * Toggle `virtualized` off at 10k to see the difference — and expect the tab
+ * Toggle `virtualized` off at 10k to see the difference, and expect the tab
  * to struggle, which is the point.
  */
 
@@ -46,13 +46,13 @@ const isoDay = (ms: number) => new Date(ms).toISOString().slice(0, 10);
 /**
  * Hoisted so the reference is stable. The timeline memoizes its resolved
  * markers on this prop, and an inline literal would invalidate that memo on
- * every commit — churn this page would then report as its own frame cost.
+ * every commit, churn this page would then report as its own frame cost.
  */
 const MARKERS: TimelineMarker[] = [
   { date: '2025-07-01', label: 'H2', variant: 'accent' }
 ];
 
-/** Seeded LCG — the same row count always renders the same canvas. */
+/** Seeded LCG, so the same row count always renders the same canvas. */
 function seededRandom(seed: number) {
   let state = seed;
   return () => {
@@ -141,7 +141,7 @@ interface Stats {
   /**
    * Height of a single gridline. These are pinned `top: 0; bottom: 0`, so
    * unclamped they are as tall as the whole canvas and their rasterization
-   * cost tracks the domain rather than the viewport — the dominant scroll cost
+   * cost tracks the domain rather than the viewport, the dominant scroll cost
    * before the clamp landed. Worth watching directly: it should stay near the
    * pane height, not the canvas height.
    */
@@ -150,7 +150,7 @@ interface Stats {
 
 /**
  * Worst frame over the last second of scrolling. A mean would hide exactly
- * what matters — one 200ms frame is a visible stall no average survives.
+ * what matters: one 200ms frame is a visible stall no average survives.
  *
  * Takes the element rather than a ref: the pane is found by query after the
  * timeline paints, and assigning a ref does not re-run an effect, so a
@@ -228,8 +228,8 @@ export default function TimelineStressPage() {
   );
 
   /**
-   * The card memo compares `renderCard` by identity, so an inline arrow — what
-   * a consumer writes by default — makes every mounted card re-render on every
+   * The card memo compares `renderCard` by identity, so an inline arrow, which
+   * a consumer writes by default, makes every mounted card re-render on every
    * commit. This toggle isolates that cost from the canvas's own.
    */
   const memoizedRenderCard = useCallback(
@@ -243,7 +243,7 @@ export default function TimelineStressPage() {
   // a stale canvas would otherwise linger under the new settings.
   const runKey = `${rowCount}-${domainDays}-${virtualized}-${onePerRow}-${grouped}`;
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: `runKey` isn't read here — it's the remount signal, and re-running on it is the point.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `runKey` isn't read here; it's the remount signal, and re-running on it is the point.
   useEffect(() => {
     const start = performance.now();
     // After paint, so the number covers layout of what actually mounted.
@@ -273,7 +273,7 @@ export default function TimelineStressPage() {
       });
     });
     return () => cancelAnimationFrame(id);
-    // Re-measure whenever the run changes — `runKey` also remounts the view.
+    // Re-measure whenever the run changes, since `runKey` also remounts the view.
   }, [runKey]);
 
   const stat = (label: string, value: string | number) => (

--- a/apps/www/src/components/dataview-demo.tsx
+++ b/apps/www/src/components/dataview-demo.tsx
@@ -454,7 +454,7 @@ export function DataViewGroupingDemo() {
 }
 
 // ---------------------------------------------------------------------------
-// Virtualized + grouping + sticky header — exercises the combined path that
+// Virtualized + grouping + sticky header, exercising the combined path that
 // uses the anchor pattern (single sticky element whose content swaps as you
 // scroll past each group's offset).
 // ---------------------------------------------------------------------------
@@ -527,7 +527,7 @@ export function DataViewLoadingDemo() {
 }
 
 // ---------------------------------------------------------------------------
-// Per-view fields override demo — Email hidden in the List view only.
+// Per-view fields override demo: Email hidden in the List view only.
 // ---------------------------------------------------------------------------
 
 export function DataViewPerViewFieldsDemo() {
@@ -583,7 +583,7 @@ export function DataViewPerViewFieldsDemo() {
 }
 
 // ---------------------------------------------------------------------------
-// Row selection demo — unmanaged checkbox column + a FloatingActions bar.
+// Row selection demo: unmanaged checkbox column + a FloatingActions bar.
 // ---------------------------------------------------------------------------
 
 const selectionColumn: DataViewListColumn<Person> = {
@@ -689,7 +689,7 @@ type Task = {
   status: 'todo' | 'active' | 'done';
   priority: 'High' | 'Medium' | 'Low';
   /* Priority as a number. Sorting the label alphabetically gives High, Low,
-     Medium — this is what "sort by priority" has to mean to be useful, and it
+     Medium. This is what "sort by priority" has to mean to be useful, and it
      is what the sort-value lane timeline lanes on. */
   rank: 1 | 2 | 3;
   start: string;
@@ -802,7 +802,7 @@ const taskFields: DataViewField<Task>[] = [
     filterable: true,
     filterType: 'select',
     hideable: true,
-    // groupOrder ranks the sections when grouping by priority — text sort
+    // groupOrder ranks the sections when grouping by priority, where text sort
     // would give High, Low, Medium.
     groupable: true,
     showGroupCount: true,
@@ -849,7 +849,7 @@ const TASK_STATUS_BADGE: Record<
   done: 'success'
 };
 
-/* The card interior is entirely consumer-owned — the Timeline only positions
+/* The card interior is entirely consumer-owned. The Timeline only positions
    the wrapper. `context.collapsed` flags spans narrower than `minCardWidth`. */
 function TaskCard({
   task,
@@ -859,7 +859,7 @@ function TaskCard({
   context: TimelineCardContext;
 }) {
   // Card height is content-driven (the wrapper auto-measures, like
-  // DataView.List rows) — fix it here so collapsed stubs match full cards.
+  // DataView.List rows), so fix it here and collapsed stubs match full cards.
   const chrome: React.CSSProperties = {
     height: 64,
     boxSizing: 'border-box',
@@ -1031,7 +1031,7 @@ export function DataViewTimelineDemo() {
             </Button>
             {/* Sort can't move a card horizontally (x is time) and `auto`
                 packing is chronological, so Ordering is hidden. Grouping is
-                left in: it renders swim-lane sections — try Team or Status. */}
+                left in: it renders swim-lane sections; try Team or Status. */}
             <DataView.DisplayControls hideOrdering />
           </Flex>
         </DataView.Toolbar>
@@ -1063,7 +1063,7 @@ export function DataViewTimelineDemo() {
 }
 
 /* ── Grouped timeline demo (swim-lane sections) ────────────────────────────
-   `group_by` in the query is the only wiring grouping needs — the timeline
+   `group_by` in the query is the only wiring grouping needs. The timeline
    consumes the same group rows `DataView.List` renders as section headers, so
    labels, order, and counts match between the two views. Packing runs per
    section, and each band pins under the axis while its section is in view. */
@@ -1123,7 +1123,7 @@ export function DataViewTimelineSortValueLaneDemo() {
       >
         <DataView.Toolbar>
           <DataView.Filters />
-          {/* Ordering stays visible — it repositions and rebuilds lanes. */}
+          {/* Ordering stays visible, and repositions and rebuilds lanes. */}
           <DataView.DisplayControls />
         </DataView.Toolbar>
         <Flex

--- a/apps/www/src/components/demo/demo.tsx
+++ b/apps/www/src/components/demo/demo.tsx
@@ -63,7 +63,7 @@ export default function Demo(props: DemoProps) {
   const {
     data,
     // `...Apsara` carries the 31 icons Apsara publishes, so none of those needs
-    // its own entry — and nothing below may repeat one of their keys, because a
+    // its own entry, and nothing below may repeat one of their keys, because a
     // later key shadows the spread. A demo that needs any other glyph names a
     // lucide component from the block above and sizes it at the call site,
     // which is exactly what an application does.

--- a/apps/www/src/components/docs/search.tsx
+++ b/apps/www/src/components/docs/search.tsx
@@ -42,8 +42,8 @@ type SearchItems = {
 };
 
 /* Map known page slugs to icons; everything else falls back to a generic one. */
-// Section glyphs. None of these is an icon Apsara publishes — the set holds
-// only what Apsara's own components draw — so they come from lucide directly
+// Section glyphs. None of these is an icon Apsara publishes. The set holds
+// only what Apsara's own components draw, so they come from lucide directly
 // and are sized at the call site.
 const PAGE_ICONS: Record<string, typeof BookOpen> = {
   docs: BookOpen,
@@ -156,7 +156,7 @@ export default function DocsSearch({ pageTree }: { pageTree: Root }) {
 
   const items = !isSearching ? defaultItems : searchResults;
 
-  /* The `items` prop opts Command out of built-in filtering/unwrapping —
+  /* The `items` prop opts Command out of built-in filtering/unwrapping,
      results are pre-filtered by fumadocs and the grouped layout stays intact. */
   const itemValues = useMemo(
     () =>
@@ -233,7 +233,7 @@ export default function DocsSearch({ pageTree }: { pageTree: Root }) {
                 <EmptyState
                   variant='empty1'
                   heading='No result found'
-                  subHeading='The keyword you’re searching for isn’t in the document—try using a different term.'
+                  subHeading='The keyword you’re searching for isn’t in the document. Try a different term.'
                   icon={<WarningIcon />}
                 />
               )}

--- a/apps/www/src/components/docs/sidebar.module.css
+++ b/apps/www/src/components/docs/sidebar.module.css
@@ -28,7 +28,7 @@
 .itemText {
   overflow: visible;
 }
-/* Plain links: primary text in every state, no grounds — weight alone marks
+/* Plain links: primary text in every state, no grounds. Weight alone marks
    hover and the current page. */
 .main .item {
   color: var(--rs-color-foreground-base-primary);

--- a/apps/www/src/components/docs/sidebar.tsx
+++ b/apps/www/src/components/docs/sidebar.tsx
@@ -26,7 +26,7 @@ function renderNode(node: Node, pathname: string): ReactNode {
     node.children.length > 0
   ) {
     // A section documented across several pages. It renders like every other
-    // section — always open — with the index page listed first under its own
+    // section, always open, with the index page listed first under its own
     // title.
     return (
       <Sidebar.Group

--- a/apps/www/src/components/icongallery/icongallery.tsx
+++ b/apps/www/src/components/icongallery/icongallery.tsx
@@ -18,7 +18,7 @@ import styles from './icongallery.module.css';
 // the size, stroke and colour controls apply to all of them.
 //
 // The grid itself is plain elements: the icons are what the page documents, so
-// their surroundings should not compete with them. The toolbar does use Apsara —
+// their surroundings should not compete with them. The toolbar does use Apsara,
 // the colour popover is our ColorPicker, and the names come from our Tooltip.
 
 type IconEntry = {
@@ -151,7 +151,7 @@ export function IconGallery() {
           <Popover>
             <Popover.Trigger className={styles.color}>
               {/* Unset falls back to `currentColor` in CSS, which is what the
-                  icons themselves inherit — so the swatch stays honest. */}
+                  icons themselves inherit, so the swatch stays honest. */}
               <span
                 className={styles.swatch}
                 style={color ? { background: color } : undefined}
@@ -184,7 +184,7 @@ export function IconGallery() {
             aria-label='Reset to the Apsara defaults'
           >
             {/* lucide direct, because a reset arrow is not a key the set
-                publishes — so it needs the size and stroke Apsara's icons get
+                publishes, so it needs the size and stroke Apsara's icons get
                 for free. */}
             <RotateCcw size={16} strokeWidth={1.5} />
           </button>

--- a/apps/www/src/components/tour-demo.tsx
+++ b/apps/www/src/components/tour-demo.tsx
@@ -82,7 +82,7 @@ export default function TourDemo() {
         </Text>
         <Text size='small' variant='secondary'>
           Four steps: a centered welcome, then the search box, analytics, and
-          notifications — each anchored and spotlighted.
+          notifications, each anchored and spotlighted.
         </Text>
         <Button onClick={() => actionsRef.current?.start()}>
           <Rocket size={16} strokeWidth={1.5} /> Start tour

--- a/apps/www/src/content/docs/(overview)/getting-started.mdx
+++ b/apps/www/src/content/docs/(overview)/getting-started.mdx
@@ -190,6 +190,6 @@ function ThemeToggle() {
 
 ## Next steps
 
-- [Theme Overview](/docs/theme/overview) — Configure colors, spacing, and style variants
-- [Button](/docs/components/button) — Start with a common component
-- [DataView](/docs/dataview) — Build data-rich interfaces
+- [Theme Overview](/docs/theme/overview): configure colors, spacing, and style variants
+- [Button](/docs/components/button): start with a common component
+- [DataView](/docs/dataview): build data-rich interfaces

--- a/apps/www/src/content/docs/(overview)/index.mdx
+++ b/apps/www/src/content/docs/(overview)/index.mdx
@@ -7,13 +7,13 @@ Apsara is an open-source React component library that provides enterprise-grade,
 
 ## Why Apsara?
 
-**Accessibility first** — Every component is built on proven primitives that handle ARIA attributes, focus management, and keyboard navigation correctly. You get accessible UI without the extra work.
+**Accessibility first.** Every component is built on proven primitives that handle ARIA attributes, focus management, and keyboard navigation correctly. You get accessible UI without the extra work.
 
-**Consistent design language** — A unified token system keeps the look consistent across your application. Colors, spacing, typography, and effects all follow predictable patterns that adapt automatically to light and dark modes.
+**Consistent design language.** A unified token system keeps the look consistent across your application. Colors, spacing, typography, and effects all follow predictable patterns that adapt automatically to light and dark modes.
 
-**Production ready** — Components are designed for real-world applications: data tables with sorting and filtering, command palettes, multi-select comboboxes, and complex form controls that handle edge cases gracefully.
+**Production ready.** Components are designed for real-world applications: data tables with sorting and filtering, command palettes, multi-select comboboxes, and complex form controls that handle edge cases gracefully.
 
-**Minimal footprint** — No runtime CSS-in-JS. Styles are vanilla CSS with semantic tokens, keeping your bundle lean and your performance predictable.
+**Minimal footprint.** No runtime CSS-in-JS. Styles are vanilla CSS with semantic tokens, keeping your bundle lean and your performance predictable.
 
 ## Components
 
@@ -57,14 +57,14 @@ See the [Theme Overview](/docs/theme/overview) for complete documentation.
 
 Apsara is built with:
 
-- **[Base UI](https://base-ui.com/)** — Headless UI components from MUI
-- **[TanStack Table](https://tanstack.com/table)** — Data table utilities
-- **[class-variance-authority](https://cva.style/)** — Type-safe component variants
-- **TypeScript** — Full type definitions for all components and props
+- **[Base UI](https://base-ui.com/)**: headless UI components from MUI
+- **[TanStack Table](https://tanstack.com/table)**: data table utilities
+- **[class-variance-authority](https://cva.style/)**: type-safe component variants
+- **TypeScript**: full type definitions for all components and props
 
 ## Next steps
 
-- [Getting Started](/docs/getting-started) — Install Apsara and build your first component
-- [Styling](/docs/styling) — Learn how to style and customize components
-- [Theme Overview](/docs/theme/overview) — Learn about the theming system
-- [Components](/docs/components/button) — Explore the component library
+- [Getting Started](/docs/getting-started): install Apsara and build your first component
+- [Styling](/docs/styling): style and customize components
+- [Theme Overview](/docs/theme/overview): how the theming system works
+- [Components](/docs/components/button): browse the component library

--- a/apps/www/src/content/docs/(overview)/styling.mdx
+++ b/apps/www/src/content/docs/(overview)/styling.mdx
@@ -3,7 +3,7 @@ title: Styling
 description: How to style and customize Apsara components in your application.
 ---
 
-Apsara uses vanilla CSS with CSS custom properties (tokens) for all styling. There is no runtime CSS-in-JS — styles are static, scoped, and predictable. This guide covers the recommended ways to customize components and build your own styled elements.
+Apsara uses vanilla CSS with CSS custom properties (tokens) for all styling. There is no runtime CSS-in-JS, so styles are static, scoped, and predictable. This guide covers the recommended ways to customize components and build your own styled elements.
 
 ## Using design tokens
 
@@ -86,7 +86,7 @@ Common data attributes include `data-open`, `data-closed`, `data-active`, `data-
 
 ### With data-slot
 
-Every part a component renders carries a `data-slot` attribute — a stable, public identifier for that element. Use it to style inner parts that have no `className` prop of their own, without depending on Apsara's internal (hashed) class names:
+Every part a component renders carries a `data-slot` attribute, a stable public identifier for that element. Use it to style inner parts that have no `className` prop of their own, without depending on Apsara's internal (hashed) class names:
 
 ```css
 /* Tint the remove button inside every filter chip */
@@ -111,7 +111,7 @@ Slot names follow one convention:
 - Subparts extend the prefix: `data-view-filter-summary-clear`.
 - The same part keeps the same name everywhere it appears (loader cells in `DataView.List` reuse `data-view-list-cell`).
 
-Slot names are covered by semver — renaming or removing one is a breaking change, so selectors written against them are safe to keep. This is different from state attributes like `data-open` above: state attributes tell you *how* an element currently is, `data-slot` tells you *what* it is.
+Slot names are covered by semver, so renaming or removing one is a breaking change, so selectors written against them are safe to keep. This is different from state attributes like `data-open` above: state attributes tell you *how* an element currently is, `data-slot` tells you *what* it is.
 
 Combine them freely:
 
@@ -126,7 +126,7 @@ Slots also make reliable selectors for tests (`querySelector('[data-slot="search
 
 ### Styling based on what a component contains
 
-Because every part carries its own slot, a parent can change its own styling based on which children are present — no prop needed to signal it. CSS's `:has()` reaches into descendants:
+Because every part carries its own slot, a parent can change its own styling based on which children are present, with no prop needed to signal it. CSS's `:has()` reaches into descendants:
 
 ```css
 /* A filter bar that's tighter when it has no chips yet */
@@ -154,7 +154,7 @@ With Tailwind's arbitrary variants, the same thing reads as a utility class inst
 </Dialog.Footer>
 ```
 
-This is the same technique as the state-based selectors above (`data-[state=open]:...`) — `data-slot` just gives you a target that's stable across releases instead of one tied to internal markup.
+This is the same technique as the state-based selectors above (`data-[state=open]:...`), except that `data-slot` gives you a target that's stable across releases instead of one tied to internal markup.
 
 Coverage: every Apsara component exposes `data-slot` on every element it renders. Each component's docs page lists its slot names.
 

--- a/apps/www/src/content/docs/(overview)/upgrading.mdx
+++ b/apps/www/src/content/docs/(overview)/upgrading.mdx
@@ -4,10 +4,10 @@ description: Breaking changes in each Apsara release, and the steps to move your
 ---
 
 One section per release, newest first, with only the changes that need action
-from you. The full record of every release — features and fixes included — is
+from you. The full record of every release, features and fixes included, is
 on [GitHub releases](https://github.com/raystack/apsara/releases).
 
-## 1.6 — lucide replaces the radix icons
+## 1.6: lucide replaces the radix icons
 
 Apsara used to draw its icons with [`@radix-ui/react-icons`](https://www.radix-ui.com/icons).
 Since 1.6 it draws them with [lucide](https://lucide.dev), behind stable keys
@@ -22,7 +22,7 @@ names `@raystack/apsara/icons` exports have changed.
 npm install lucide-react
 ```
 
-The range is wide — `>=0.500.0 <1.0.0` — so your app picks the version. If a
+The range is wide, `>=0.500.0 <1.0.0`, so your app picks the version. If a
 lucide release changes a drawing you care about, replace that one icon (step 5)
 rather than pinning the whole library.
 
@@ -59,12 +59,12 @@ names are gone.
 
 Two names survive, both with a new drawing:
 
-- `CoPilotIcon` — lucide `Sparkles` in place of the in-house solid sparkle.
-- `FilterIcon` — lucide `ListFilter` in place of the in-house solid funnel.
+- `CoPilotIcon`: lucide `Sparkles` in place of the in-house solid sparkle.
+- `FilterIcon`: lucide `ListFilter` in place of the in-house solid funnel.
 
 A raw lucide component draws 24×24 at `strokeWidth={2}`, so set
 `size={16} strokeWidth={1.5}` at the call site to match the Apsara icons beside
-it — or wrap it once with `createIcon`, which applies those for you:
+it, or wrap it once with `createIcon`, which applies those for you:
 
 ```tsx
 // src/icons.ts
@@ -109,9 +109,9 @@ Every Apsara icon renders at **16×16** with `strokeWidth={1.5}`, which draws th
 icons were intrinsically 15×15.
 
 - A call site that set no size grows from 15px to 16px.
-- A call site that set a CSS class is unaffected — CSS beats an SVG presentation
+- A call site that set a CSS class is unaffected, since CSS beats an SVG presentation
   attribute.
-- A call site that set `width`/`height` explicitly is unaffected — your props are
+- A call site that set `width`/`height` explicitly is unaffected, since your props are
   applied after Apsara's base values.
 
 To change the size or the stroke of every icon at once, use the `props` half of
@@ -214,7 +214,7 @@ This applies to any runtime icon override.
 See [Icons](/docs/theme/icons) for the full set, the override API, and what each
 key draws.
 
-## 1.0 — Base UI replaces Radix and Ariakit
+## 1.0: Base UI replaces Radix and Ariakit
 
 Apsara 1.0 rebuilds every component on [Base UI](https://base-ui.com) in place
 of Radix UI, Ariakit, sonner and cmdk. It is the largest migration Apsara has
@@ -241,5 +241,5 @@ walks through every component with before-and-after examples. The headlines:
   `gap={17}` in place of the named sizes, and `Headline` sizes become
   `t1`–`t4`.
 
-If you are coming from 0.x, work through the full guide in order — the
+If you are coming from 0.x, work through the full guide in order: the
 cross-cutting changes first, then your components one by one.

--- a/apps/www/src/content/docs/ai-elements/chat-panel/index.mdx
+++ b/apps/www/src/content/docs/ai-elements/chat-panel/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Chat Panel
-description: A dockable, floating, minimizable window frame for chat — an inline sidebar that pops out to a draggable, resizable window or collapses to a corner bubble.
+description: A dockable, floating, minimizable window frame for chat. An inline sidebar that pops out to a draggable, resizable window or collapses to a corner bubble.
 source: packages/raystack/components/chat-panel
 tag: new
 ---
@@ -31,23 +31,23 @@ import { ChatPanel } from '@raystack/apsara'
 </Flex>
 ```
 
-The panel mounts **once** in your layout and switches between modes in place —
+The panel mounts **once** in your layout and switches between modes in place:
 no portal, no remount, so chat state (scroll position, focus, streams) survives
 every transition:
 
-- **`docked`** — an in-flow sidebar (a flex sibling, like `SidePanel`) that
+- **`docked`**: an in-flow sidebar (a flex sibling, like `SidePanel`) that
   squeezes the main content rather than covering it.
-- **`floating`** — the same element switched to `position: fixed`. Drag it by
+- **`floating`**: the same element switched to `position: fixed`. Drag it by
   the header, resize it from any edge or corner.
   - Drag is clamped to the viewport, or to a container via `dragBoundary`.
     Turn it off with `draggable={false}`.
   - Constrain the resize axes with `resize`. Resizing only shrinks the window
-    below its starting size — pass a larger `maxSize` to let it grow.
-- **`minimized`** — the frame collapses to `ChatPanel.Trigger`, a fixed corner
+    below its starting size, so pass a larger `maxSize` to let it grow.
+- **`minimized`**: the frame collapses to `ChatPanel.Trigger`, a fixed corner
   bubble, and clicking it restores the previous mode. Render no trigger and
   minimized shows nothing, so your app can supply its own affordance.
 
-There is deliberately no close (×) — header actions are slottable, so apps
+There is deliberately no close (×), because header actions are slottable, so apps
 add their own controls next to the ready-made mode triggers.
 
 Because floating and minimized rely on `position: fixed`, mount the panel
@@ -74,7 +74,7 @@ that is.
 
 Both ease with `--rs-ease-out`, so the panel settles into place rather than
 starting from a standstill. Both are skipped under
-`prefers-reduced-motion: reduce`, and neither runs on first paint — a mode has
+`prefers-reduced-motion: reduce`, and neither runs on first paint. A mode has
 to have changed for there to be a transition.
 
 Dragging is exempt. A drag writes an inline `transform`, and only the separate
@@ -84,7 +84,7 @@ pointer and ending a drag never replays the transition.
 ### Controlled mode
 
 Control `mode` to persist it, or to open the panel from your own UI. The
-floating window here is fixed to the browser viewport — pop it out and drag
+floating window here is fixed to the browser viewport, so pop it out and drag
 its header.
 
 <Demo data={controlledDemo} />
@@ -148,7 +148,7 @@ The frame wraps a header, a content area and the minimized bubble. Header action
 
 ### Header
 
-The title bar. In floating mode it is the drag handle — pointer drags on it
+The title bar. In floating mode it is the drag handle, and pointer drags on it
 move the window (interactive children like buttons are excluded, as is
 anything marked `data-chat-panel-no-drag`).
 
@@ -176,13 +176,13 @@ also accept a render function receiving `{ floating }` for per-state icons:
 
 ### Content
 
-The body wrapper — a flex column that gives `Chat.Messages` its bounded
+The body wrapper, a flex column that gives `Chat.Messages` its bounded
 height.
 
 ### Trigger
 
 The minimized-state corner bubble. Children replace the default `CoPilotIcon`,
-and `draggable` lets the bubble be dragged around the viewport — a completed
+and `draggable` lets the bubble be dragged around the viewport. A completed
 drag never triggers the restore click.
 
 <auto-type-table path="./props.ts" name="ChatPanelTriggerProps" />

--- a/apps/www/src/content/docs/ai-elements/chat/index.mdx
+++ b/apps/www/src/content/docs/ai-elements/chat/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Chat
-description: The conversation scroller — live-edge following, turn anchoring, prepend preservation and visibility tracking, plus separators and attachments.
+description: The conversation scroller. Live-edge following, turn anchoring, prepend preservation and visibility tracking, plus separators and attachments.
 source: packages/raystack/components/chat
 tag: new
 ---
@@ -49,7 +49,7 @@ import { Chat, Message, PromptInput, Reasoning } from '@raystack/apsara'
 elements/message) and [Reasoning](/docs/ai-elements/reasoning), composed as
 children.
 
-`Chat.Item` is the bridge — a neutral wrapper that registers whatever it wraps
+`Chat.Item` is the bridge, a neutral wrapper that registers whatever it wraps
 with the scroller, whether that is a message, a separator, or a tool-call
 card.
 
@@ -101,7 +101,7 @@ Imperative commands are available through `actionsRef`:
 The per-item behavior unit. It registers its element with the enclosing
 `Chat.Messages` for visibility tracking and `scrollToMessage`, marks the turn
 anchor, and applies `content-visibility: auto` containment so offscreen items
-skip layout and paint. It wraps anything — it has no opinion about what a
+skip layout and paint. It wraps anything and has no opinion about what a
 message looks like.
 
 <auto-type-table path="./props.ts" name="ChatItemProps" />
@@ -123,14 +123,14 @@ messages viewport and pads the sides and bottom.
 
 ### useChatMessages
 
-Hook for components rendered inside `Chat.Messages` — active-turn indicators,
+Hook for components rendered inside `Chat.Messages`: active-turn indicators,
 jump-to-message navigation, custom scroll buttons.
 
 <auto-type-table path="./props.ts" name="UseChatMessagesReturn" />
 
 ### Chat.Separator
 
-A centered label between hairlines — "Today 1:52 AM". Purely presentational;
+A centered label between hairlines, such as "Today 1:52 AM". Purely presentational;
 format dates however your app does.
 
 ### Chat.Attachment

--- a/apps/www/src/content/docs/ai-elements/message/index.mdx
+++ b/apps/www/src/content/docs/ai-elements/message/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Message
-description: Inert message layout — avatar, header, content, footer, hover actions and bubbles, aligned to either side of a conversation.
+description: Inert message layout with avatar, header, content, footer, hover actions and bubbles, aligned to either side of a conversation.
 source: packages/raystack/components/message
 tag: new
 ---
@@ -25,10 +25,10 @@ import { Message } from '@raystack/apsara'
 </Message>
 ```
 
-`Message` is pure layout — no context, no effects, no chat coupling. It works
+`Message` is pure layout, with no context, no effects and no chat coupling. It works
 anywhere: inside a `Chat` scroller, a comment thread, or a standalone
 transcript. Scroll behavior (visibility tracking, turn anchoring) belongs to
-[Chat](/docs/ai-elements/chat) — wrap a message in `Chat.Item` to opt in.
+[Chat](/docs/ai-elements/chat). Wrap a message in `Chat.Item` to opt in.
 
 ## Usage
 
@@ -56,7 +56,7 @@ appear once.
 
 ### Ghost bubbles
 
-`variant="ghost"` removes the surface — no background, border or padding — and
+`variant="ghost"` removes the surface, so there is no background, border or padding, and
 the bubble runs the full width of the message row instead of shrink-wrapping.
 It renders as plain body copy (Text at `size="small"`), which is the
 conventional treatment for assistant replies: the reader's own messages keep a
@@ -82,7 +82,7 @@ column), `Message.Footer` (timestamp line) and `Message.Actions`
 ### Message.Group
 
 A flex column that pulls consecutive messages from the same sender closer
-together. Render the avatar and footer once — typically on the group's last
+together. Render the avatar and footer once, typically on the group's last
 message.
 
 ### Message.Bubble
@@ -100,7 +100,7 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | `message` | A single message row |
 | `message-group` | Wrapper around consecutive messages from one sender |
 | `message-avatar` | The sender avatar |
-| `message-header` | Row above the bubble — sender name and timestamp |
+| `message-header` | Row above the bubble, for sender name and timestamp |
 | `message-content` | The bubble holding the message body |
 | `message-actions` | Action row revealed on the message |
 | `message-footer` | Row below the bubble |
@@ -109,5 +109,5 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 
 - `Message.Actions` reveal on hover **and** on focus-within, and stay visible
   on touch devices, so keyboard and touch users are not locked out.
-- Message bodies are regular document content — screen readers announce them
+- Message bodies are regular document content, so screen readers announce them
   in reading order with no extra semantics to configure.

--- a/apps/www/src/content/docs/ai-elements/prompt-input/index.mdx
+++ b/apps/www/src/content/docs/ai-elements/prompt-input/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Prompt Input
-description: A composer for AI chat and standalone "Ask anything" boxes — auto-growing input, inline @-mention chips, toolbar slots, and a status-aware submit button.
+description: A composer for AI chat and standalone "Ask anything" boxes, with auto-growing input, inline @-mention chips, toolbar slots, and a status-aware submit button.
 source: packages/raystack/components/prompt-input
 tag: new
 ---
@@ -32,12 +32,12 @@ import { PromptInput } from '@raystack/apsara'
 
 `PromptInput` is purely presentational: it never talks to a model or manages a
 request. Pass the lifecycle in through `status` and react to `onSubmit` /
-`onStop` — it works with the AI SDK's `useChat`, a custom SSE client, or
+`onStop`. It works with the AI SDK's `useChat`, a custom SSE client, or
 anything else.
 
 ## Usage
 
-The composer is a form with a swappable input. Start with the value format — it decides which input you want and what you get back on submit.
+The composer is a form with a swappable input. Start with the value format, which decides which input you want and what you get back on submit.
 
 ### Value format
 
@@ -61,12 +61,12 @@ Save this string as the user's draft. A few details:
 - `]`, `)` and `\` in a label are escaped with `\`, as are `:`, `)` and `\` in
   a type or id.
 - A line break is written as `\n`.
-- Anything that does not parse stays as plain text — nothing throws, nothing
+- Anything that does not parse stays as plain text. Nothing throws and nothing
   is dropped.
 - Only `value` and `defaultValue` are parsed. Text you type or paste that
   happens to look like `@[…](…)` stays as-is.
 - Icons and `data` cannot be saved in a string, so restoring a draft needs
-  `resolveMentions` — see [Restoring a draft](#restoring-a-draft).
+  `resolveMentions`. See [Restoring a draft](#restoring-a-draft).
 
 ### Everything the Editor can do
 
@@ -82,14 +82,14 @@ Things worth trying in it:
   keys step past it, and clicking one selects it.
 - **Undo and redo** with Cmd/Ctrl+Z and Cmd/Ctrl+Shift+Z. Inserting a chip
   undoes in one step.
-- **Copy a chip and paste it back** — it comes back as a chip, id intact.
+- **Copy a chip and paste it back** and it returns as a chip, id intact.
   Paste it into a plain text field and you get `@Maya Chen`.
 - **Paste formatted text** from a doc or a webpage and it arrives as plain
   text. The editor has no bold, headings or lists to paste into.
 - **Shift+Enter** adds a line break; Enter sends.
 - **The length cap** counts a chip as its label and applies to pasted text
   too, so you can't paste past it.
-- **Multi-word search:** type `@maya ch` — the space keeps searching. Keep
+- **Multi-word search:** type `@maya ch`, and the space keeps searching. Keep
   typing past the point where nothing matches and the menu gives up and leaves
   your text alone.
 - **Escape** closes the menu and leaves what you typed as plain text. Delete a
@@ -101,7 +101,7 @@ Typing `@` opens a menu at the cursor. Picking an item drops a chip into the
 text, followed by a space. The chip deletes in one press, arrow keys step over
 it, and a message that is nothing but a chip still sends.
 
-The chip itself shows the item's icon and label — not the `@`. The trigger is
+The chip itself shows the item's icon and label, not the `@`. The trigger is
 kept in the text you get on submit (`@Maya Chen`), where the mention boundary
 has to survive being read by a model.
 
@@ -126,7 +126,7 @@ alone.
 
 A chip loaded from `defaultValue` starts with just its label, since a saved
 string can't carry an icon or `data`. Pass `resolveMentions` to look those up
-and fill them in — it also refreshes the label if the entity was renamed.
+and fill them in. It also refreshes the label if the entity was renamed.
 Lookups are batched and cached. If one fails or comes back empty, the chip
 stays label-only; it is never removed.
 
@@ -151,14 +151,14 @@ drag-drop and uploads belong to your app.
 
 `status` reflects the request lifecycle your app manages:
 
-- **`idle`** — the resting state; the submit button shows the send arrow and
+- **`idle`**: the resting state; the submit button shows the send arrow and
   disables itself while the composer is empty.
-- **`submitted`** — the request is sent but nothing has streamed back yet;
+- **`submitted`**: the request is sent but nothing has streamed back yet;
   the button shows a spinner, Enter/submit is blocked, and clicking calls
   `onStop`.
-- **`streaming`** — tokens are arriving; the button flips to a stop square
+- **`streaming`**: tokens are arriving; the button flips to a stop square
   that calls `onStop`, and submit stays blocked.
-- **`error`** — the request failed; the composer returns to a submittable
+- **`error`**: the request failed; the composer returns to a submittable
   state (send arrow) so the user can retry. Render your error message
   outside the composer.
 
@@ -166,7 +166,7 @@ drag-drop and uploads belong to your app.
 
 ### Controlled value
 
-Control `value` to sync the draft elsewhere — persistence, slash-command
+Control `value` to sync the draft elsewhere: persistence, slash-command
 menus, mention pickers.
 
 <Demo data={controlledDemo} />
@@ -196,8 +196,8 @@ The form wraps one of two inputs, `Textarea` or `Editor`, with the header, foote
 
 The `<form>` that holds the value and submit semantics.
 
-The whole frame reads as one field. Clicking its empty space — the header and
-footer padding, or the gap between their controls — focuses the input, while
+The whole frame reads as one field. Clicking its empty space, whether the header and
+footer padding or the gap between their controls, focuses the input, while
 anything you put in those slots still handles its own clicks. Whichever input
 part you render registers itself on mount.
 
@@ -226,8 +226,8 @@ content up to a max-height cap (override with
 The input to use when you want `@`-mention chips. Use it *instead of*
 `Textarea`, not alongside it.
 
-It behaves like `Textarea` — Enter submits, Shift+Enter adds a newline, same
-placeholder and same growth — and adds undo/redo plus the mention menu. Its line
+It behaves like `Textarea`, with Enter to submit, Shift+Enter for a newline, the same
+placeholder and the same growth, and it adds undo/redo plus the mention menu. Its line
 height is taller, so a chip fits on one line without changing the composer's
 height as chips come and go.
 
@@ -245,7 +245,7 @@ A few `Textarea` props work differently here:
 ### Mentions
 
 Sets up a trigger character and its data. It renders nothing on its own and
-needs `PromptInput.Editor` — next to a `Textarea` it does nothing and warns in
+needs `PromptInput.Editor`. Next to a `Textarea` it does nothing and warns in
 development.
 
 Pass `items` for a list you already have, or `onSearch` to fetch results as the
@@ -255,7 +255,7 @@ user types. `onSearch` wins if you pass both.
 
 <auto-type-table path="./props.ts" name="PromptInputMentionItem" />
 
-Each item sets its own `type`, so one `@` menu can mix kinds — the demo below
+Each item sets its own `type`, so one `@` menu can mix kinds. The demo below
 has a page, components and users. You get `type` back on submit.
 
 ### Header
@@ -265,8 +265,8 @@ while empty.
 
 ### Footer
 
-The bottom toolbar row. Hidden while empty. Toolbar controls — attach, skills,
-model pickers and similar — are composed from regular Apsara components
+The bottom toolbar row. Hidden while empty. Toolbar controls such as attach, skills and
+model pickers are composed from regular Apsara components
 (`Button`, `IconButton`, `Select`, …); give them `type="button"` so they don't
 submit the form.
 
@@ -285,7 +285,7 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 | Slot | Element |
 |------|---------|
 | `prompt-input` | Root container |
-| `prompt-input-header` | Row above the textarea — attachments and context |
+| `prompt-input-header` | Row above the textarea, for attachments and context |
 | `prompt-input-textarea` | The editable composer |
 | `prompt-input-footer` | Row below the textarea |
 | `prompt-input-submit` | The send button |
@@ -301,15 +301,15 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
   form.
 - `Editor` and its mention menu use the standard combobox roles, so screen
   readers announce the highlighted row as the user arrows through it. Focus
-  stays in the editor the whole time — the menu never takes it.
+  stays in the editor the whole time, and the menu never takes it.
 - While the menu is open, ↑ ↓ Enter Tab and Escape control the menu. Escape
   closes the menu without also closing a surrounding `ChatPanel`, `Dialog` or
   `Drawer`, so the draft survives. With the menu closed, those keys behave as
   usual.
 - Each chip has an accessible name, like `"mention: DataTable"`.
-- The composer frame carries the focus treatment — the border tints when a
-  child has visible focus (`:has(:focus-visible)`) — while the borderless
+- The composer frame carries the focus treatment, so the border tints when a
+  child has visible focus (`:has(:focus-visible)`), while the borderless
   input suppresses its own duplicate focus ring.
 - Click-to-focus runs on `mousedown` and cancels the default focus shift, so
-  focus never leaves the input and back again — a round trip that would dismiss
+  focus never leaves the input and back again, a round trip that would dismiss
   anything anchored to it. Keyboard focus order is untouched.

--- a/apps/www/src/content/docs/ai-elements/reasoning/index.mdx
+++ b/apps/www/src/content/docs/ai-elements/reasoning/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Reasoning
-description: Collapsible "thinking" section for AI responses — auto-opens while streaming, auto-collapses on completion, with labelled steps.
+description: Collapsible "thinking" section for AI responses. Auto-opens while streaming, auto-collapses on completion, with labelled steps.
 source: packages/raystack/components/reasoning
 tag: new
 ---
@@ -27,7 +27,7 @@ import { Reasoning } from '@raystack/apsara'
 ```
 
 Built on `Collapsible`. Drive `streaming` from your transport; everything
-here is presentational and works anywhere — inside a
+here is presentational and works anywhere, whether inside a
 [Message](/docs/ai-elements/message) body, a `Chat` scroller, or on its own.
 
 ## Usage
@@ -49,7 +49,7 @@ Replace the default trigger text when "Reasoning" is not the right word for what
 
 ### Controlled
 
-Pass `open` with `onOpenChange` to own the panel — needed when reasoning should expand automatically while the model streams and collapse once it finishes.
+Pass `open` with `onOpenChange` to own the panel. Do this when reasoning should expand automatically while the model streams and collapse once it finishes.
 
 <Demo data={controlledDemo} />
 
@@ -62,7 +62,7 @@ The trigger toggles the content. `Step` renders a single line of thinking.
 <auto-type-table path="./props.ts" name="ReasoningProps" />
 
 The open state auto-follows `streaming` (open while `true`, collapsed once it
-flips back) until the user toggles the panel manually — from then on it's
+flips back) until the user toggles the panel manually. From then on it's
 theirs.
 
 ### Reasoning.Trigger

--- a/apps/www/src/content/docs/components/accordion/index.mdx
+++ b/apps/www/src/content/docs/components/accordion/index.mdx
@@ -41,7 +41,7 @@ Start with how many sections may be open at once, then decide whether you own th
 
 ### Controlled
 
-Pass `value` with `onValueChange` to own which item is open — needed when something outside the accordion has to open or close a section.
+Pass `value` with `onValueChange` to own which item is open. Do this when something outside the accordion has to open or close a section.
 
 <Demo data={controlledDemo} />
 

--- a/apps/www/src/content/docs/components/alert-dialog/index.mdx
+++ b/apps/www/src/content/docs/components/alert-dialog/index.mdx
@@ -36,7 +36,7 @@ An alert dialog cannot be dismissed by clicking away, so the work is deciding wh
 
 ### Controlled
 
-Pass `open` with `onOpenChange` to own the state — needed when something other than the trigger has to close the dialog, such as a request completing.
+Pass `open` with `onOpenChange` to own the state. Do this when something other than the trigger has to close the dialog, such as a request completing.
 
 <Demo data={controlledDemo} />
 

--- a/apps/www/src/content/docs/components/amount/index.mdx
+++ b/apps/www/src/content/docs/components/amount/index.mdx
@@ -60,7 +60,7 @@ Render only the formatted number, without any currency symbol, code, or name. Lo
 
 ### Minor units
 
-Set `valueInMinorUnits` when your API returns integer cents, paise, or fils. Amount divides by the currency's own exponent — 100 for USD, 1 for JPY — so you never hard-code the divisor.
+Set `valueInMinorUnits` when your API returns integer cents, paise, or fils. Amount divides by the currency's own exponent, 100 for USD and 1 for JPY, so you never hard-code the divisor.
 
 <Demo data={valueInMinorUnitsDemo} />
 

--- a/apps/www/src/content/docs/components/announcement-bar/index.mdx
+++ b/apps/www/src/content/docs/components/announcement-bar/index.mdx
@@ -32,7 +32,7 @@ Variants convey the tone of the announcement. Default is `normal`; use `error` f
 
 ### Icon and action
 
-`leadingIcon` marks the kind of notice, and `actionLabel` turns the bar into a link. Give the action a verb that says where it goes — the bar is easy to ignore, so the label carries the click.
+`leadingIcon` marks the kind of notice, and `actionLabel` turns the bar into a link. Give the action a verb that says where it goes, since the bar is easy to ignore, so the label carries the click.
 
 <Demo data={actionDemo} />
 
@@ -59,7 +59,7 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 
 - The action (when `actionLabel` or `actionIcon` is provided) is rendered
   as a real `<button>`, so it's focusable, reachable by Tab, and activated
-  by Enter/Space — not as a `<Text>` with an `onClick` handler.
+  by Enter/Space, not as a `<Text>` with an `onClick` handler.
 - The action button exposes a focus ring via `:focus-visible`.
 - Decorative `leadingIcon` and `actionIcon` are marked `aria-hidden="true"`
   so they don't add noise to screen readers.

--- a/apps/www/src/content/docs/components/breadcrumb/index.mdx
+++ b/apps/www/src/content/docs/components/breadcrumb/index.mdx
@@ -84,7 +84,7 @@ Use the `render` prop to render the breadcrumb item as a custom component. Pass 
 
 ### Disabled
 
-Use the `disabled` prop for non-clickable, visually muted items—for example, loading states or segments the user does not have access to. Disabled items render as a span with `aria-disabled="true"` and do not navigate.
+Use the `disabled` prop for non-clickable, visually muted items, for example loading states or segments the user does not have access to. Disabled items render as a span with `aria-disabled="true"` and do not navigate.
 
 <Demo data={disabledDemo} />
 

--- a/apps/www/src/content/docs/components/button/index.mdx
+++ b/apps/www/src/content/docs/components/button/index.mdx
@@ -29,7 +29,7 @@ import { Button } from '@raystack/apsara'
 
 ## Usage
 
-A button's appearance comes from three independent props — variant, color and size. The rest change what it does.
+A button's appearance comes from three independent props: variant, color and size. The rest change what it does.
 
 ### Variant
 
@@ -57,7 +57,7 @@ Pass `leadingIcon`, `trailingIcon`, or both. A leading icon reinforces the actio
 
 ### Loading
 
-`loading` swaps the content for a spinner and blocks further clicks, so an in-flight action can't be fired twice. Add `loaderText` to say what's happening — useful when the wait is longer than a second or two.
+`loading` swaps the content for a spinner and blocks further clicks, so an in-flight action can't be fired twice. Add `loaderText` to say what's happening, which helps when the wait is longer than a second or two.
 
 <Demo data={loadingDemo} />
 

--- a/apps/www/src/content/docs/components/calendar/index.mdx
+++ b/apps/www/src/content/docs/components/calendar/index.mdx
@@ -56,11 +56,11 @@ You can display custom components above each date using the `dateInfo` prop. The
 
 Selects a date range across two inputs. The grid uses a state machine that branches on the current `from` / `to`:
 
-- **Empty** — first click sets `from` and advances focus to the end input.
-- **Only `from` set** — clicking a later date completes the range and closes the popover; clicking an earlier date resets `from`.
-- **Both set** — clicking again restarts: the new date becomes `from`, `to` clears.
+- **Empty**: first click sets `from` and advances focus to the end input.
+- **Only `from` set**: clicking a later date completes the range and closes the popover; clicking an earlier date resets `from`.
+- **Both set**: clicking again restarts: the new date becomes `from`, `to` clears.
 
-`onSelect` fires on every step (the shape is `{ from?: Date; to?: Date }` — partial during interaction). Gate on `range.to` if you only want the completed-range event.
+`onSelect` fires on every step (the shape is `{ from?: Date; to?: Date }`, partial during interaction). Gate on `range.to` if you only want the completed-range event.
 
 <Demo data={rangePickerDemo} />
 
@@ -72,7 +72,7 @@ Single-date selection with a typable input. The popover opens on focus; pressing
 
 ### Controlled
 
-Pass `selected` with `onSelect` to own the date — needed when the value comes from a form or has to be set from elsewhere, like a Today button.
+Pass `selected` with `onSelect` to own the date. This is needed when the value comes from a form or has to be set from elsewhere, like a Today button.
 
 <Demo data={controlledDemo} />
 
@@ -88,13 +88,13 @@ Renders a standalone calendar for date selection.
 
 ### RangePicker
 
-The RangePicker exposes its slots — `startInput`, `endInput`, `calendar`, `popover` — through the `slotProps` prop.
+The RangePicker exposes its `startInput`, `endInput`, `calendar` and `popover` slots through the `slotProps` prop.
 
 <auto-type-table path="./props.ts" name="RangePickerProps" />
 
 ### DatePicker
 
-The DatePicker exposes its slots — `input`, `calendar`, `popover` — through the `slotProps` prop.
+The DatePicker exposes its `input`, `calendar` and `popover` slots through the `slotProps` prop.
 
 <auto-type-table path="./props.ts" name="DatePickerProps" />
 

--- a/apps/www/src/content/docs/components/callout/index.mdx
+++ b/apps/www/src/content/docs/components/callout/index.mdx
@@ -37,7 +37,7 @@ Type carries the meaning: `grey` for neutral information, and the semantic types
 
 ### Outline
 
-`solid` (the default) fills the callout. `outline` draws a border instead — quieter, for a page that already has several filled surfaces.
+`solid` (the default) fills the callout. `outline` draws a border instead, which is quieter for a page that already has several filled surfaces.
 
 <Demo data={outlineDemo} />
 

--- a/apps/www/src/content/docs/components/checkbox/index.mdx
+++ b/apps/www/src/content/docs/components/checkbox/index.mdx
@@ -32,7 +32,7 @@ Use `Checkbox.Group` to manage shared state across multiple checkboxes:
 
 ## Usage
 
-A checkbox on its own, then in a group — where a parent can both reflect and drive the children beneath it.
+A checkbox on its own, then in a group, where a parent can both reflect and drive the children beneath it.
 
 ### Size variants
 
@@ -42,13 +42,13 @@ Two sizes. `large` is the default; `small` fits table rows and dense lists.
 
 ### States
 
-A checkbox can be checked, unchecked, or `indeterminate` — the third state for a parent whose children are only partly selected.
+A checkbox can be checked, unchecked, or `indeterminate`, the third state for a parent whose children are only partly selected.
 
 <Demo data={statesExamples} />
 
 ### Controlled
 
-Pass `checked` with `onCheckedChange` to own the state — needed when the value lives in a form, gates another control, or has to be read back on submit.
+Pass `checked` with `onCheckedChange` to own the state. Do this when the value lives in a form, gates another control, or has to be read back on submit.
 
 <Demo data={controlledDemo} />
 

--- a/apps/www/src/content/docs/components/chip/index.mdx
+++ b/apps/www/src/content/docs/components/chip/index.mdx
@@ -27,7 +27,7 @@ import { Chip } from "@raystack/apsara";
 
 ## Usage
 
-Appearance first — variant, size and color — then the two things a chip can carry: icons and a dismiss action.
+Appearance first, meaning variant, size and color, then the two things a chip can carry: icons and a dismiss action.
 
 ### Variant
 

--- a/apps/www/src/content/docs/components/code-block/index.mdx
+++ b/apps/www/src/content/docs/components/code-block/index.mdx
@@ -83,7 +83,7 @@ The `CodeBlock.CopyButton` component offers two placement options:
 
 ## API Reference
 
-The code sits in a root. Everything else — label, language select, copy button, collapse trigger — is optional header furniture.
+The code sits in a root. Everything else, meaning the label, language select, copy button and collapse trigger, is optional header furniture.
 
 ### Root
 

--- a/apps/www/src/content/docs/components/collapsible/index.mdx
+++ b/apps/www/src/content/docs/components/collapsible/index.mdx
@@ -44,7 +44,7 @@ Use `defaultOpen` to have the panel initially expanded.
 
 ### Disabled
 
-`disabled` freezes the collapsible in its current state — use it while content is still loading rather than hiding the section outright.
+`disabled` freezes the collapsible in its current state. Use it while content is still loading rather than hiding the section outright.
 
 <Demo data={disabledDemo} />
 

--- a/apps/www/src/content/docs/components/color-picker/index.mdx
+++ b/apps/www/src/content/docs/components/color-picker/index.mdx
@@ -50,8 +50,8 @@ Pass the `copyable` prop on `ColorPicker.Input` to render a copy-to-clipboard bu
 
 The picker stores color internally in OKLCH. What the controls show depends on the mode:
 
-- **`hex`, `rgb`, `hsl`** — the area pad is the familiar HSL saturation × brightness square and the hue slider runs in HSL hue. The picker behaves like a traditional color picker and only emits colors the chosen format can represent.
-- **`oklch`** — the pad becomes a chroma × lightness plane covering the full P3 gamut, and the hue slider runs in OKLCH hue, where equal steps are equal perceptual changes.
+- **`hex`, `rgb`, `hsl`**: the area pad is the familiar HSL saturation × brightness square and the hue slider runs in HSL hue. The picker behaves like a traditional color picker and only emits colors the chosen format can represent.
+- **`oklch`**: the pad becomes a chroma × lightness plane covering the full P3 gamut, and the hue slider runs in OKLCH hue, where equal steps are equal perceptual changes.
 
 To start in OKLCH, pass an `oklch(...)` string as `defaultValue` and set `defaultMode='oklch'`.
 
@@ -118,7 +118,7 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 
 ### formatColor
 
-Converts any CSS color string to the requested format. Useful when consuming apsara color tokens (which are authored in OKLCH) from APIs that need a specific format — chart libraries, SVG attributes, canvas fills, design exports, and similar.
+Converts any CSS color string to the requested format. Useful when consuming apsara color tokens (which are authored in OKLCH) from APIs that need a specific format: chart libraries, SVG attributes, canvas fills, design exports, and similar.
 
 ```tsx
 import { formatColor } from '@raystack/apsara'
@@ -135,9 +135,9 @@ formatColor('not a color', 'hex')                  // null
 
 - Accepts any CSS color string: `oklch()`, `rgb()`/`rgba()`, `hsl()`/`hsla()`, hex, named colors, `transparent`.
 - For `hex`, `rgb`, and `hsl` outputs, wide-gamut OKLCH inputs are gamut-mapped into sRGB by **reducing chroma while preserving lightness and hue**, so the returned string is the closest sRGB representation rather than a per-channel-clipped one (which would distort hue).
-- For `oklch` output, the full color is preserved — OKLCH can express the wide gamut natively. Output matches the design system's token format (4-decimal L/C, 2-decimal H, hue pinned to 0 when achromatic).
+- For `oklch` output, the full color is preserved, since OKLCH can express the wide gamut natively. Output matches the design system's token format (4-decimal L/C, 2-decimal H, hue pinned to 0 when achromatic).
 - Hex is uppercase; uses 8-digit form (`#rrggbbaa`) when alpha < 1. Translucent rgb/hsl/oklch produce `rgba()` / `hsla()` / `oklch(... / A)`.
-- Returns `null` for unparseable input rather than throwing — safe to call on user-supplied strings.
+- Returns `null` for unparseable input rather than throwing, so it is safe to call on user-supplied strings.
 
 **Signature**
 

--- a/apps/www/src/content/docs/components/combobox/index.mdx
+++ b/apps/www/src/content/docs/components/combobox/index.mdx
@@ -143,11 +143,11 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
   is a `role="combobox"` with `aria-expanded` and `aria-controls`, the popup list
   is a `listbox`, and each item is an `option` with `aria-selected`.
 - Arrow keys move the highlight through visible options, Enter selects the
-  highlighted option, and Escape closes the popup — focus stays in the input
+  highlighted option, and Escape closes the popup, and focus stays in the input
   the whole time, so typing to filter never loses the user's place.
 - In multiple mode, each item renders a checkbox that mirrors its selected
   state, and selected values appear in the input as removable chips.
 - Group labels use Base UI's `Combobox.GroupLabel`, which links the label to
-  its group via `aria-labelledby` — wrap `Combobox.Label` in `Combobox.Group`.
+  its group via `aria-labelledby`, so wrap `Combobox.Label` in `Combobox.Group`.
 - Wrap the Combobox with [Field](/docs/components/field) to associate a
   visible label, description, and error message with the input.

--- a/apps/www/src/content/docs/components/command/index.mdx
+++ b/apps/www/src/content/docs/components/command/index.mdx
@@ -41,7 +41,7 @@ import { Command } from "@raystack/apsara";
 </Command.Dialog>
 ```
 
-`Command` can also be rendered inline (without a dialog) — useful for embedding a
+`Command` can also be rendered inline (without a dialog), which suits embedding a
 persistent command menu in a page or surface.
 
 ## Usage
@@ -80,7 +80,7 @@ Control the input value by passing `value` and `onValueChange`.
 
 ### Items prop
 
-By default, `Command` filters `Command.Item` children based on the input value — the same behavior as our [Combobox](/docs/components/combobox). No `items` prop is required. Matching is case-insensitive and looks at both the `value` prop and the item's text content.
+By default, `Command` filters `Command.Item` children based on the input value, the same behavior as our [Combobox](/docs/components/combobox). No `items` prop is required. Matching is case-insensitive and looks at both the `value` prop and the item's text content.
 
 Pass the `items` prop to opt out of this built-in behavior and delegate filtering to Base UI's internal logic (or your own `filter` function). `Command.Content` then accepts a render function that receives each item.
 
@@ -116,7 +116,7 @@ Rendered when no items are visible (all filtered out, or the list is empty). Aut
 
 ### Item
 
-A selectable entry. When `value` is omitted and `children` is a string, the string is used as the value. `onClick` fires on pointer click **and** on keyboard `Enter` when the item is highlighted. Pass a [`Kbd`](/docs/components/kbd) as `trailingIcon` to show a keyboard hint — use the `ghost` variant so the keys sit on the item's own background.
+A selectable entry. When `value` is omitted and `children` is a string, the string is used as the value. `onClick` fires on pointer click **and** on keyboard `Enter` when the item is highlighted. Pass a [`Kbd`](/docs/components/kbd) as `trailingIcon` to show a keyboard hint, and use the `ghost` variant so the keys sit on the item's own background.
 
 <auto-type-table path="./props.ts" name="CommandItemProps" />
 

--- a/apps/www/src/content/docs/components/container/index.mdx
+++ b/apps/www/src/content/docs/components/container/index.mdx
@@ -34,7 +34,7 @@ The `size` prop caps the container's max-width. The default is `none`, which let
 
 ### Align
 
-The `align` prop positions the container within its parent — left, center, or right. Default is `center`.
+The `align` prop positions the container within its parent: left, center, or right. Default is `center`.
 
 <Demo data={alignDemo} />
 
@@ -58,6 +58,6 @@ The Container component is designed with accessibility in mind:
 
 - Applies `role="region"` automatically when an `aria-label` or
   `aria-labelledby` is provided, exposing the container as a landmark.
-- Without a label, no role is applied — Container stays a generic `<div>`
+- Without a label, no role is applied, and Container stays a generic `<div>`
   to avoid emitting unlabeled regions that clutter assistive-tech output.
 - Pass `role` explicitly to override (e.g. `role="main"`).

--- a/apps/www/src/content/docs/components/context-menu/index.mdx
+++ b/apps/www/src/content/docs/components/context-menu/index.mdx
@@ -70,7 +70,7 @@ Pass `autocomplete` to the ContextMenu root. Each menu manages its own autocompl
 
 ### Controlled
 
-Pass `open` with `onOpenChange` to own the state — needed when the menu has to close on something other than a selection, or when only one menu may be open at a time.
+Pass `open` with `onOpenChange` to own the state. Do this when the menu has to close on something other than a selection, or when only one menu may be open at a time.
 
 <Demo data={controlledDemo} />
 
@@ -181,6 +181,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
   ArrowRight/ArrowLeft open and close submenus.
 - With `autocomplete`, the popup becomes a `role="dialog"` containing a search
   input, items render as `role="option"`, and focus stays in the input while
-  arrow keys move the highlight — Escape first closes an open submenu.
+  arrow keys move the highlight, and Escape first closes an open submenu.
 - `ContextMenu.Label` must be wrapped in `ContextMenu.Group` so the group is
   labelled via `aria-labelledby`.

--- a/apps/www/src/content/docs/components/dialog/index.mdx
+++ b/apps/www/src/content/docs/components/dialog/index.mdx
@@ -36,7 +36,7 @@ A dialog is a trigger and a content shell. Which regions of that shell you fill 
 
 ### Controlled Dialog
 
-Pass `open` with `onOpenChange` to own the state — needed when the dialog must close on something other than a click, such as a save completing.
+Pass `open` with `onOpenChange` to own the state. Do this when the dialog must close on something other than a click, such as a save completing.
 
 <Demo data={controlledDemo} />
 

--- a/apps/www/src/content/docs/components/drawer/index.mdx
+++ b/apps/www/src/content/docs/components/drawer/index.mdx
@@ -47,7 +47,7 @@ The Drawer can slide in from different sides of the screen. Swipe-to-dismiss is 
 
 ### Controlled
 
-Pass `open` with `onOpenChange` to own the state — needed when the drawer has to open from elsewhere on the page, or stay open until a save completes.
+Pass `open` with `onOpenChange` to own the state. Do this when the drawer has to open from elsewhere on the page, or stay open until a save completes.
 
 <Demo data={controlledDemo} />
 

--- a/apps/www/src/content/docs/components/empty-state/index.mdx
+++ b/apps/www/src/content/docs/components/empty-state/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Empty State
-description: A placeholder for views with nothing to show yet — pairs an icon and message with optional actions to help users take the next step.
+description: A placeholder for views with nothing to show yet. It pairs an icon and message with optional actions to help users take the next step.
 source: packages/raystack/components/empty-state
 ---
 
@@ -12,7 +12,7 @@ import { playground, variantsDemo,
 
 ## Overview
 
-`EmptyState` fills a view that has no content yet — an empty inbox, zero search results, a feature that needs setup. It pairs a required `icon` with an optional `heading`, `subHeading`, and up to two action slots (`primaryAction`, `secondaryAction`) so users always have a next step.
+`EmptyState` fills a view that has no content yet: an empty inbox, zero search results, a feature that needs setup. It pairs a required `icon` with an optional `heading`, `subHeading`, and up to two action slots (`primaryAction`, `secondaryAction`) so users always have a next step.
 
 Use `empty1`, the default, for compact centered placeholders inside panels and lists. Use `empty2` for full-page states, which left-align the content and put the actions in a side-by-side row.
 
@@ -33,7 +33,7 @@ Pick the variant that suits the space, then fill in the icon, the message and up
 
 ### Variants
 
-`empty1` (the default) centers everything and stacks the actions vertically — suited to panels, tables, and lists. `empty2` left-aligns the content, uses a larger icon, and places both actions in a row — suited to full-page states.
+`empty1` (the default) centers everything and stacks the actions vertically, which suits panels, tables, and lists. `empty2` left-aligns the content, uses a larger icon, and places both actions in a row, which suits full-page states.
 
 <Demo data={variantsDemo} />
 
@@ -71,5 +71,5 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
   (e.g. `heading={<h2>…</h2>}`) to keep the outline intact.
 - The icon is decorative by default. If it carries meaning on its own,
   give it an accessible name; otherwise mark it `aria-hidden`.
-- Actions are whatever you pass in — use real `Button`s so keyboard and
+- Actions are whatever you pass in, so use real `Button`s and keyboard and
   screen reader users can reach them.

--- a/apps/www/src/content/docs/components/field/index.mdx
+++ b/apps/www/src/content/docs/components/field/index.mdx
@@ -65,7 +65,7 @@ Use Field to add label, description, and error to an Input.
 
 ### With TextArea
 
-Field wraps a TextArea the same way it wraps an Input — the label, description, and error all wire up through the same context.
+Field wraps a TextArea the same way it wraps an Input, so the label, description, and error all wire up through the same context.
 
 <Demo data={withTextAreaDemo} />
 
@@ -145,12 +145,12 @@ An error message displayed when validation fails. Renders a `<div>` element.
 
 The `match` prop controls when the error is shown:
 
-- **`match="valueMissing"`** — shown when a `required` field is empty
-- **`match="typeMismatch"`** — shown when `type="email"` or `type="url"` value is invalid
-- **`match="patternMismatch"`** — shown when value doesn't match the `pattern` regex
-- **`match="tooShort"` / `match="tooLong"`** — shown for `minLength` / `maxLength` violations
-- **`match="rangeUnderflow"` / `match="rangeOverflow"`** — shown for `min` / `max` violations
-- **`match="customError"`** — shown when the Field's `validate` prop returns an error
+- **`match="valueMissing"`**: shown when a `required` field is empty
+- **`match="typeMismatch"`**: shown when `type="email"` or `type="url"` value is invalid
+- **`match="patternMismatch"`**: shown when value doesn't match the `pattern` regex
+- **`match="tooShort"` / `match="tooLong"`**: shown for `minLength` / `maxLength` violations
+- **`match="rangeUnderflow"` / `match="rangeOverflow"`**: shown for `min` / `max` violations
+- **`match="customError"`**: shown when the Field's `validate` prop returns an error
 
 <auto-type-table path="./props.ts" name="FieldErrorProps" />
 

--- a/apps/www/src/content/docs/components/filter-chip/index.mdx
+++ b/apps/www/src/content/docs/components/filter-chip/index.mdx
@@ -22,11 +22,11 @@ import { FilterChip } from "@raystack/apsara";
 
 ## Usage
 
-The input type decides what the chip edits — text, a number, a date, or a list of options — and everything else follows from it.
+The input type decides what the chip edits: text, a number, a date, or a list of options. Everything else follows from it.
 
 ### Input types
 
-FilterChip supports five input types — `select`, `multiselect`, `date`, `string`, and `number` — to handle various filtering needs. `multiselect` takes a `string[]` value and summarizes two or more selections as "N selected".
+FilterChip supports five input types, `select`, `multiselect`, `date`, `string`, and `number`, to handle various filtering needs. `multiselect` takes a `string[]` value and summarizes two or more selections as "N selected".
 
 <Demo data={inputDemo} />
 
@@ -38,7 +38,7 @@ Use `selectProps` to enable autocomplete search on select and multiselect filter
 
 ### Date with calendarProps
 
-Use `calendarProps` to forward DatePicker options — `dateFormat`, `timeZone`, `slotProps.calendar`, etc. — to the chip's date control. `value`, `onSelect`, and `defaultValue` are owned by `FilterChip`, and `children` is excluded so the chip's input trigger isn't replaced.
+Use `calendarProps` to forward DatePicker options such as `dateFormat`, `timeZone` and `slotProps.calendar` to the chip's date control. `value`, `onSelect`, and `defaultValue` are owned by `FilterChip`, and `children` is excluded so the chip's input trigger isn't replaced.
 
 <Demo data={calendarPropsDemo} />
 
@@ -66,7 +66,7 @@ FilterChip supports custom filter operations through the `operations` prop. When
 
 ### Controlled
 
-Pass `value` with `onValueChange` to own the filter — needed when the chip drives a query and the value has to survive a refetch or a shared URL.
+Pass `value` with `onValueChange` to own the filter. Do this when the chip drives a query and the value has to survive a refetch or a shared URL.
 
 <Demo data={controlledDemo} />
 

--- a/apps/www/src/content/docs/components/flex/index.mdx
+++ b/apps/www/src/content/docs/components/flex/index.mdx
@@ -15,7 +15,7 @@ import { playground, basicDemo,
 
 ## Overview
 
-`Flex` is the workhorse layout primitive: a `div` with `display: flex` and props for `direction`, `align`, `justify`, `wrap`, and `gap`, so you rarely write flexbox CSS by hand. By default it lays children out in a row (`direction="row"`, `align="stretch"`, `justify="start"`, `wrap="noWrap"`). Reach for it whenever you're stacking or spacing things along one axis — toolbars, form rows, sidebars. For two-dimensional layouts use [Grid](/docs/components/grid), and for a page-width wrapper use [Container](/docs/components/container).
+`Flex` is the workhorse layout primitive: a `div` with `display: flex` and props for `direction`, `align`, `justify`, `wrap`, and `gap`, so you rarely write flexbox CSS by hand. By default it lays children out in a row (`direction="row"`, `align="stretch"`, `justify="start"`, `wrap="noWrap"`). Reach for it whenever you're stacking or spacing things along one axis: toolbars, form rows, sidebars. For two-dimensional layouts use [Grid](/docs/components/grid), and for a page-width wrapper use [Container](/docs/components/container).
 
 ## Anatomy
 
@@ -33,7 +33,7 @@ import { Flex } from "@raystack/apsara";
 
 ### Nesting
 
-Nest Flex containers to compose a layout: here an outer row — the default direction — holds two columns, each spaced with `gap`.
+Nest Flex containers to compose a layout: here an outer row, the default direction, holds two columns, each spaced with `gap`.
 
 <Demo data={basicDemo} />
 
@@ -51,7 +51,7 @@ Nest Flex containers to compose a layout: here an outer row — the default dire
 
 ### Align
 
-`align` positions children on the cross axis. `center` is what pulls a row of mixed heights — an icon, a label, a button — onto one optical line. `baseline` aligns their text instead.
+`align` positions children on the cross axis. `center` is what pulls a row of mixed heights, such as an icon, a label and a button, onto one optical line. `baseline` aligns their text instead.
 
 <Demo data={alignDemo} />
 
@@ -77,7 +77,7 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 
 ## Accessibility
 
-- Renders a plain `<div>` and adds no roles or ARIA attributes — purely
+- Renders a plain `<div>` and adds no roles or ARIA attributes, and is purely
   visual layout with no semantic meaning.
 - Screen readers read children in DOM order, so `rowReverse` and
   `columnReverse` change only the visual order. Don't rely on them to

--- a/apps/www/src/content/docs/components/floating-actions/index.mdx
+++ b/apps/www/src/content/docs/components/floating-actions/index.mdx
@@ -29,7 +29,7 @@ The bar floats above the view and holds actions for whatever is selected. Appear
 
 ### Variant
 
-`floating` (default) renders with `position: fixed` anchored to the viewport via `side` and `align` — use it when the bar should follow the user as the page scrolls (bulk-selection toolbars, contextual action trays). `inline` opts out of viewport positioning so the bar flows with surrounding content.
+`floating` (default) renders with `position: fixed` anchored to the viewport via `side` and `align`. Use it when the bar should follow the user as the page scrolls (bulk-selection toolbars, contextual action trays). `inline` opts out of viewport positioning so the bar flows with surrounding content.
 
 <Demo data={variantsDemo} />
 
@@ -65,13 +65,13 @@ Use `FloatingActions.Group` to cluster related items so they navigate as one uni
 
 ### Scrolling context
 
-The floating variant stays pinned to the viewport (or the nearest containing block) while content scrolls beneath it — the canonical use case for a bulk-selection bar over a long list or table.
+The floating variant stays pinned to the viewport (or the nearest containing block) while content scrolls beneath it, the canonical use case for a bulk-selection bar over a long list or table.
 
 <Demo data={scrollingDemo} />
 
 ### Use with DataView
 
-For the row-selection pattern — rendering this bar over a `DataView` and wiring it to selected rows — see [DataView.List → Row selection](/docs/dataview/list#row-selection).
+For the row-selection pattern, meaning this bar over a `DataView` wired to selected rows, see [DataView.List → Row selection](/docs/dataview/list#row-selection).
 
 ## API Reference
 

--- a/apps/www/src/content/docs/components/grid/index.mdx
+++ b/apps/www/src/content/docs/components/grid/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Grid
-description: A layout primitive for CSS grid — define columns, rows, template areas, and gaps with props instead of stylesheet rules.
+description: A layout primitive for CSS grid. Define columns, rows, template areas, and gaps with props instead of stylesheet rules.
 source: packages/raystack/components/grid
 ---
 
@@ -17,7 +17,7 @@ import { playground,  basicDemo,
 
 `Grid` is a `div` with `display: grid`, exposing CSS grid through props: `columns` and `rows` (a number becomes `repeat(n, 1fr)`, a string passes through as-is), `templateAreas`, `autoFlow`, `gap`/`columnGap`/`rowGap`, and the alignment props.
 
-Reach for it when a layout runs in two dimensions at once — dashboards, card grids, page shells with named areas. For a single row or column, [Flex](/docs/components/flex) is the simpler tool.
+Reach for it when a layout runs in two dimensions at once: dashboards, card grids, page shells with named areas. For a single row or column, [Flex](/docs/components/flex) is the simpler tool.
 
 Children can be any elements. Wrap one in `Grid.Item` only when it needs its own placement or styling.
 
@@ -36,11 +36,11 @@ import { Grid } from "@raystack/apsara";
 
 ## Usage
 
-Define the tracks on the root, then place children into them — by span, by named area, or by letting the grid flow them automatically.
+Define the tracks on the root, then place children into them: by span, by named area, or by letting the grid flow them automatically.
 
 ### Basic usage
 
-A 2×2 grid defined with numeric `rows` and `columns`. Plain children and `Grid.Item` wrappers mix freely — both flow into cells in order.
+A 2×2 grid defined with numeric `rows` and `columns`. Plain children and `Grid.Item` wrappers mix freely, and both flow into cells in order.
 
 Reach for Grid when the layout is two-dimensional: rows *and* columns that have to line up with each other. For a single row or column, [Flex](/docs/components/flex) is simpler and needs no track definitions.
 
@@ -54,7 +54,7 @@ Reach for Grid when the layout is two-dimensional: rows *and* columns that have 
 
 ### Template areas
 
-`templateAreas` names regions and `area` places an item into one. Worth it when the layout has more than three or four regions — the names document the intent, and moving a region means editing one string rather than every child.
+`templateAreas` names regions and `area` places an item into one. Worth it when the layout has more than three or four regions, since the names document the intent, and moving a region means editing one string rather than every child.
 
 <Demo data={areasDemo} />
 
@@ -97,7 +97,7 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 
 ## Accessibility
 
-- Renders a plain `<div>` and adds no roles or ARIA attributes — CSS grid
+- Renders a plain `<div>` and adds no roles or ARIA attributes, so CSS grid
   is purely visual layout.
 - Screen readers read children in DOM order. Explicit placement,
   `templateAreas`, and `dense` auto-flow can make the visual order differ

--- a/apps/www/src/content/docs/components/headline/index.mdx
+++ b/apps/www/src/content/docs/components/headline/index.mdx
@@ -10,7 +10,7 @@ import { playground, alignDemo, truncateDemo, weightDemo } from "./demo.ts";
 
 ## Overview
 
-`Headline` renders page and section titles with the design system's heading scale — four sizes (`t1`–`t4`, default `t2`) plus `weight`, `align`, and `truncate` props. It outputs an `<h2>` by default; use the `render` prop to pick the heading level that fits the document outline. For body copy, labels, and any non-heading text, use [Text](/docs/components/text) instead.
+`Headline` renders page and section titles with the design system's heading scale: four sizes (`t1`–`t4`, default `t2`) plus `weight`, `align`, and `truncate` props. It outputs an `<h2>` by default; use the `render` prop to pick the heading level that fits the document outline. For body copy, labels, and any non-heading text, use [Text](/docs/components/text) instead.
 
 ## Anatomy
 

--- a/apps/www/src/content/docs/components/image/index.mdx
+++ b/apps/www/src/content/docs/components/image/index.mdx
@@ -62,7 +62,7 @@ The Image component follows accessibility best practices:
 
 - `alt` is the accessible name. Set it to a meaningful description, or `""`
   for decorative images (which marks the element as presentational).
-- No redundant `role="img"` or duplicated `aria-label` is emitted — the
+- No redundant `role="img"` or duplicated `aria-label` is emitted, so the
   native `<img>` element already provides those semantics.
 
 ### Performance

--- a/apps/www/src/content/docs/components/input/index.mdx
+++ b/apps/www/src/content/docs/components/input/index.mdx
@@ -58,7 +58,7 @@ Input comes in two sizes: small (24px) and large (32px).
 
 ### With prefix and suffix
 
-Prefix and suffix sit inside the field for fixed units and protocols — a currency symbol, `https://`, `@`. They are decoration, not part of the value.
+Prefix and suffix sit inside the field for fixed units and protocols: a currency symbol, `https://`, `@`. They are decoration, not part of the value.
 
 <Demo data={prefixDemo} />
 
@@ -85,7 +85,7 @@ chips?: Array<{ label: string; onRemove?: () => void }>;
 maxChipsVisible?: number;  // defaults to 2   
 ```
 
-This is purely a presentation layer — it does not manage chip state. The wrapper component owns the array and decides when items are added or removed.
+This is purely a presentation layer and does not manage chip state. The wrapper component owns the array and decides when items are added or removed.
 
 The example below 
   appends a chip on `Enter`, removes one when its dismiss button is clicked.
@@ -100,7 +100,7 @@ Use Field to add label, description, and error handling.
 
 ### Controlled
 
-Use `onValueChange` for a callback that receives only the new string value, or `onChange` for the full React change event. Both fire on every keystroke — pick whichever fits your needs.
+Use `onValueChange` for a callback that receives only the new string value, or `onChange` for the full React change event. Both fire on every keystroke, so pick whichever fits your needs.
 
 <Demo data={onValueChangeDemo} />
 

--- a/apps/www/src/content/docs/components/kbd/index.mdx
+++ b/apps/www/src/content/docs/components/kbd/index.mdx
@@ -69,7 +69,7 @@ Keys sit on the text baseline, so they can be dropped straight into a sentence.
 
 ### In an input
 
-Surface a focus shortcut in a search field. Use a single `ghost` key here — the input's trailing slot is sized for an icon, so a multi-key `Kbd.Group` will be clipped.
+Surface a focus shortcut in a search field. Use a single `ghost` key here, because the input's trailing slot is sized for an icon, so a multi-key `Kbd.Group` will be clipped.
 
 <Demo data={withInputDemo} />
 
@@ -107,6 +107,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 ## Accessibility
 
 - `Kbd` is presentational: it styles a key. The `<kbd>` element carries no ARIA role and no accessible name of its own, so it adds no semantics to the text around it.
-- A symbol on its own — `⌘`, `⇧`, `↵` — carries no name for the key it stands for, and how any given screen reader reads the bare glyph varies. Give the key a name whenever the symbol is the only cue: `<Kbd aria-label="Command">⌘</Kbd>`.
-- Keys are not focusable and carry no interaction. Keep the shortcut wired to a real handler elsewhere — `Kbd` only displays it.
+- A symbol on its own, such as `⌘`, `⇧` or `↵`, carries no name for the key it stands for, and how any given screen reader reads the bare glyph varies. Give the key a name whenever the symbol is the only cue: `<Kbd aria-label="Command">⌘</Kbd>`.
+- Keys are not focusable and carry no interaction. Keep the shortcut wired to a real handler elsewhere, since `Kbd` only displays it.
 - Keys ignore pointer events and text selection, so clicking or dragging across a command item does not highlight the key labels.

--- a/apps/www/src/content/docs/components/label/index.mdx
+++ b/apps/www/src/content/docs/components/label/index.mdx
@@ -41,7 +41,7 @@ Renders a text label for form elements. Outside of a `Field`, use `Label` to
 attach a label to a control via `htmlFor`. Inside a `Field`, prefer
 `Field.Label` so the label is wired up to the field automatically.
 
-`Label` is layout-neutral — compose it with `Flex` (or wrap a control as a
+`Label` is layout-neutral, so compose it with `Flex` (or wrap a control as a
 child) to lay out the label and its control.
 
 <auto-type-table path="./props.ts" name="LabelProps" />

--- a/apps/www/src/content/docs/components/link/index.mdx
+++ b/apps/www/src/content/docs/components/link/index.mdx
@@ -80,7 +80,7 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 
 The Link component follows accessibility best practices:
 
-- Renders a native `<a>` by default — no explicit `role="link"` is set
+- Renders a native `<a>` by default, and no explicit `role="link"` is set
   because the native element already provides it. If you swap the element
   via `render` to something non-anchor (e.g. `<button>`), it will be
   announced according to that element's own semantics.

--- a/apps/www/src/content/docs/components/list/index.mdx
+++ b/apps/www/src/content/docs/components/list/index.mdx
@@ -96,7 +96,7 @@ The List component implements proper ARIA attributes for accessibility:
 - List renders a `<ul>` with explicit `role="list"`. The role is kept
   even though the element is native, because Safari/VoiceOver drop the
   implicit list role when `list-style: none` is applied.
-- List relies on the native `<li>` semantics for items — no redundant
+- List relies on the native `<li>` semantics for items, with no redundant
   `role="listitem"` is set.
 - No generic default `aria-label` is added. Pass `aria-label` when the
   list needs an accessible name distinct from surrounding context.

--- a/apps/www/src/content/docs/components/menu/index.mdx
+++ b/apps/www/src/content/docs/components/menu/index.mdx
@@ -65,7 +65,7 @@ Use `Menu.Submenu`, `Menu.SubmenuTrigger`, and `Menu.SubmenuContent` to create n
 Pass `autocomplete` to the Menu root. Each menu manages its own autocomplete state.
 
 - **`autocompleteMode="auto"`** is the default. Items filter as the user types, matched against each item's `value` prop or its children text.
-- **`autocompleteMode="manual"`** leaves filtering to you — do it in `onInputValueChange`.
+- **`autocompleteMode="manual"`** leaves filtering to you. Do it in `onInputValueChange`.
 - **Submenus** opt in separately: pass `autocomplete` to `Menu.Submenu`.
 
 <Demo data={autocompleteDemo} />
@@ -80,7 +80,7 @@ To closely replicate Linear-style filtering, the filtering logic should include 
 
 ### Controlled
 
-Pass `open` with `onOpenChange` to own the state — needed when a keyboard shortcut or another control has to open the menu.
+Pass `open` with `onOpenChange` to own the state. Do this when a keyboard shortcut or another control has to open the menu.
 
 <Demo data={controlledDemo} />
 
@@ -195,7 +195,7 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
   open and close submenus.
 - With `autocomplete`, the popup becomes a `role="dialog"` containing a search
   input, items render as `role="option"`, and focus stays in the input while
-  arrow keys move the highlight — ArrowRight or Enter opens a highlighted
+  arrow keys move the highlight, and ArrowRight or Enter opens a highlighted
   submenu, and Escape first closes an open submenu.
 - `Menu.Label` must be wrapped in `Menu.Group` so the group is labelled via
   `aria-labelledby`.

--- a/apps/www/src/content/docs/components/menubar/index.mdx
+++ b/apps/www/src/content/docs/components/menubar/index.mdx
@@ -53,7 +53,7 @@ Use the `autocomplete` prop on `Menu` to enable search filtering within a menuba
 
 ## API Reference
 
-Just the bar itself — the menus inside are plain `Menu`s.
+Just the bar itself. The menus inside are plain `Menu`s.
 
 ### Root
 

--- a/apps/www/src/content/docs/components/meter/index.mdx
+++ b/apps/www/src/content/docs/components/meter/index.mdx
@@ -15,7 +15,7 @@ Import and assemble the component:
 ```tsx
 import { Meter } from '@raystack/apsara'
 
-{/* Direct usage — renders track automatically */}
+{/* Direct usage: renders track automatically */}
 <Meter value={40} />
 
 {/* Composable usage */}

--- a/apps/www/src/content/docs/components/navbar/index.mdx
+++ b/apps/www/src/content/docs/components/navbar/index.mdx
@@ -31,7 +31,7 @@ import { Navbar } from "@raystack/apsara";
 
 ## Usage
 
-The bar has three regions — start, center and end. The props below cover how it behaves as the page scrolls.
+The bar has three regions: start, center and end. The props below cover how it behaves as the page scrolls.
 
 ### Sticky navigation
 
@@ -41,7 +41,7 @@ A sticky navbar stays pinned while the page scrolls. Use it when navigation has 
 
 ### Section layouts
 
-Start, Center, and End are independent — use any combination. The three-column grid keeps Center optically centred even when Start and End differ in width.
+Start, Center, and End are independent, so use any combination. The three-column grid keeps Center optically centred even when Start and End differ in width.
 
 <Demo data={sectionsDemo} />
 
@@ -75,7 +75,7 @@ The start section is a container that accepts Flex props (`align`, `gap`, `direc
 
 ### Center
 
-The center section sits in the middle of the navbar in a fixed position—it stays absolutely centered regardless of the width of Start or End content. The navbar uses a 3-column grid (Start | Center | End) so the center does not shift when left or right content changes. It accepts Flex props and section props.
+The center section sits in the middle of the navbar in a fixed position, so it stays absolutely centered regardless of the width of Start or End content. The navbar uses a 3-column grid (Start | Center | End) so the center does not shift when left or right content changes. It accepts Flex props and section props.
 
 <auto-type-table path="./props.ts" name="NavbarCenterProps" />
 

--- a/apps/www/src/content/docs/components/number-field/index.mdx
+++ b/apps/www/src/content/docs/components/number-field/index.mdx
@@ -24,10 +24,10 @@ Import and use the component standalone or composed:
 ```tsx
 import { NumberField } from "@raystack/apsara";
 
-{/* Standalone — renders decrement, input, and increment internally */}
+{/* Standalone: renders decrement, input, and increment internally */}
 <NumberField defaultValue={0} />
 
-{/* Composed — full control over sub-components */}
+{/* Composed: full control over sub-components */}
 <NumberField defaultValue={0}>
   <NumberField.ScrubArea label="Amount" />
   <NumberField.Group>
@@ -82,7 +82,7 @@ Number field with currency formatting, powered by `Intl.NumberFormat` internally
 
 ### Controlled
 
-Pass `value` with `onValueChange` to own the number — needed when the value feeds a calculation, a query, or another field.
+Pass `value` with `onValueChange` to own the number. Do this when the value feeds a calculation, a query, or another field.
 
 <Demo data={controlledDemo} />
 

--- a/apps/www/src/content/docs/components/otp-field/index.mdx
+++ b/apps/www/src/content/docs/components/otp-field/index.mdx
@@ -49,7 +49,7 @@ Group slots visually with `OTPField.Separator` to make long codes easier to read
 
 ### Masked
 
-Use `mask` to obscure entered characters — useful for sensitive codes.
+Use `mask` to obscure entered characters, which suits sensitive codes.
 
 <Demo data={maskedDemo} />
 
@@ -85,7 +85,7 @@ Pass `value` and `onValueChange` to control the field from React state.
 
 ### Custom normalization
 
-Provide `normalizeValue` to restrict input to a custom set of characters. It composes with `validationType` filtering — set `validationType="none"` to rely on it entirely.
+Provide `normalizeValue` to restrict input to a custom set of characters. It composes with `validationType` filtering, so set `validationType="none"` to rely on it entirely.
 
 <Demo data={customNormalizeDemo} />
 

--- a/apps/www/src/content/docs/components/popover/index.mdx
+++ b/apps/www/src/content/docs/components/popover/index.mdx
@@ -41,7 +41,7 @@ Customize how the popover aligns with its trigger.
 
 ### Controlled
 
-Pass `open` with `onOpenChange` to own the state — needed when something other than the trigger has to close the popover, such as applying a filter.
+Pass `open` with `onOpenChange` to own the state. Do this when something other than the trigger has to close the popover, such as applying a filter.
 
 <Demo data={controlledDemo} />
 

--- a/apps/www/src/content/docs/components/progress/index.mdx
+++ b/apps/www/src/content/docs/components/progress/index.mdx
@@ -15,7 +15,7 @@ Import and assemble the component:
 ```tsx
 import { Progress } from '@raystack/apsara'
 
-{/* Direct usage — renders track automatically */}
+{/* Direct usage: renders track automatically */}
 <Progress value={40} />
 
 {/* Composable usage */}

--- a/apps/www/src/content/docs/components/radio/index.mdx
+++ b/apps/www/src/content/docs/components/radio/index.mdx
@@ -59,7 +59,7 @@ Radio buttons can be used in forms with proper validation and submission handlin
 
 ### Controlled
 
-Pass `value` with `onValueChange` on `Radio.Group` to own the selection — needed when the choice drives something else on the page or is submitted with a form.
+Pass `value` with `onValueChange` on `Radio.Group` to own the selection. Do this when the choice drives something else on the page or is submitted with a form.
 
 <Demo data={controlledDemo} />
 

--- a/apps/www/src/content/docs/components/select/index.mdx
+++ b/apps/www/src/content/docs/components/select/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Select
-description: Displays a list of options for the user to pick from—triggered by a button.
+description: Displays a list of options for the user to pick from, triggered by a button.
 source: packages/raystack/components/select
 ---
 
@@ -39,7 +39,7 @@ import { Select } from "@raystack/apsara";
 
 ## Usage
 
-Appearance first — size and variant — then how many items can be chosen, and who owns the value.
+Appearance first, meaning size and variant, then how many items can be chosen, and who owns the value.
 
 ### Basic Select
 
@@ -89,7 +89,7 @@ By default, only select items are filtered using a simple match. For more advanc
 
 ### Controlled
 
-Pass `value` with `onValueChange` to own the selection — needed when the value comes from a form, a URL, or another control on the page.
+Pass `value` with `onValueChange` to own the selection. Do this when the value comes from a form, a URL, or another control on the page.
 
 <Demo data={controlledDemo} />
 

--- a/apps/www/src/content/docs/components/sidebar/index.mdx
+++ b/apps/www/src/content/docs/components/sidebar/index.mdx
@@ -48,7 +48,7 @@ import { Sidebar } from "@raystack/apsara";
 
 ## Usage
 
-Most of a sidebar's behaviour is about collapsing — what it looks like collapsed, who controls it, and how the user gets it back.
+Most of a sidebar's behaviour is about collapsing: what it looks like collapsed, who controls it, and how the user gets it back.
 
 ### Position
 
@@ -81,7 +81,7 @@ For a responsive layout, drive it from your own breakpoint check:
 <Sidebar collapsible={isMobile ? 'hidden' : 'icon'} />
 ```
 
-When `collapsible="hidden"` is closed, the strip is just wide enough for the resize handle — reopen by clicking it, or place a `Sidebar.Trigger` as a direct child of `<Sidebar>` (not inside `Header`/`Main`/`Footer`, which are hidden along with everything else) for a clearer affordance, as in the "Hidden" tab below.
+When `collapsible="hidden"` is closed, the strip is just wide enough for the resize handle. Reopen by clicking it, or place a `Sidebar.Trigger` as a direct child of `<Sidebar>` (not inside `Header`/`Main`/`Footer`, which are hidden along with everything else) for a clearer affordance, as in the "Hidden" tab below.
 
 <Demo data={collapsedAppearanceDemo} />
 
@@ -109,7 +109,7 @@ content instead of pushing it, and the real `open` state never changes.
 - **A `Sidebar.Item`** just navigates, leaving the open state alone.
 
 It works with either collapsed appearance. With `"hidden"` there is no icon rail,
-so hover the thin strip at the edge instead — the "Hidden" tab below shows this.
+so hover the thin strip at the edge instead, as the "Hidden" tab below shows.
 
 The peek waits 100ms so it does not fire when the mouse only passes over.
 Change that with `peekDelay`.
@@ -124,7 +124,7 @@ Item tooltips show the item label when collapsed. Override the message when the 
 
 ### Hide item tooltips when collapsed
 
-Set `hideItemTooltips` to disable the tooltips the Sidebar adds to navigation items — the label tooltip when collapsed, and the full-text tooltip on clipped labels when expanded. Useful when you show your own tooltips or want a cleaner collapsed state.
+Set `hideItemTooltips` to disable the tooltips the Sidebar adds to navigation items: the label tooltip when collapsed, and the full-text tooltip on clipped labels when expanded. Useful when you show your own tooltips or want a cleaner collapsed state.
 
 <Demo data={hideTooltipDemo} />
 
@@ -196,7 +196,7 @@ The footer section is a container that accepts all `div` props. It's commonly us
 
 A button that toggles the sidebar open/closed. It works whether the Sidebar is controlled or uncontrolled, so you can drop it into a header without wiring up any state yourself. It accepts all `IconButton` props (e.g. `size`) plus the ones below.
 
-*Note: disabled automatically when the Sidebar has `collapsible="none"`. If you use `collapsible="hidden"`, don't place `Sidebar.Trigger` inside `Sidebar.Header`/`Main`/`Footer` — those sections are hidden along with the rest of the collapsed content, taking the trigger with them. Render it as a direct child of `<Sidebar>` instead, or drive `open`/`onOpenChange` yourself with a toggle button that lives outside `<Sidebar>` entirely (e.g. in your app's top bar).*
+*Note: disabled automatically when the Sidebar has `collapsible="none"`. If you use `collapsible="hidden"`, don't place `Sidebar.Trigger` inside `Sidebar.Header`/`Main`/`Footer`, because those sections are hidden along with the rest of the collapsed content, taking the trigger with them. Render it as a direct child of `<Sidebar>` instead, or drive `open`/`onOpenChange` yourself with a toggle button that lives outside `<Sidebar>` entirely (e.g. in your app's top bar).*
 
 <auto-type-table path="./props.ts" name="SidebarTriggerProps" />
 
@@ -240,13 +240,13 @@ A hook that reads the sidebar state from context. Use it in custom header, foote
 
 It returns:
 
-- `isCollapsed` — `true` when the sidebar is collapsed (accounts for `peekOnHover`: `false` while peeking)
-- `isPeeking` — `true` while a collapsed sidebar is being temporarily revealed via `peekOnHover`
-- `open` — `true` when the sidebar is expanded
-- `setOpen(open)` — expand or collapse the sidebar
-- `collapsible` — mirrors the `collapsible` prop: `"icon"`, `"hidden"`, or `"none"` (`"none"` means it cannot be collapsed)
-- `position` — `"left"` or `"right"`
-- `hideItemTooltips` — whether the tooltips the Sidebar adds to items are disabled
+- `isCollapsed`: `true` when the sidebar is collapsed (accounts for `peekOnHover`: `false` while peeking)
+- `isPeeking`: `true` while a collapsed sidebar is being temporarily revealed via `peekOnHover`
+- `open`: `true` when the sidebar is expanded
+- `setOpen(open)`: expand or collapse the sidebar
+- `collapsible`: mirrors the `collapsible` prop: `"icon"`, `"hidden"`, or `"none"` (`"none"` means it cannot be collapsed)
+- `position`: `"left"` or `"right"`
+- `hideItemTooltips`: whether the tooltips the Sidebar adds to items are disabled
 
 ```tsx
 import { Sidebar, useSidebar } from "@raystack/apsara";
@@ -280,7 +280,7 @@ Add `data-collapse-hidden` to any element inside the Sidebar to hide it automati
 
 The Sidebar implements the following accessibility features:
 
-- **Reduced motion** — Sidebar collapse/expand motion is enabled only when `prefers-reduced-motion: no-preference`.
+- **Reduced motion**: Sidebar collapse/expand motion is enabled only when `prefers-reduced-motion: no-preference`.
 - Proper ARIA roles and attributes
 
   - `role="navigation"` for the main sidebar
@@ -305,4 +305,4 @@ The Sidebar implements the following accessibility features:
   - Clear state indicators
 
 - Known limitations
-  - `peekOnHover` is mouse-only; there's no keyboard/focus equivalent that reveals the preview. Keyboard and screen reader users still get each item's full label via the existing per-item tooltip on focus, so no content is unreachable — they just don't get the hover preview shortcut.
+  - `peekOnHover` is mouse-only; there's no keyboard/focus equivalent that reveals the preview. Keyboard and screen reader users still get each item's full label via the existing per-item tooltip on focus, so no content is unreachable; they only miss the hover preview shortcut.

--- a/apps/www/src/content/docs/components/sidepanel/index.mdx
+++ b/apps/www/src/content/docs/components/sidepanel/index.mdx
@@ -71,7 +71,7 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 
 ## Accessibility
 
-- Renders as a native `<aside>` — assistive tech announces it as the
+- Renders as a native `<aside>`, so assistive tech announces it as the
   `complementary` landmark automatically.
 - `SidePanel.Header` renders the `title` as a semantic `<h2>` and assigns
   it an auto-generated id (override via `titleId`). Pair it with

--- a/apps/www/src/content/docs/components/spinner/index.mdx
+++ b/apps/www/src/content/docs/components/spinner/index.mdx
@@ -32,7 +32,7 @@ The Spinner component offers different size options. You can customize the size 
 
 ### Color
 
-`default` inherits `currentColor`, so the spinner takes the color of the text around it. The other five carry meaning — `accent`, `danger`, `success`, `attention`, `neutral`.
+`default` inherits `currentColor`, so the spinner takes the color of the text around it. The other five carry meaning: `accent`, `danger`, `success`, `attention`, `neutral`.
 
 The Spinner component offers 6 color values. `default` prop sets the color to `currentColor` mainly helpful if we want to render the Spinner inside another component like Button. Spinner (with color="default") inherits the foreground color of button text.
 

--- a/apps/www/src/content/docs/components/switch/index.mdx
+++ b/apps/www/src/content/docs/components/switch/index.mdx
@@ -36,7 +36,7 @@ A switch can be on, off, or disabled. Use `defaultChecked` for the starting posi
 
 ### Controlled
 
-Pass `checked` with `onCheckedChange` to own the state yourself — needed when the value lives in a form, syncs to a server, or drives something else on the page.
+Pass `checked` with `onCheckedChange` to own the state yourself. Do this when the value lives in a form, syncs to a server, or drives something else on the page.
 
 <Demo data={controlDemo} />
 

--- a/apps/www/src/content/docs/components/table/index.mdx
+++ b/apps/www/src/content/docs/components/table/index.mdx
@@ -38,13 +38,13 @@ Rows and cells are composed by hand, so a table is whatever markup you give it. 
 
 ### Basic usage
 
-Compose a table from its parts: `Header` and `Body` wrap `Row`s, with `Head` for column titles and `Cell` for each value. Table renders static markup — for sorting, filtering, or pagination, use [DataView](/docs/dataview).
+Compose a table from its parts: `Header` and `Body` wrap `Row`s, with `Head` for column titles and `Cell` for each value. Table renders static markup. For sorting, filtering, or pagination, use [DataView](/docs/dataview).
 
 <Demo data={basicDemo} />
 
 ### Interactive rows
 
-Set `interactive` on a `Row` to make it respond to hover and keyboard focus. Pair it with `onClick` when the whole row opens something — the row becomes the target, so people don't have to hit a link inside a cell.
+Set `interactive` on a `Row` to make it respond to hover and keyboard focus. Pair it with `onClick` when the whole row opens something. The row becomes the target, so people don't have to hit a link inside a cell.
 
 <Demo data={interactiveDemo} />
 
@@ -114,7 +114,7 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 ## Accessibility
 
 - Uses semantic `table`, `thead`, `tbody`, `tr`, `th`, and `td` elements.
-- `Table.Head` applies `scope="col"` by default — override to `"row"`,
+- `Table.Head` applies `scope="col"` by default. Override it to `"row"`,
   `"colgroup"`, or `"rowgroup"` for non-standard layouts. `SectionHeader`
   uses `scope="colgroup"`.
 - Supports `aria-label` and `aria-labelledby` for table identification.

--- a/apps/www/src/content/docs/components/tabs/index.mdx
+++ b/apps/www/src/content/docs/components/tabs/index.mdx
@@ -67,7 +67,7 @@ Set `disabled` on a trigger to keep a tab visible but unreachable.
 
 ### Controlled
 
-Pass `value` with `onValueChange` to own the active tab — needed when something outside the tab list has to switch panels, or when the tab is part of the URL.
+Pass `value` with `onValueChange` to own the active tab. Do this when something outside the tab list has to switch panels, or when the tab is part of the URL.
 
 <Demo data={controlledDemo} />
 

--- a/apps/www/src/content/docs/components/toast/index.mdx
+++ b/apps/www/src/content/docs/components/toast/index.mdx
@@ -84,7 +84,7 @@ Use `useToastManager()` inside a component to dispatch toasts and/or read the re
 
 ## API Reference
 
-The provider that renders toasts, and the manager APIs that add them — from a module, or from inside a component.
+The provider that renders toasts, and the manager APIs that add them, from a module or from inside a component.
 
 ### Toast.Provider
 
@@ -94,7 +94,7 @@ Renders the toast viewport and manages the toast lifecycle. Place once at the ro
 
 ### toastManager.add(options)
 
-Creates a new toast and returns its unique ID. The `toastManager` can be imported and used anywhere — including outside React components (e.g., API interceptors, utility functions).
+Creates a new toast and returns its unique ID. The `toastManager` can be imported and used anywhere, including outside React components (e.g., API interceptors, utility functions).
 
 <auto-type-table path="./props.ts" name="ToastManagerAddOptions" />
 
@@ -118,7 +118,7 @@ The returned object exposes the four manager methods:
 
 #### Update options
 
-The `update(id, options)` method accepts a partial of the toast — every field optional, used to patch an existing toast in place.
+The `update(id, options)` method accepts a partial of the toast, with every field optional, used to patch an existing toast in place.
 
 <auto-type-table path="./props.ts" name="ToastManagerUpdateOptions" />
 

--- a/apps/www/src/content/docs/components/toggle/index.mdx
+++ b/apps/www/src/content/docs/components/toggle/index.mdx
@@ -52,7 +52,7 @@ Four steps, 1 through 4, matching the icon button scale so toggles and buttons l
 
 ### Controlled
 
-Pass `pressed` with `onPressedChange` to own the state — needed when the toggle reflects something stored elsewhere.
+Pass `pressed` with `onPressedChange` to own the state. Do this when the toggle reflects something stored elsewhere.
 
 <Demo data={controlledDemo} />
 

--- a/apps/www/src/content/docs/components/tooltip/index.mdx
+++ b/apps/www/src/content/docs/components/tooltip/index.mdx
@@ -64,7 +64,7 @@ Show the arrow by setting `showArrow={true}` on the Content component:
 
 ### Controlled
 
-Pass `open` with `onOpenChange` to own the state. Use it to show a tooltip from somewhere other than hover — a first-run hint, or a validation message tied to a field.
+Pass `open` with `onOpenChange` to own the state. Use it to show a tooltip from somewhere other than hover: a first-run hint, or a validation message tied to a field.
 
 <Demo data={controlledDemo} />
 

--- a/apps/www/src/content/docs/components/tour/index.mdx
+++ b/apps/www/src/content/docs/components/tour/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tour
-description: Guided product walkthroughs — a sequence of cards that point at real elements, spotlight them, and let people move on, go back, or leave.
+description: Guided product walkthroughs. A sequence of cards that point at real elements, spotlight them, and let people move on, go back, or leave.
 source: packages/raystack/components/tour
 tag: new
 ---
@@ -72,7 +72,7 @@ const [index, setIndex] = useState(0);
 
 ### Custom card with a render function
 
-Leave out `Tour.Next` and advance from app code when the user does something —
+Leave out `Tour.Next` and advance from app code when the user does something. This is
 useful for action-gated steps (draw a shape, open a panel).
 
 ```tsx
@@ -104,8 +104,8 @@ useEffect(() => {
 A target can be a CSS selector, an element, a React ref, or a function. Targets
 that mount after the tour starts are awaited automatically; if one never
 appears within `targetTimeout` the tour skips it (or stops, per
-`targetNotFound`). If a target unmounts mid-step — its dialog closes, its route
-changes — the tour recovers instead of leaving a broken overlay.
+`targetNotFound`). If a target unmounts mid-step, because its dialog closes or its route
+changes, the tour recovers instead of leaving a broken overlay.
 
 ```tsx
 const steps = [
@@ -118,7 +118,7 @@ const steps = [
 
 ### Motion between steps
 
-The dimmed backdrop stays put for the whole tour — it never flashes away
+The dimmed backdrop stays put for the whole tour and never flashes away
 between steps. Only the spotlight cutout animates: it fades shut (dimming the
 old target), repositions while covered, and fades back open once the next
 target has scrolled into view and settled, so the hole never slides across the
@@ -142,7 +142,7 @@ The tour and its step shape, then the card parts to compose when the default car
 ### Tour
 
 The root. Holds the steps and the open/index state, resolves targets, emits
-events, and owns the actions. Renders a context provider — its children default
+events, and owns the actions. Renders a context provider whose children default
 to `<Tour.Overlay />` and `<Tour.Content />`.
 
 <auto-type-table path="./props.ts" name="TourProps" />
@@ -229,6 +229,6 @@ Every rendered part carries a stable `data-slot` attribute for [styling and test
 - Escape ends the tour. Outside clicks and focus moves do not, so a step can keep
   focus on the element it highlights.
 - The tour is non-modal (`modal={false}`); it does not trap focus or lock scroll.
-- Motion — the spotlight cutout's fade, the card fade or glide, and scroll-into-view —
+- Motion, meaning the spotlight cutout's fade, the card fade or glide, and scroll-into-view,
   is enabled only when `prefers-reduced-motion: no-preference`; otherwise steps swap
   instantly.

--- a/apps/www/src/content/docs/dataview/index.mdx
+++ b/apps/www/src/content/docs/dataview/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: DataView
-description: A unified data primitive whose query state drives swappable renderers. List, timeline, custom — one filter/sort/group/search model.
+description: A unified data primitive whose query state drives swappable renderers. List, timeline, custom, all on one filter/sort/group/search model.
 source: packages/raystack/components/data-view
 ---
 
@@ -17,14 +17,14 @@ import {
 
 ## Overview
 
-`DataView` owns the data layer — query state (filters, sort, group, search), client or server mode, and row model derivation. It doesn't draw anything itself. You pick the renderer that does, and the same `<DataView>` can host a table, a list, or a free-form view, switchable at runtime without losing query state.
+`DataView` owns the data layer: query state (filters, sort, group, search), client or server mode, and row model derivation. It doesn't draw anything itself. You pick the renderer that does, and the same `<DataView>` can host a table, a list, or a free-form view, switchable at runtime without losing query state.
 
 This page covers what every renderer shares. The renderers have their own pages:
 
-- **[List](/docs/dataview/list)** — table and list presentations.
-- **[Timeline](/docs/dataview/timeline)** — cards on a continuous time axis.
+- **[List](/docs/dataview/list)**: table and list presentations.
+- **[Timeline](/docs/dataview/timeline)**: cards on a continuous time axis.
 
-`DataView.Custom` is the escape hatch for everything else — cards, kanban, gallery — and is covered below.
+`DataView.Custom` is the escape hatch for everything else, such as cards, kanban and gallery, and is covered below.
 
 ## Anatomy
 
@@ -61,7 +61,7 @@ Everything on this page applies to every renderer. Read it in order: fields and 
 
 ### Fields and columns
 
-`fields` is renderer-agnostic metadata declared **once on the root** — filter capability, sort capability, group capability, visibility, group-header presentation. Cell and header renderers live on the **renderer's** column spec instead, such as `DataView.List`'s `columns`.
+`fields` is renderer-agnostic metadata declared **once on the root**: filter capability, sort capability, group capability, visibility, and group-header presentation. Cell and header renderers live on the **renderer's** column spec instead, such as `DataView.List`'s `columns`.
 
 ```ts
 const fields: DataViewField<Person>[] = [
@@ -81,7 +81,7 @@ The split is what lets one set of filters, sorts, and toggles drive every render
 
 ### Search
 
-`DataView.Search` writes the input to `query.search`, which feeds TanStack's `globalFilter` — rows are filtered across every field as the user types. Drop it into the toolbar wherever you want it; in client mode no extra wiring is needed. Type a name, email, or team below to filter the rows.
+`DataView.Search` writes the input to `query.search`, which feeds TanStack's `globalFilter`, so rows are filtered across every field as the user types. Drop it into the toolbar wherever you want it; in client mode no extra wiring is needed. Type a name, email, or team below to filter the rows.
 
 <Demo data={searchPreview} />
 
@@ -89,7 +89,7 @@ By default search auto-disables in the zero state (no data and no active query) 
 
 ### Display properties
 
-Column visibility is a **single global map** on context. `DataView.List` honours it for free — TanStack column visibility hides the grid track. For free-form renderers, wrap fields in `DataView.DisplayAccess`:
+Column visibility is a **single global map** on context. `DataView.List` honours it for free, since TanStack column visibility hides the grid track. For free-form renderers, wrap fields in `DataView.DisplayAccess`:
 
 ```tsx
 <DataView.DisplayAccess accessorKey="email">
@@ -103,8 +103,8 @@ Column visibility is a **single global map** on context. `DataView.List` honours
 
 Empty and zero are computed once on context (`isEmptyState`, `isZeroState`) and exposed as sibling components.
 
-- **Zero state** — no data, no active query. The first-use surface. The toolbar is hidden automatically.
-- **Empty state** — no rows visible because filters, search, or sort exclude them all. The toolbar stays visible so the user can correct it.
+- **Zero state**: no data, no active query. The first-use surface. The toolbar is hidden automatically.
+- **Empty state**: no rows visible because filters, search, or sort exclude them all. The toolbar stays visible so the user can correct it.
 
 ```tsx
 <DataView.EmptyState>
@@ -116,7 +116,7 @@ Empty and zero are computed once on context (`isEmptyState`, `isZeroState`) and 
 <DataView.ClearFilters />
 ```
 
-Renderers return `null` when `!hasData` — the siblings render the messaging.
+Renderers return `null` when `!hasData`, and the siblings render the messaging.
 
 <Demo data={emptyZeroPreview} />
 
@@ -136,13 +136,13 @@ When rows are hidden by filters, `DataView.List` automatically renders a flat fo
 
 ### Multi-view
 
-Pass `views` and give each renderer a `name`. `DataView.DisplayControls` hosts the view switcher at the top of its popover automatically — give each view an optional `leadingIcon` to show alongside its label. Query state (filters, sort, search, visibility) persists across switches.
+Pass `views` and give each renderer a `name`. `DataView.DisplayControls` hosts the view switcher at the top of its popover automatically. Give each view an optional `leadingIcon` to show alongside its label. Query state (filters, sort, search, visibility) persists across switches.
 
 <Demo data={multiViewPreview} />
 
 ### Per-view fields
 
-Each renderer accepts an optional `fields` prop. It **fully replaces** the root `fields` for that view's active session — filter chips, sort menu, and Display Properties reflect the override while the view is active. The common pattern is to spread the root fields and tweak the few that differ.
+Each renderer accepts an optional `fields` prop. It **fully replaces** the root `fields` for that view's active session, so filter chips, sort menu, and Display Properties reflect the override while the view is active. The common pattern is to spread the root fields and tweak the few that differ.
 
 <Demo data={perViewFieldsPreview} />
 
@@ -178,13 +178,13 @@ In client mode `DataView` derives everything locally: filter predicates, sort, g
 </DataView>
 ```
 
-- **`onTableQueryChange`** hands you the full [query object](#query) whenever any part of it changes — a filter chip, a sort, a grouping choice, a keystroke in search. Translate it to your API's parameters and refetch.
+- **`onTableQueryChange`** hands you the full [query object](#query) whenever any part of it changes: a filter chip, a sort, a grouping choice, a keystroke in search. Translate it to your API's parameters and refetch.
 - **`totalRowCount`** is what the "hidden by filters" footer counts against. Without it the footer can't tell how many rows your filters excluded, since the client only ever sees the current page.
 - **Grouping** still comes from the root's `groupData`, so section order, labels, and counts match across renderers.
 
 Sorting is the one place a silent mismatch is possible. Rows render in whatever order your backend returned them, so a backend that ignores the `sort` it was handed produces a correctly filtered view in an arbitrary order, with nothing logged to say so.
 
-Grouping stays `group_by: string[]` on the wire in both modes. To group by something that isn't a raw accessor — "by week of `created_at`", "by first letter" — supply a resolver on the root. The resolved key is what lands in `query.group_by`, so your backend receives a stable string it can switch on, and the same code works unchanged in client mode.
+Grouping stays `group_by: string[]` on the wire in both modes. To group by something that isn't a raw accessor, such as "by week of `created_at`" or "by first letter", supply a resolver on the root. The resolved key is what lands in `query.group_by`, so your backend receives a stable string it can switch on, and the same code works unchanged in client mode.
 
 ```tsx
 <DataView

--- a/apps/www/src/content/docs/dataview/list.mdx
+++ b/apps/www/src/content/docs/dataview/list.mdx
@@ -1,6 +1,6 @@
 ---
 title: List
-description: DataView's table and list renderer — two presentations behind one component, with virtualization, grouping, and row selection.
+description: DataView's table and list renderer. Two presentations behind one component, with virtualization, grouping, and row selection.
 source: packages/raystack/components/data-view
 ---
 
@@ -18,7 +18,7 @@ import {
 
 ## Overview
 
-`DataView.List` draws the row model as a grid. It ships two presentations behind one renderer — `variant="table"` for column headers and aligned tracks, `variant="list"` for card-style rows — and both read the same [fields, filters, and display properties](/docs/dataview) declared on the root.
+`DataView.List` draws the row model as a grid. It ships two presentations behind one renderer, `variant="table"` for column headers and aligned tracks and `variant="list"` for card-style rows, and both read the same [fields, filters, and display properties](/docs/dataview) declared on the root.
 
 ## Anatomy
 
@@ -42,7 +42,7 @@ One renderer, two presentations. `variant` decides which; everything else applie
 
 ### Variant
 
-`variant="table"` is the default: a header row, aligned column tracks, and real table semantics. `variant="list"` drops the header and renders card-style rows — the default `1fr` middle column with `auto` end columns gives you the familiar justify-between layout.
+`variant="table"` is the default: a header row, aligned column tracks, and real table semantics. `variant="list"` drops the header and renders card-style rows, where the default `1fr` middle column with `auto` end columns gives you the familiar justify-between layout.
 
 <Demo data={listPreview} />
 
@@ -61,13 +61,13 @@ An accessor with no matching entry in the root's `fields` is an **unmanaged disp
 
 ### Virtualization
 
-For large datasets, pass `virtualized`. The parent must have a fixed height — only the rows in view are rendered. Rows auto-measure after paint, so variable-height content (avatars, wrapped text, badges) just works. `estimatedRowHeight` is an optional hint used only until the first measurement.
+For large datasets, pass `virtualized`. The parent must have a fixed height, and only the rows in view are rendered. Rows auto-measure after paint, so variable-height content (avatars, wrapped text, badges) just works. `estimatedRowHeight` is an optional hint used only until the first measurement.
 
 <Demo data={virtualizedPreview} />
 
 ### Grouping
 
-Group rows by any `groupable` field. `stickyGroupHeader` pins the active group label directly under the column headers while you scroll past that group's rows. Pick a different field from `DisplayControls` → Grouping at runtime — the wire format stays `group_by: string[]`.
+Group rows by any `groupable` field. `stickyGroupHeader` pins the active group label directly under the column headers while you scroll past that group's rows. Pick a different field from `DisplayControls` → Grouping at runtime, and the wire format stays `group_by: string[]`.
 
 <Demo data={groupingPreview} />
 
@@ -81,7 +81,7 @@ While `isLoading` is `true`, `DataView.List` renders `loadingRowCount` skeleton 
 
 <Demo data={loadingPreview} />
 
-In [server mode](/docs/dataview#server-mode), infinite scroll triggers via a single sentinel and an `IntersectionObserver` — there are no scroll-distance knobs to tune. While `isLoading` is true the sentinel is suppressed so your `onLoadMore` isn't fired again during a fetch.
+In [server mode](/docs/dataview#server-mode), infinite scroll triggers via a single sentinel and an `IntersectionObserver`, so there are no scroll-distance knobs to tune. While `isLoading` is true the sentinel is suppressed so your `onLoadMore` isn't fired again during a fetch.
 
 ### Row selection
 
@@ -91,11 +91,11 @@ DataView doesn't ship a selection toolbar, but the underlying TanStack table ins
 
 - **Pass `getRowId` whenever the data can change under you.** Without it, selection falls back to positional keys (`'0'`, `'1'`, and `'<group>.<index>'` inside a group section). Those keys come from the `data` array rather than the visible order, so client-side sort, filter, and search are safe, and a static dataset needs nothing. What they can't survive is the identity behind a position changing: a refetch or a server-mode sort returning rows in a new order moves the selection to whatever now sits at that index, and toggling Grouping re-keys the rows and drops it.
 - **Selection state lives on the table instance.** Read it with `table.getSelectedRowModel()`, clear it with `table.resetRowSelection()`, and mirror it outside the tree with `onRowSelectionChange` on the root.
-- **The TanStack [row selection API](https://tanstack.com/table/v8/docs/guide/row-selection) works as documented** — `row.getIsSelected()`, `row.toggleSelected()`, `row.getIsSomeSelected()`, `table.getIsAllRowsSelected()`, `getIsSomeRowsSelected()`, `toggleAllRowsSelected()`, `setRowSelection()`, `resetRowSelection()`. The header helpers are computed over the **filtered** rows, so select-all tracks what the user can see rather than the whole dataset.
+- **The TanStack [row selection API](https://tanstack.com/table/v8/docs/guide/row-selection) works as documented**: `row.getIsSelected()`, `row.toggleSelected()`, `row.getIsSomeSelected()`, `table.getIsAllRowsSelected()`, `getIsSomeRowsSelected()`, `toggleAllRowsSelected()`, `setRowSelection()`, `resetRowSelection()`. The header helpers are computed over the **filtered** rows, so select-all tracks what the user can see rather than the whole dataset.
 - **Skip the two handler getters from that guide.** `row.getToggleSelectedHandler()` and `table.getToggleAllRowsSelectedHandler()` adapt a native `<input type="checkbox" onChange>` and read `event.target.checked`. Apsara's [`Checkbox`](/docs/components/checkbox) reports a boolean through `onCheckedChange`, so the table-level getter throws on `undefined.checked` and the row-level one only works through its "no value means invert" fallback. Call `toggleSelected` and `toggleAllRowsSelected` with the boolean instead.
-- **Position the bar through `FloatingActions`.** It defaults to `variant="floating"` — `position: fixed`, bottom-center — so the call site needs no positioning CSS. To scope the bar to the view instead of the viewport, give an ancestor `transform`, `filter`, or `contain: paint` so it becomes the containing block. Add `padding-bottom` via `classNames.root` if rows would otherwise sit behind it.
+- **Position the bar through `FloatingActions`.** It defaults to `variant="floating"`, meaning `position: fixed` and bottom-center, so the call site needs no positioning CSS. To scope the bar to the view instead of the viewport, give an ancestor `transform`, `filter`, or `contain: paint` so it becomes the containing block. Add `padding-bottom` via `classNames.root` if rows would otherwise sit behind it.
 - **Stop propagation in the checkbox's `onClick`** when the root has an `onRowClick`, otherwise ticking a checkbox also activates the row.
-- **Grouping works alongside selection.** Group header rows are keyed in their own id space and are not selectable, so `rowSelection` holds one key per data row and select-all covers the visible data rows without flagging the bands. Read the count off `getSelectedRowModel().flatRows`, not `.rows` — the latter only walks selected *top-level* rows, which is empty while grouping puts every data row one level down.
+- **Grouping works alongside selection.** Group header rows are keyed in their own id space and are not selectable, so `rowSelection` holds one key per data row and select-all covers the visible data rows without flagging the bands. Read the count off `getSelectedRowModel().flatRows`, not `.rows`, since the latter only walks selected *top-level* rows, which is empty while grouping puts every data row one level down.
 
 ## API Reference
 

--- a/apps/www/src/content/docs/dataview/timeline.mdx
+++ b/apps/www/src/content/docs/dataview/timeline.mdx
@@ -1,6 +1,6 @@
 ---
 title: Timeline
-description: DataView's time-axis renderer — cards positioned on a continuous, scrollable date range with lane packing, swim-lane grouping, and range-window loading.
+description: DataView's time-axis renderer. Cards positioned on a continuous, scrollable date range with lane packing, swim-lane grouping, and range-window loading.
 source: packages/raystack/components/data-view
 ---
 
@@ -15,9 +15,9 @@ import {
 
 ## Overview
 
-`DataView.Timeline` positions the same row model as cards on a continuous, horizontally scrollable time axis — orders on a delivery schedule, tasks on a Gantt-style plan, releases on a strip. It shares the root's entire data layer: search, filters, grouping, and Display Properties apply to cards exactly as they do to list rows, and it participates in multi-view switching via `name`.
+`DataView.Timeline` positions the same row model as cards on a continuous, horizontally scrollable time axis: orders on a delivery schedule, tasks on a Gantt-style plan, releases on a strip. It shares the root's entire data layer: search, filters, grouping, and Display Properties apply to cards exactly as they do to list rows, and it participates in multi-view switching via `name`.
 
-In the demo above: drag the background to pan (with a momentum glide), hover for the snapped date cursor, and use the Today button — wired through `actionsRef` — to jump back. The narrow "B" stub is a span shorter than `minCardWidth`, rendered via `context.collapsed`.
+In the demo above: drag the background to pan (with a momentum glide), hover for the snapped date cursor, and use the Today button, wired through `actionsRef`, to jump back. The narrow "B" stub is a span shorter than `minCardWidth`, rendered via `context.collapsed`.
 
 ## Anatomy
 
@@ -45,7 +45,7 @@ Horizontal position is always time. Everything below is about the vertical axis 
 
 ### Cards
 
-The Timeline owns **positioning** — the time scale (date to x, span to width, using real timestamps so variable-length months don't distort placement), lane packing, the sticky two-tier axis, and scrolling. You own the **card**: `renderCard(row, context)` draws everything visual, the same split as `DataView.List`'s `columns[].cell`.
+The Timeline owns **positioning**: the time scale (date to x, span to width, using real timestamps so variable-length months don't distort placement), lane packing, the sticky two-tier axis, and scrolling. You own the **card**: `renderCard(row, context)` draws everything visual, the same split as `DataView.List`'s `columns[].cell`.
 
 ```tsx
 <DataView.Timeline
@@ -59,7 +59,7 @@ The Timeline owns **positioning** — the time scale (date to x, span to width, 
 />
 ```
 
-`context.collapsed` flips when the span is narrower than `minCardWidth` (default 60px) — render a compact stub instead of letting the full card clip. Point cards never collapse; they size to their content. Wrap card fields in `DataView.DisplayAccess` so the toolbar's Display Properties toggles reach them.
+`context.collapsed` flips when the span is narrower than `minCardWidth` (default 60px). Render a compact stub instead of letting the full card clip. Point cards never collapse; they size to their content. Wrap card fields in `DataView.DisplayAccess` so the toolbar's Display Properties toggles reach them.
 
 Card height is content-driven, the same contract as `DataView.List` rows: cards auto-measure after paint, each lane sizes to its tallest card, and `estimatedRowHeight` (default 66) is only a layout hint until real heights arrive.
 
@@ -67,17 +67,17 @@ Under `virtualized` this inverts. A culled card never reports a height, so measu
 
 Give a card an explicit height if you want uniform cards, and keep that height within the pitch if you virtualize.
 
-Keep `renderCard` referentially stable — define it outside the component or wrap it in `useCallback`. Cards are memoized against it, and an inline closure forces every visible card to re-render on each scroll frame.
+Keep `renderCard` referentially stable by defining it outside the component or wrapping it in `useCallback`. Cards are memoized against it, and an inline closure forces every visible card to re-render on each scroll frame.
 
 ### Point markers
 
-Omit `endField` and rows render as point markers at their date — releases, incidents, audit events. The wrapper sizes to the card's content instead of a time span, and `context.end` is `null`. Because the packer can't measure content, it assumes each point card is `estimatedPointWidth` wide (default 120px) when assigning lanes — set it to roughly your widest point card so nearby markers don't overlap in a lane.
+Omit `endField` and rows render as point markers at their date: releases, incidents, audit events. The wrapper sizes to the card's content instead of a time span, and `context.end` is `null`. Because the packer can't measure content, it assumes each point card is `estimatedPointWidth` wide (default 120px) when assigning lanes. Set it to roughly your widest point card so nearby markers don't overlap in a lane.
 
 <Demo data={timelinePointPreview} />
 
 ### Lane packing
 
-`lanePacking` decides what a lane *means*. All three modes run per group section — a card never shares a lane across sections.
+`lanePacking` decides what a lane *means*. All three modes run per group section. A card never shares a lane across sections.
 
 | Mode | A lane is | Use it for |
 | --- | --- | --- |
@@ -107,15 +107,15 @@ The active sort does double duty here: it picks the field lanes are built from *
 </DataView>
 ```
 
-- **Rank what doesn't sort naturally.** Sorting `priority` alphabetically gives High, Low, Medium. Carry a numeric `rank` alongside it and sort on that for High, Medium, Low — the lane values are then the ranks, which is invisible unless your card shows them.
-- **Rows with no usable value** — null, `undefined`, `""`, or a non-primitive (which also logs a dev warning) — share one lane, always last, wherever the sort would have put them.
+- **Rank what doesn't sort naturally.** Sorting `priority` alphabetically gives High, Low, Medium. Carry a numeric `rank` alongside it and sort on that for High, Medium, Low. The lane values are then the ranks, which is invisible unless your card shows them.
+- **Rows with no usable value**, meaning null, `undefined`, `""`, or a non-primitive (which also logs a dev warning), share one lane, always last, wherever the sort would have put them.
 - **Values are keyed by their string form**, so `1` and `"1"` share a lane. Resolve an object-valued field to a primitive before sorting on it.
 - **No sort, no lanes.** The mode falls back to `auto` if the query carries no sort. `defaultSort` is required on the root, so that's a guard rather than a configuration.
 - **With `group_by` active**, each section gets its own lane set and `context.laneIndex` stays section-relative. Grouping by the sorted field is allowed, and collapses to the simple case: a section already holds one value, so it renders as one lane, plus sub-lanes on overlap.
 
 ### Grouping
 
-Set `group_by` — from `DataView.DisplayControls` → Grouping, or on the initial `query` — and the timeline splits into **swim-lane sections** stacked under the single shared time axis: a full-width header band per group, with that group's cards lane-packed beneath it. Horizontal position stays purely time; grouping reorganizes vertically only.
+Set `group_by`, either from `DataView.DisplayControls` → Grouping or on the initial `query`, and the timeline splits into **swim-lane sections** stacked under the single shared time axis: a full-width header band per group, with that group's cards lane-packed beneath it. Horizontal position stays purely time; grouping reorganizes vertically only.
 
 <Demo data={timelineGroupingPreview} />
 
@@ -131,27 +131,27 @@ const fields = [
 </DataView>
 ```
 
-The timeline consumes the **same group rows** `DataView.List` renders as section headers — the root's `groupData` output — so section order, labels (`groupLabelsMap`), and counts (`groupCountMap`, or the bucket size) match between views, in client and server mode alike. There's no timeline-specific grouping path to keep in sync.
+The timeline consumes the **same group rows** `DataView.List` renders as section headers (the root's `groupData` output), so section order, labels (`groupLabelsMap`), and counts (`groupCountMap`, or the bucket size) match between views, in client and server mode alike. There's no timeline-specific grouping path to keep in sync.
 
-Section order is the field's `groupOrder` where it declares one (`['High', 'Medium', 'Low']` — the ranking sorting can't express), then values it doesn't list in first-occurrence order, with rows that have no value in the last section. A declared value with no rows renders no section.
+Section order is the field's `groupOrder` where it declares one (`['High', 'Medium', 'Low']`, the ranking sorting can't express), then values it doesn't list in first-occurrence order, with rows that have no value in the last section. A declared value with no rows renders no section.
 
-- **Packing is per section.** A card only ever shares a lane with cards in its own group, and `context.laneIndex` is section-relative — every section starts at lane 0. `lanePacking="one-per-row"` and `"one-per-sort-value"` apply within each section too.
-- **Bands pin while their section is in view.** The active band sticks directly under the time axis and is pushed off by the next section's band; its label sticks to the left edge so it stays readable while you pan to a distant month. Always on — pure CSS, no prop.
-- **Empty sections disappear.** A group whose cards all fall outside an explicit `range`, or that has no valid `startField` values, renders nothing — no band, no empty strip. A band that *does* render shows the full group count, even when some of its cards are culled, matching List.
-- **`showGroupHeaders={false}`** hides the bands but keeps the sections — same semantics as the prop on `DataView.List`. Style a band with `classNames.groupHeader`.
+- **Packing is per section.** A card only ever shares a lane with cards in its own group, and `context.laneIndex` is section-relative. Every section starts at lane 0. `lanePacking="one-per-row"` and `"one-per-sort-value"` apply within each section too.
+- **Bands pin while their section is in view.** The active band sticks directly under the time axis and is pushed off by the next section's band; its label sticks to the left edge so it stays readable while you pan to a distant month. Always on, in pure CSS, with no prop.
+- **Empty sections disappear.** A group whose cards all fall outside an explicit `range`, or that has no valid `startField` values, renders nothing: no band, no empty strip. A band that *does* render shows the full group count, even when some of its cards are culled, matching List.
+- **`showGroupHeaders={false}`** hides the bands but keeps the sections, the same semantics as the prop on `DataView.List`. Style a band with `classNames.groupHeader`.
 
 Bands are labels only in this release: no chevron, no collapsing.
 
 ### Ordering
 
-Sort can't move a card horizontally — x is locked to the start date — so it reaches the vertical axis only, and only under two of the three packing modes.
+Sort can't move a card horizontally, because x is locked to the start date, so it reaches the vertical axis only, and only under two of the three packing modes.
 
-- **`one-per-row`** — row order follows the active sort, within each section when grouped.
-- **`one-per-sort-value`** — the sorted-by field *defines* the lanes, so changing the sort field rebuilds them.
+- **`one-per-row`**: row order follows the active sort, within each section when grouped.
+- **`one-per-sort-value`**: the sorted-by field *defines* the lanes, so changing the sort field rebuilds them.
 
 Leave the Ordering control visible for both.
 
-Under the default `auto` packing the sort has no visible effect at all — lanes are assigned by dense chronological first-fit — so there, hide the control with `<DataView.DisplayControls hideOrdering />`, or leave `sortable` off the timeline's per-view `fields`.
+Under the default `auto` packing the sort has no visible effect at all, since lanes are assigned by dense chronological first-fit, so there hide the control with `<DataView.DisplayControls hideOrdering />`, or leave `sortable` off the timeline's per-view `fields`.
 
 In [server mode](/docs/dataview#server-mode) the sort is the backend's to apply: rows arrive already ordered and `one-per-sort-value` takes lane order from that row order, first value seen first. A backend that ignores the `sort` in `onTableQueryChange` therefore produces lanes in whatever order it returned rows, with nothing logged to say so. The lane *membership* is still correct, only the ranking is arbitrary.
 
@@ -159,12 +159,12 @@ In [server mode](/docs/dataview#server-mode) the sort is the backend's to apply:
 
 Four props control the axis, and they compose rather than overlap:
 
-- `scale` — the tick unit: `day` (default), `week`, `month`, or `quarter`.
-- `unitWidth` — pixels per unit (defaults: day 20, week 56, month 96, quarter 140). This is the zoom knob.
-- `tickInterval` — label every Nth unit. Labels never render closer than a collision floor, so a too-dense value degrades gracefully instead of overlapping.
-- `gridlineInterval` — draw a gridline every Nth unit. Purely visual: cards, the today line, and cursor snapping still land on every unit.
+- `scale` sets the tick unit: `day` (default), `week`, `month`, or `quarter`.
+- `unitWidth` sets pixels per unit (defaults: day 20, week 56, month 96, quarter 140). This is the zoom knob.
+- `tickInterval` labels every Nth unit. Labels never render closer than a collision floor, so a too-dense value degrades gracefully instead of overlapping.
+- `gridlineInterval` draws a gridline every Nth unit. Purely visual: cards, the today line, and cursor snapping still land on every unit.
 
-The domain defaults to the data extent (plus today and markers) with padding. Pass an explicit `range` to fix the coordinate space — essential for range-window loading, since the scrollbar then never jumps as data streams in. Rows entirely outside an explicit `range` are culled.
+The domain defaults to the data extent (plus today and markers) with padding. Pass an explicit `range` to fix the coordinate space. This is essential for range-window loading, since the scrollbar then never jumps as data streams in. Rows entirely outside an explicit `range` are culled.
 
 ### Today and markers
 
@@ -194,7 +194,7 @@ const timelineActions = useRef<TimelineActions | null>(null);
 </Button>
 ```
 
-`scrollTo(target, { align = "center", behavior = "smooth" })` accepts the same target vocabulary as `defaultScrollTo`. Out-of-domain dates clamp to the nearest domain edge; while the timeline is hidden (inactive view, no data) calls no-op with a dev warning. `getVisibleRange()` returns the visible `[Date, Date]` window, or `null` while hidden — useful for showing the Today button only when today is off-screen.
+`scrollTo(target, { align = "center", behavior = "smooth" })` accepts the same target vocabulary as `defaultScrollTo`. Out-of-domain dates clamp to the nearest domain edge; while the timeline is hidden (inactive view, no data) calls no-op with a dev warning. `getVisibleRange()` returns the visible `[Date, Date]` window, or `null` while hidden, which is useful for showing the Today button only when today is off-screen.
 
 Filtering navigates too: when a filter or search change leaves no matching card in the viewport, the timeline scrolls the earliest match into view instead of leaving you parked on empty canvas. A change whose results are already on screen doesn't move the view. Opt out with `scrollToResults={false}`.
 
@@ -202,17 +202,17 @@ Filtering navigates too: when a filter or search change leaves no matching card 
 
 `virtualized` culls both axes. Cards, gridlines, tick labels, month bands, and markers render only near the viewport, and the grid and marker lines span the visible window rather than the full canvas height.
 
-A frame then costs what is on screen rather than what is in the data, so a long domain and deep grouping stay affordable. It defaults to `false` — pass it explicitly. Reach for it whenever the domain is long or the rows are many.
+A frame then costs what is on screen rather than what is in the data, so a long domain and deep grouping stay affordable. It defaults to `false`, so pass it explicitly. Reach for it whenever the domain is long or the rows are many.
 
 Without it, nothing is culled vertically. Every lane in the domain stays mounted and every card in the visible time window renders, so deep grouping over thousands of rows builds a tall, fully populated canvas. The trade is content-driven lane heights, which virtualization gives up.
 
 ### Loading by visible range
 
-Offset pagination doesn't fit a 2-D time canvas — the natural unit of fetching is the **visible window**. So unlike List, a timeline backed by an API usually stays in **client mode** and fetches through `onVisibleRangeChange` rather than switching to [server mode](/docs/dataview#server-mode).
+Offset pagination doesn't fit a 2-D time canvas. The natural unit of fetching is the **visible window**. So unlike List, a timeline backed by an API usually stays in **client mode** and fetches through `onVisibleRangeChange` rather than switching to [server mode](/docs/dataview#server-mode).
 
 1. Fix the coordinate space with an explicit `range` so the scrollbar stays stable while rows stream in.
 2. On `onVisibleRangeChange`, widen the window by a prefetch pad and fetch rows **overlapping** it (`start <= to AND end >= from`). A containment filter drops cards straddling the window edges.
-3. Track requested buckets, such as months, in a `Set` so re-entering a window is free, and dedupe merged rows by id — edge-straddling rows come back from both adjacent fetches. On a failed fetch, delete the affected buckets from the `Set` so scrolling back retries them instead of leaving a permanent hole.
+3. Track requested buckets, such as months, in a `Set` so re-entering a window is free, and dedupe merged rows by id, since edge-straddling rows come back from both adjacent fetches. On a failed fetch, delete the affected buckets from the `Set` so scrolling back retries them instead of leaving a permanent hole.
 4. Throttle, don't debounce. A debounce waits for scrolling to stop, leaving a gap of missing cards mid-drag.
 
 ```tsx
@@ -240,7 +240,7 @@ const [isLoading, setIsLoading] = useState(true); // initial fetch in flight
 
 Start with `isLoading={true}` and fire an initial fetch on mount. With no data and no loading flag the timeline renders `null` and the zero state takes over, so `onVisibleRangeChange` would never fire to bootstrap the first window.
 
-Keep the row model **cumulative**. The domain is stable, so previously fetched cards stay mounted and scrolling back is instant. Scroll position is anchored by *time*, not pixels: if the domain shifts — a `range` extension, rows prepended by a fetch — the date under the viewport's left edge stays put instead of the content jumping.
+Keep the row model **cumulative**. The domain is stable, so previously fetched cards stay mounted and scrolling back is instant. Scroll position is anchored by *time*, not pixels: if the domain shifts (a `range` extension, or rows prepended by a fetch), the date under the viewport's left edge stays put instead of the content jumping.
 
 ## API Reference
 

--- a/apps/www/src/content/docs/theme/colors/index.mdx
+++ b/apps/www/src/content/docs/theme/colors/index.mdx
@@ -3,7 +3,7 @@ title: Colors
 description: Overview of the color system and semantic color tokens in Apsara.
 ---
 
-Apsara uses a semantic color system that provides meaningful, context-aware colors for your interface. Rather than using fixed color values, semantic tokens represent the intended purpose of a color—such as "primary text" or "danger background"—and automatically resolve to the appropriate value based on the active theme and style. This abstraction allows you to build consistent, themeable interfaces by focusing on what a color represents rather than what it looks like.
+Apsara uses a semantic color system that provides meaningful, context-aware colors for your interface. Rather than using fixed color values, semantic tokens represent the intended purpose of a color, such as "primary text" or "danger background", and automatically resolve to the appropriate value based on the active theme and style. This abstraction allows you to build consistent, themeable interfaces by focusing on what a color represents rather than what it looks like.
 
 ## Foreground colors
 

--- a/apps/www/src/content/docs/theme/effects/index.mdx
+++ b/apps/www/src/content/docs/theme/effects/index.mdx
@@ -3,7 +3,7 @@ title: Effects
 description: Overview of shadow and blur effect tokens in Apsara.
 ---
 
-Shadows and blur add depth. Effect tokens are tuned for both themes — shadow intensity and color shift so contrast holds in light and dark. Custom surfaces and overlays built on them sit naturally beside the rest of the interface.
+Shadows and blur add depth. Effect tokens are tuned for both themes, so shadow intensity and color shift so contrast holds in light and dark. Custom surfaces and overlays built on them sit naturally beside the rest of the interface.
 
 ## Shadows
 

--- a/apps/www/src/content/docs/theme/icons/index.mdx
+++ b/apps/www/src/content/docs/theme/icons/index.mdx
@@ -31,7 +31,7 @@ You pay only for the icons you import. A build that shows three icons ships
 three icons, not all 31.
 
 The package root exports the same components, so
-`import { SearchIcon } from '@raystack/apsara'` works too — it is the natural
+`import { SearchIcon } from '@raystack/apsara'` works too, and it is the natural
 choice in a file that already imports Apsara components. See
 [which path to import from](#which-path-to-import-from) for the difference.
 
@@ -41,7 +41,7 @@ choice in a file that already imports Apsara components. See
 
 Need an icon that is not here? `createIcon` is public, so
 [build your own](#building-your-own-icons) and it behaves like the ones above.
-lucide draws over 1,700 icons and your app can reach all of them — Apsara
+lucide draws over 1,700 icons and your app can reach all of them. Apsara
 exports these 31 because they are the ones inside its components, which you
 cannot reach any other way.
 
@@ -63,7 +63,7 @@ the drawing behind them is a choice rather than a shape you asked for:
 | `CoPilotIcon` | lucide `Sparkles` |
 
 A key is yours to rely on; the drawing behind it can change in a release. So
-prefer the key that says the job — `SortDescendingIcon` — over one that repeats
+prefer the key that says the job, such as `SortDescendingIcon`, over one that repeats
 lucide's own vocabulary.
 
 Two keys can share a drawing. `ErrorIcon` and `ClearIcon` are both `CircleX`, so
@@ -77,7 +77,7 @@ Every icon renders with `width={16} height={16} strokeWidth={1.5}`. The rendered
 stroke is `strokeWidth × size ÷ 24`, because lucide draws in a 24-unit viewBox.
 So the default draws a 1px stroke at 16px.
 
-If you change the size and want to keep a 1px stroke, scale the stroke with it —
+If you change the size and want to keep a 1px stroke, scale the stroke with it:
 `strokeWidth={24 / size}`.
 
 All three are standard SVG attributes, so any icon library accepts them. A
@@ -136,7 +136,7 @@ const icons = {
 </Theme>
 ```
 
-Apsara then uses your component everywhere that icon appears — inside its own
+Apsara then uses your component everywhere that icon appears, including inside its own
 components too. The map is partial: a key you do not name keeps its default, so
 you never have to supply a complete set.
 
@@ -152,7 +152,7 @@ still win.
 
 <Demo data={globalPropsDemo} />
 
-Prefer `data-icon` and CSS when a style rule is enough — `props` flows through
+Prefer `data-icon` and CSS when a style rule is enough. `props` flows through
 React and re-renders the icons, and CSS does not.
 
 ### Nesting
@@ -169,7 +169,7 @@ Overrides are resolved at runtime, so a bundler cannot know which defaults to
 drop.
 
 Replacing all 31 costs about 3.6 kB gzipped of lucide that never draws. The cost
-is flat — it does not grow as you override more. If you want the default gone
+is flat and does not grow as you override more. If you want the default gone
 from the bundle entirely, import your own icon at the call site instead of
 overriding it.
 
@@ -179,7 +179,7 @@ overriding it.
 that does:
 
 ```tsx
-// src/icons.ts — the app's single place for icons
+// src/icons.ts: the app's single place for icons
 import { createIcon } from '@raystack/apsara/icons';
 import { Rocket, Trash2 } from 'lucide-react';
 
@@ -197,11 +197,11 @@ You get the base props, `data-icon`, and one file to edit if you ever change
 icon library.
 
 Your icons read the same context, so the `props` half of `<Theme icons>` reaches
-them too. The `components` half only accepts the keys Apsara ships — to change
+them too. The `components` half only accepts the keys Apsara ships. To change
 one of your own, edit the file above.
 
 <Callout type="grey">
-  lucide exports several aliases per icon — `Search`, `SearchIcon` and
+  lucide exports several aliases per icon, so `Search`, `SearchIcon` and
   `LucideSearch` are the same drawing. Apsara's names collide with the middle
   flavour, so `import { SearchIcon } from 'lucide-react'` and `import
   { SearchIcon } from '@raystack/apsara/icons'` are different components with one
@@ -244,8 +244,8 @@ export default function Layout({ children }) {
 }
 ```
 
-Resolution is a pure function of the context and the props — no `localStorage`,
-no `window`, no effect — so the server markup and the client markup are
+Resolution is a pure function of the context and the props, with no `localStorage`,
+no `window` and no effect, so the server markup and the client markup are
 identical. There is no hydration mismatch and no flash of the wrong icon.
 
 ## Which path to import from
@@ -284,7 +284,7 @@ The `icons` prop on `Theme`.
 
 ### IconOptions
 
-The object `icons` accepts — `components` replaces drawings by key, `props` applies to every icon.
+The object `icons` accepts. `components` replaces drawings by key, and `props` applies to every icon.
 
 <auto-type-table path="./props.ts" name="IconOptions" />
 
@@ -302,7 +302,7 @@ function createIcon(name: string, Default: IconComponent): IconComponent;
 ```
 
 Wraps a component as an Apsara icon: base props below the call site,
-`data-icon="<name>"`, and the provider `props`. `name` is any string —
+`data-icon="<name>"`, and the provider `props`. `name` is any string, while
 `IconName` covers only what Apsara ships, and only those keys can be replaced
 through `<Theme icons>`.
 
@@ -310,7 +310,7 @@ through `<Theme icons>`.
 
 `IconProps` is `Omit<SVGProps<SVGSVGElement>, 'children'>`: every SVG attribute
 React accepts, minus `children`. In practice you pass `width`, `height`,
-`strokeWidth`, `className`, `style` or `color` — see [base props](#base-props).
+`strokeWidth`, `className`, `style` or `color`. See [base props](#base-props).
 
 `IconComponent` is `ComponentType<IconProps>`, so any component with those props
 can stand in for an icon. `IconOverrides` is

--- a/apps/www/src/content/docs/theme/overview/index.mdx
+++ b/apps/www/src/content/docs/theme/overview/index.mdx
@@ -25,7 +25,7 @@ function App() {
 
 ## Customization
 
-The `Theme` component accepts props to control the visual identity of your application. Combine `style` variants with `accentColor` and `grayColor` to create distinct aesthetics—from sharp and technical to warm and editorial. The `defaultTheme` prop controls light/dark mode, with `system` respecting the user's OS preference.
+The `Theme` component accepts props to control the visual identity of your application. Combine `style` variants with `accentColor` and `grayColor` to create distinct aesthetics, from sharp and technical to warm and editorial. The `defaultTheme` prop controls light/dark mode, with `system` respecting the user's OS preference.
 
 ```tsx
 // Clean, technical aesthetic
@@ -44,22 +44,22 @@ See [API Reference](#api-reference) for all available props and options.
 
 Tokens follow two naming patterns:
 
-**Semantic tokens** — for context-aware values that adapt to theme:
+**Semantic tokens** hold context-aware values that adapt to the theme:
 ```
 --rs-{category}-{property}-{variant}-{state}
 ```
 
-**Scale tokens** — for numerical progressions:
+**Scale tokens** hold numerical progressions:
 ```
 --rs-{category}-{step}
 ```
 
 **Examples:**
-- `--rs-color-foreground-base-primary` — primary text color
-- `--rs-color-background-accent-emphasis` — accent button background
-- `--rs-space-5` — 16px spacing
-- `--rs-radius-3` — medium border radius
-- `--rs-shadow-lifted` — elevated shadow
+- `--rs-color-foreground-base-primary`: primary text color
+- `--rs-color-background-accent-emphasis`: accent button background
+- `--rs-space-5`: 16px spacing
+- `--rs-radius-3`: medium border radius
+- `--rs-shadow-lifted`: elevated shadow
 
 **Using tokens in CSS:**
 
@@ -74,21 +74,21 @@ Tokens follow two naming patterns:
 ```
 
 **Token Categories:**
-- [Colors](/docs/theme/colors) — foreground, background, border, and overlay colors
-- [Spacing](/docs/theme/spacing) — consistent scale from 2px to 120px
-- [Radius](/docs/theme/radius) — border radius that adapts to style variants
-- [Typography](/docs/theme/typography) — font families, sizes, weights, and line heights
-- [Effects](/docs/theme/effects) — shadows and blur for depth and elevation
+- [Colors](/docs/theme/colors): foreground, background, border, and overlay colors
+- [Spacing](/docs/theme/spacing): consistent scale from 2px to 120px
+- [Radius](/docs/theme/radius): border radius that adapts to style variants
+- [Typography](/docs/theme/typography): font families, sizes, weights, and line heights
+- [Effects](/docs/theme/effects): shadows and blur for depth and elevation
 
 ## Framework integration
 
-**HTML Attributes** — `Theme` sets data attributes on the document element for CSS targeting:
-- `data-theme` — current color scheme (`light` | `dark`)
-- `data-style` — active style variant (`modern` | `traditional`)
-- `data-accent-color` — active accent color (`indigo` | `orange` | `mint`)
-- `data-gray-color` — active gray variant (`gray` | `mauve` | `slate`)
+**HTML attributes.** `Theme` sets data attributes on the document element for CSS targeting:
+- `data-theme`: current color scheme (`light` | `dark`)
+- `data-style`: active style variant (`modern` | `traditional`)
+- `data-accent-color`: active accent color (`indigo` | `orange` | `mint`)
+- `data-gray-color`: active gray variant (`gray` | `mauve` | `slate`)
 
-**SSR & Flash Prevention** — `Theme` includes an inline script that runs before React hydration to prevent flash of incorrect theme. For SSR frameworks, include the provider in your root layout:
+**SSR and flash prevention.** `Theme` includes an inline script that runs before React hydration to prevent flash of incorrect theme. For SSR frameworks, include the provider in your root layout:
 
 ```tsx
 // Next.js App Router: app/layout.tsx
@@ -109,7 +109,7 @@ The `suppressHydrationWarning` is required because the theme script modifies the
 
 ## Scoped theming
 
-Themes are not limited to the document root. Any element with a `data-theme` attribute creates an isolated theme scope — descendants resolve every design token from the nearest scoped ancestor. This enables theme preview cards, split-screen comparisons, and dark sidebars in light apps without any extra plumbing.
+Themes are not limited to the document root. Any element with a `data-theme` attribute creates an isolated theme scope. Descendants resolve every design token from the nearest scoped ancestor. This enables theme preview cards, split-screen comparisons, and dark sidebars in light apps without any extra plumbing.
 
 ### Bare attribute
 
@@ -147,12 +147,12 @@ When `Theme` is rendered inside another `Theme`, it switches to scope mode: it w
 
 Two rules cover every case:
 
-1. **Each prop inherits independently.** Any prop you don't pass to a nested `Theme` is inherited from the parent. Any prop you do pass overrides only that field — the rest still inherits.
-2. **`useTheme()` inside a scope talks to that scope only.** Calling `setTheme()` updates the nearest scope, never propagates outward. To target a specific outer scope (e.g., the root), use `useTheme({ storageKey })` — see [Targeting a specific scope](#targeting-a-specific-scope).
+1. **Each prop inherits independently.** Any prop you don't pass to a nested `Theme` is inherited from the parent. Any prop you do pass overrides only that field. The rest still inherits.
+2. **`useTheme()` inside a scope talks to that scope only.** Calling `setTheme()` updates the nearest scope, never propagates outward. To target a specific outer scope (e.g., the root), use `useTheme({ storageKey })`. See [Targeting a specific scope](#targeting-a-specific-scope).
 
 ### Activating a scope
 
-A nested `<Theme>` becomes an *active scope* (owns state, renders a wrapper, provides its own context) when you pass at least one of: `forcedTheme`, `defaultTheme`, `accentColor`, `grayColor`, `style`, or `storageKey`. A bare `<Theme>` with no props is a no-op pass-through — children render with the parent's context.
+A nested `<Theme>` becomes an *active scope* (owns state, renders a wrapper, provides its own context) when you pass at least one of: `forcedTheme`, `defaultTheme`, `accentColor`, `grayColor`, `style`, or `storageKey`. A bare `<Theme>` with no props is a no-op pass-through. Children render with the parent's context.
 
 If you want a section to act as a scope but don't need to override any specific token, pass `defaultTheme` (seeds an initial scope theme):
 
@@ -166,7 +166,7 @@ If you want a section to act as a scope but don't need to override any specific 
 
 The cases below assume a configured page-level `Theme` and progressively richer nested overrides.
 
-**Both fully configured — independent states**
+**Both fully configured, independent states**
 
 ```tsx
 <Theme defaultTheme="dark" accentColor="orange" grayColor="mauve" style="traditional">
@@ -181,7 +181,7 @@ The cases below assume a configured page-level `Theme` and progressively richer 
 - `Card` renders with the scope's values.
 - Toggling the page does not move the scope; toggling the scope does not move the page.
 
-**Partial override — single prop**
+**Partial override, single prop**
 
 ```tsx
 <Theme defaultTheme="dark" accentColor="orange" grayColor="mauve" style="traditional">
@@ -204,7 +204,7 @@ What `Card` sees:
 - If the page theme later flips to light, the scope follows (still inheriting `theme`). Accent stays `mint`.
 - If the scope's own `setTheme()` is called, the scope decouples from the page for theme only; non-overridden fields keep inheriting.
 
-**Display-locked region — `forcedTheme`**
+**Display-locked region with `forcedTheme`**
 
 ```tsx
 <Theme defaultTheme="dark">
@@ -218,7 +218,7 @@ What `Card` sees:
 - Accent / gray / style still inherit from the page.
 - `setTheme()` inside still updates the scope's stored value, but `forcedTheme` always wins for display.
 
-**Persistent independent island — `storageKey`**
+**Persistent independent island with `storageKey`**
 
 ```tsx
 <Theme defaultTheme="dark">
@@ -234,7 +234,7 @@ What `Card` sees:
 - Reloading the page restores both to their last-saved values.
 - A toggle inside the sidebar flips only the sidebar.
 
-**Empty nested — no scope created**
+**Empty nested, no scope created**
 
 ```tsx
 <Theme defaultTheme="dark">
@@ -250,7 +250,7 @@ What `Card` sees:
 
 ### Persistent scope
 
-Pass `storageKey` to a nested `Theme` and it becomes stateful, persisting the scope's theme to localStorage. Descendants read and update it through the same `useTheme()` hook — it returns the nearest provider's state, so inside a persistent scope it returns the scope's theme and setter:
+Pass `storageKey` to a nested `Theme` and it becomes stateful, persisting the scope's theme to localStorage. Descendants read and update it through the same `useTheme()` hook. It returns the nearest provider's state, so inside a persistent scope it returns the scope's theme and setter:
 
 ```tsx
 import { Theme, useTheme } from "@raystack/apsara";
@@ -278,7 +278,7 @@ function ScopeToggle() {
 - `setTheme(value)` updates state and writes to the scope's localStorage key.
 - `setTheme(undefined)` clears the storage entry and re-inherits from the parent.
 - Changes from other tabs propagate automatically via the `storage` event.
-- `forcedTheme`, if passed, wins over storage for display but is **not** persisted — it's a developer override, not a user choice.
+- `forcedTheme`, if passed, wins over storage for display but is **not** persisted. It is a developer override, not a user choice.
 
 **Gotchas:**
 
@@ -321,7 +321,7 @@ Every nesting case in one table.
 
 ### Nested provider vs. bare attribute
 
-- Use the **bare `data-theme` attribute** when you're already rendering a custom element and don't want another wrapper. The CSS handles everything — components inside will theme correctly.
+- Use the **bare `data-theme` attribute** when you're already rendering a custom element and don't want another wrapper. The CSS handles everything, so components inside will theme correctly.
 - Use a **nested `Theme`** when you want typed props (`forcedTheme`, `accentColor`, etc.), automatic inheritance of unspecified fields, and `useTheme()` integration.
 
 ## API Reference

--- a/apps/www/src/styles/base.css
+++ b/apps/www/src/styles/base.css
@@ -1,5 +1,5 @@
 /*
-  Global element rules for the docs — the few things that sit outside a CSS
+  Global element rules for the docs: the few things that sit outside a CSS
   module and outside the token layers in `typeset.css` and `surfaces.css`.
 
   Kept deliberately short. Apsara's `normalize.css` already handles the usual
@@ -7,7 +7,7 @@
 */
 
 /*
-  A long unbroken token in a table cell — a slot name, a union type — would
+  A long unbroken token in a table cell, such as a slot name or a union type, would
   otherwise push the column past the table's width and scroll the page
   sideways. Scoped to prose tables so ordinary code blocks, which scroll
   inside their own box, are untouched.

--- a/apps/www/src/styles/surfaces.css
+++ b/apps/www/src/styles/surfaces.css
@@ -1,5 +1,5 @@
 /*
-  Docs surfaces — local to apps/www, like the typeset. Never imported by the
+  Docs surfaces, local to apps/www, like the typeset. Never imported by the
   package.
 
   The docs page is three grounds nested inside one another. Naming them here
@@ -8,8 +8,8 @@
 
     outside   the space past the shell's outer rules, on a display wide
               enough for the width cap to bite
-    shell     the page itself — sidebar, article, contents rail, page nav
-    surface   the things that sit on the page — demos, code blocks, tables
+    shell     the page itself: sidebar, article, contents rail, page nav
+    surface   the things that sit on the page: demos, code blocks, tables
 
   `outside` and `shell` resolve to the same color today. They are separate
   tokens because they are separate jobs, and splitting them later is a one-line
@@ -26,7 +26,7 @@
   --docs-bg-shell: var(--rs-color-background-base-secondary);
   --docs-bg-surface: var(--rs-color-background-base-primary);
 
-  /* A band inside a surface — the head of a table. One step back from the
+  /* A band inside a surface, such as the head of a table. One step back from the
      surface it sits on, which lands it on the same color as the shell. */
   --docs-bg-surface-header: var(--rs-color-background-base-secondary);
 

--- a/apps/www/src/styles/typeset.css
+++ b/apps/www/src/styles/typeset.css
@@ -1,5 +1,5 @@
 /*
-  Docs typeset — local to apps/www. Never imported by the package.
+  Docs typeset, local to apps/www. Never imported by the package.
 
   Apsara's `Headline` scale (t1-t4) is tuned for product surfaces: four sizes
   inside 12px of each other, which leaves a section heading and the entries
@@ -7,21 +7,21 @@
   top and a tighter one at the bottom, so the docs own their own scale here
   rather than bending the core tokens that every product depends on.
 
-  Tracking follows Inter's dynamic metric — `a + b*e^(c*size)` with a = -0.0223,
-  b = 0.185, c = -0.1745 — the curve Apsara already uses for body text.
+  Tracking follows Inter's dynamic metric, `a + b*e^(c*size)` with a = -0.0223,
+  b = 0.185, c = -0.1745, the curve Apsara already uses for body text.
 
   Sizes stay in px because the values are optical choices, not a modular scale.
 */
 
 :root {
-  /* Page title — one per page, on the top step of Apsara's heading scale. */
+  /* Page title: one per page, on the top step of Apsara's heading scale. */
   --docs-title-size: var(--rs-font-size-t4);
   --docs-title-leading: var(--rs-line-height-t4);
   --docs-title-tracking: var(--rs-letter-spacing-t4);
   --docs-title-weight: var(--rs-font-weight-medium);
 
   /* Section (h2). Space above it carries the separation, so the type only has
-     to label — it does not need to grow to do that job. */
+     to label, and does not need to grow to do that job. */
   --docs-section-size: 24px;
   --docs-section-leading: 30px;
   --docs-section-tracking: -0.019em;
@@ -39,12 +39,12 @@
   --docs-subentry-tracking: var(--rs-letter-spacing-large);
   --docs-subentry-weight: var(--rs-font-weight-medium);
 
-  /* Prose. Looser leading than the product default — this is read, not scanned. */
+  /* Prose. Looser leading than the product default, since this is read, not scanned. */
   --docs-body-size: var(--rs-font-size-large);
   --docs-body-leading: var(--rs-line-height-large);
   --docs-body-tracking: var(--rs-letter-spacing-large);
 
-  /* Lede — the frontmatter description under the title. Reads at body size:
+  /* Lede: the frontmatter description under the title. Reads at body size:
      it is the first thing you read, not a size class of its own. */
   --docs-lede-size: var(--rs-font-size-large);
   --docs-lede-leading: var(--rs-line-height-large);
@@ -57,7 +57,7 @@
   --docs-label-tracking: 0.12em;
   --docs-label-weight: var(--rs-font-weight-medium);
 
-  /* Caption — table footnotes, muted asides. */
+  /* Caption: table footnotes, muted asides. */
   --docs-caption-size: 13px;
   --docs-caption-leading: 19px;
   --docs-caption-tracking: 0em;

--- a/packages/raystack/README.md
+++ b/packages/raystack/README.md
@@ -45,12 +45,12 @@ import { useCopyToClipboard } from "@raystack/apsara/hooks";
 
 Over 70 components, styled with plain CSS and `data-*` attributes so you can theme them with CSS variables. A few highlights:
 
-- **Layout** — Flex, Grid, Container, Sidebar, ScrollArea
-- **Navigation** — Tabs, Breadcrumb, Command, Menu, Navbar, Toolbar
-- **Data** — Table, DataView, Avatar, Badge, Chip, Meter
-- **Forms** — Input, Select, Combobox, Checkbox, Radio, Switch, Slider, Calendar, ColorPicker
-- **Feedback** — Toast, Tooltip, Callout, Spinner, Indicator
-- **Overlay** — Dialog, Popover, Drawer, ContextMenu
+- **Layout**: Flex, Grid, Container, Sidebar, ScrollArea
+- **Navigation**: Tabs, Breadcrumb, Command, Menu, Navbar, Toolbar
+- **Data**: Table, DataView, Avatar, Badge, Chip, Meter
+- **Forms**: Input, Select, Combobox, Checkbox, Radio, Switch, Slider, Calendar, ColorPicker
+- **Feedback**: Toast, Tooltip, Callout, Spinner, Indicator
+- **Overlay**: Dialog, Popover, Drawer, ContextMenu
 
 See the [documentation site](https://apsara.raystack.org) for the full list, live examples, and API references.
 

--- a/packages/raystack/components/accordion/accordion-root.tsx
+++ b/packages/raystack/components/accordion/accordion-root.tsx
@@ -30,7 +30,7 @@ export type AccordionRootProps = AccordionSingleProps | AccordionMultipleProps;
  * Convert the wrapper's `string | string[]` API into Base UI's `string[]` format.
  *
  * Only `undefined` maps to `undefined` (uncontrolled).
- * Empty string and empty array map to `[]` (controlled, nothing open) — this prevents the
+ * Empty string and empty array map to `[]` (controlled, nothing open), which prevents the
  * controlled → uncontrolled flip that would otherwise break reopen-after-close.
  */
 const toArray = (v: string | string[] | undefined): string[] | undefined => {

--- a/packages/raystack/components/amount/amount.tsx
+++ b/packages/raystack/components/amount/amount.tsx
@@ -6,8 +6,8 @@ export interface AmountProps extends ComponentProps<'span'> {
   /**
    * The monetary value to display.
    * For exact precision beyond 2^53, pass either:
-   *   - a `string` — supports decimals (e.g. "1299" or "12.99")
-   *   - a `bigint` — integer-only; treated as already in major units, so
+   *   - a `string`, which supports decimals (e.g. "1299" or "12.99")
+   *   - a `bigint`, integer-only and treated as already in major units, so
    *     `valueInMinorUnits` is ignored when value is a bigint
    * @default 0
    * @example
@@ -205,7 +205,7 @@ export const Amount = ({
         const unsigned = isNegative ? value.slice(1) : value;
         const [intPart, fracPart = ''] = unsigned.split('.');
         // Shift the existing decimal point left by `decimals` without
-        // round-tripping through Number — preserves precision for large strings
+        // round-tripping through Number, which preserves precision for large strings
         // and handles decimal strings like "12.99" (=> "0.1299" for USD).
         const allDigits = intPart + fracPart;
         const fracLen = fracPart.length + decimals;
@@ -230,7 +230,7 @@ export const Amount = ({
           : Math.trunc(baseValue);
 
     /**
-     * Always format in currency mode — Intl's currency-style handles fraction digits per the currency,
+     * Always format in currency mode, since Intl's currency-style handles fraction digits per the currency,
      * locale-correct grouping/separators,
      * and auto-clamps when only one of min/max is user-provided.
      * For hideCurrency, we then strip the currency token from the output via formatToParts(),
@@ -264,7 +264,7 @@ export const Amount = ({
           .join('')
           .trim()
       : formatter.format(
-          // @ts-expect-error TS lib types omit `string` from format() params, but Intl.NumberFormat accepts numeric strings at runtime — needed for large values that would lose precision as `number`.
+          // @ts-expect-error TS lib types omit `string` from format() params, but Intl.NumberFormat accepts numeric strings at runtime, which is needed for large values that would lose precision as `number`.
           finalBaseValue
         );
 

--- a/packages/raystack/components/announcement-bar/announcement-bar.module.css
+++ b/packages/raystack/components/announcement-bar/announcement-bar.module.css
@@ -57,7 +57,7 @@
   opacity: 0.8;
 }
 
-/* Press reads as scale, not a second dim — 0.64 text mid-press is barely
+/* Press reads as scale, not a second dim, since 0.64 text mid-press is barely
    legible on the gradient variant, and hover's 0.8 still applies. */
 .action-btn:active {
   transform: scale(var(--rs-scale-pressed));

--- a/packages/raystack/components/calendar/__tests__/calendar.test.tsx
+++ b/packages/raystack/components/calendar/__tests__/calendar.test.tsx
@@ -217,7 +217,7 @@ describe('Calendar', () => {
 
       /*
        * Renders for Sundays if any are visible. Test just exercises the
-       * function-based path — actual presence depends on which days the
+       * function-based path, where actual presence depends on which days the
        * current month surfaces.
        */
       expect(container).toBeInTheDocument();

--- a/packages/raystack/components/calendar/__tests__/date-picker.test.tsx
+++ b/packages/raystack/components/calendar/__tests__/date-picker.test.tsx
@@ -39,12 +39,12 @@ describe('DatePicker', () => {
     /*
      * Two regressions on the picker's `calendarProps` type:
      * - Original type required `mode`/`selected`/`onSelect`, which the picker
-     *   overrides after the spread — consumer values were silently ignored.
+     *   overrides after the spread, so consumer values were silently ignored.
      * - CalendarPropsExtended fields (tooltipMessages, dateInfo, loadingData,
      *   showTooltip) were unreachable because the type didn't include them.
      */
     it('accepts CalendarPropsExtended fields via calendarProps without type cast', () => {
-      // The compile-time check is the real test — failing it stops compilation.
+      // The compile-time check is the real test, and failing it stops compilation.
       expect(() =>
         render(
           <DatePicker
@@ -424,14 +424,14 @@ describe('DatePicker', () => {
       ) as HTMLInputElement;
 
       fireEvent.change(input, { target: { value: '15/06/2025' } });
-      // The change handler accepted it — no error transition fired.
+      // The change handler accepted it, so no error transition fired.
       expect(onErrorChange).not.toHaveBeenCalled();
     });
 
     /*
      * Follow-up regression: pre-fix the input was bound to a derived
      * `formattedDate`, so partial typed values were overwritten on the next
-     * render and typing felt broken — only paste of the full string worked.
+     * render and typing felt broken, and only paste of the full string worked.
      */
     it('keeps typed characters visible while typing a full date one char at a time', () => {
       const onSelect = vi.fn();
@@ -466,7 +466,7 @@ describe('DatePicker', () => {
       }
     });
 
-    it('does not fire onSelect while typing — partial stays uncommitted, valid waits for commit (Enter/blur/outside-click)', () => {
+    it('does not fire onSelect while typing, so partial stays uncommitted, valid waits for commit (Enter/blur/outside-click)', () => {
       const onSelect = vi.fn();
       const onErrorChange = vi.fn();
       render(
@@ -481,11 +481,11 @@ describe('DatePicker', () => {
         'Select date'
       ) as HTMLInputElement;
 
-      // Partial input is not even parseable — no commit.
+      // Partial input is not even parseable, so no commit.
       fireEvent.change(input, { target: { value: '15/06' } });
       expect(onSelect).not.toHaveBeenCalled();
 
-      // Full valid input parses internally but still doesn't fire onSelect —
+      // Full valid input parses internally but still doesn't fire onSelect,
       // commit only happens via Enter / blur / outside-click (see the
       // dedicated single-fire test below for that path).
       fireEvent.change(input, { target: { value: '15/06/2025' } });
@@ -496,7 +496,7 @@ describe('DatePicker', () => {
 
   describe('onErrorChange', () => {
     /*
-     * DatePicker renders no error message itself — consumers lift validity
+     * DatePicker renders no error message itself, and consumers lift validity
      * into `Field`'s `error` prop (or a form library) via this callback.
      * It fires on transitions only, like `onOpenChange`.
      */
@@ -567,7 +567,7 @@ describe('DatePicker', () => {
       expect(onErrorChange).toHaveBeenLastCalledWith(undefined);
     });
 
-    it('renders no error presentation of its own — no message, no aria-invalid', () => {
+    it('renders no error presentation of its own, with no message and no aria-invalid', () => {
       render(<DatePicker dateFormat='DD/MM/YYYY' />);
 
       const input = screen.getByPlaceholderText('Select date');
@@ -682,7 +682,7 @@ describe('DatePicker', () => {
 
     it('does not throw on input change with no calendar bounds', () => {
       /*
-       * Covers the no-bounds path — past regression had an unconditional
+       * Covers the no-bounds path, where a past regression had an unconditional
        * `isSameOrBefore(dayjs())` that threw without the plugin extended.
        */
       render(<DatePicker dateFormat='DD/MM/YYYY' />);
@@ -701,7 +701,7 @@ describe('DatePicker', () => {
     /*
      * Regression: Base UI's `Popover.Trigger` toggles open on every trigger
      * click. The input's `onFocus` opens the picker, so the same click's
-     * trigger-press toggled it straight back closed — the popover flickered
+     * trigger-press toggled it straight back closed, so the popover flickered
      * shut on the first click and only stuck open on the second. The hook's
      * `onOpenChange` now ignores trigger-press *closes* (see use-picker-popover).
      */

--- a/packages/raystack/components/calendar/__tests__/range-picker.runtime.test.tsx
+++ b/packages/raystack/components/calendar/__tests__/range-picker.runtime.test.tsx
@@ -4,7 +4,7 @@ import { RangePicker } from '../range-picker';
 
 /*
  * Real-Calendar runtime regression tests for RangePicker. Mirrors
- * date-picker.runtime.test.tsx — uses the real Calendar to catch
+ * date-picker.runtime.test.tsx. Uses the real Calendar to catch
  * mount/unmount loops in Base UI internals after RangePicker adopted
  * usePickerPopover.
  */

--- a/packages/raystack/components/calendar/__tests__/range-picker.test.tsx
+++ b/packages/raystack/components/calendar/__tests__/range-picker.test.tsx
@@ -270,7 +270,7 @@ describe('RangePicker', () => {
       /*
        * Popover should have closed -> Calendar unmounted. A tight call-count
        * assertion would be brittle (React's final commit may queue more);
-       * instead assert data-active returned to 'from' — only the B2 close
+       * instead assert data-active returned to 'from', since only the B2 close
        * path does that.
        */
       const callsAfter = calendarCalls.list.length;
@@ -399,7 +399,7 @@ describe('RangePicker', () => {
      * Partial-disable (one input disabled, the other enabled) also gates
      * the popover. Without this, the enabled input's click would open the
      * shared popover and the calendar's range state machine would happily
-     * rewrite the "disabled" field through the grid — defeating the
+     * rewrite the "disabled" field through the grid, defeating the
      * disabled intent. Consumers who need to fix one side and pick the
      * other should constrain the calendar via `calendarProps`.
      */

--- a/packages/raystack/components/calendar/calendar.tsx
+++ b/packages/raystack/components/calendar/calendar.tsx
@@ -54,7 +54,7 @@ function DropDown({
   const [open, setOpen] = useState(false);
 
   /*
-   * Mirror the callback into a ref so the effect depends only on `open` —
+   * Mirror the callback into a ref so the effect depends only on `open`,
    * parents that re-create `onDropdownOpen` per render would otherwise cause
    * a re-fire on every parent render where `open` is true.
    */

--- a/packages/raystack/components/calendar/date-picker.tsx
+++ b/packages/raystack/components/calendar/date-picker.tsx
@@ -51,7 +51,7 @@ export interface DatePickerProps {
    * Fires when the typed-input validation state changes: with a message when
    * the typed text stops parsing as a valid in-bounds date, and with
    * `undefined` when it becomes valid again (or the picker commits/closes).
-   * DatePicker renders no error UI of its own — not even `aria-invalid`.
+   * DatePicker renders no error UI of its own, not even `aria-invalid`.
    * Lift this into `Field`'s `error` prop (or your form library) to display
    * it; `Field` also wires `aria-invalid` onto the input.
    */
@@ -84,7 +84,7 @@ export function DatePicker({
   const calendarProps = { ...legacyCalendarProps, ...slotProps?.calendar };
   const popoverProps = { ...legacyPopoverProps, ...slotProps?.popover };
   /*
-   * Gate the popover when the input is disabled — the trailing icon
+   * Gate the popover when the input is disabled, since the trailing icon
    * renders as a sibling `<div>` to the `<input>`, so its clicks bubble
    * to `Popover.Trigger` even when the input itself is `disabled`.
    */
@@ -105,7 +105,7 @@ export function DatePicker({
     errorRef.current = next;
   }
 
-  // Sync only when controlled — uncontrolled mode keeps its own state.
+  // Sync only when controlled, since uncontrolled mode keeps its own state.
   // biome-ignore lint/correctness/useExhaustiveDependencies: compare on timestamp, not Date identity
   useEffect(() => {
     if (valueProp !== undefined) setSelectedDate(valueProp);
@@ -119,7 +119,7 @@ export function DatePicker({
 
   /*
    * Separate from `selectedDate` so chevron/dropdown nav doesn't rewrite the
-   * committed date — only day-clicks (`onSelect`) do. Initial month honors
+   * committed date. Only day-clicks (`onSelect`) do. Initial month honors
    * `calendarProps.defaultMonth`, then the selected date, then today.
    */
   const [viewMonth, setViewMonth] = useState<Date>(
@@ -166,7 +166,7 @@ export function DatePicker({
      * a format spec, which falls back to native `Date` parsing and can shift
      * non-ISO formats (e.g. DD/MM/YYYY → wrong Date).
      *
-     * Skip when nothing was ever selected — `onSelect` is typed
+     * Skip when nothing was ever selected, since `onSelect` is typed
      * `(date: Date) => void` so we don't fire with `undefined`.
      */
     if (!hadError && committedDate) onSelect(committedDate);
@@ -176,7 +176,7 @@ export function DatePicker({
     setSelectedDate(day);
     // RDP can hand us `undefined` when `required={false}` and the user
     // clicks the currently-selected day (deselect). Only forward defined
-    // dates to consumer `onSelect` — keeps the prop type narrow.
+    // dates to consumer `onSelect`, which keeps the prop type narrow.
     if (day) onSelect(day);
     updateError(undefined);
     popover.disengage();
@@ -198,7 +198,7 @@ export function DatePicker({
     const isValidDate = date.isValid();
 
     /*
-     * RDP treats `startMonth`/`endMonth` as months — compare against month
+     * RDP treats `startMonth`/`endMonth` as months, so compare against month
      * bounds so any day inside the boundary month is accepted.
      */
     const isAfter =
@@ -245,7 +245,7 @@ export function DatePicker({
    * Always wrap the trigger in a `<div>` so the rendered outer element is
    * never a `<button>`. This keeps `nativeButton={false}` correct regardless
    * of what the consumer passes (string, host element, React component that
-   * happens to render a button, etc.) — avoiding Base UI's button-nesting
+   * happens to render a button, etc.), avoiding Base UI's button-nesting
    * warning.
    */
   const triggerContent =

--- a/packages/raystack/components/calendar/range-picker.tsx
+++ b/packages/raystack/components/calendar/range-picker.tsx
@@ -64,7 +64,7 @@ export function RangePicker({
   onSelect = () => undefined,
   value,
   /*
-   * No inline default — the state machine's "first click sets `from`" branch
+   * No inline default, since the state machine's "first click sets `from`" branch
    * needs an empty range to fire.
    */
   defaultValue,
@@ -120,7 +120,7 @@ export function RangePicker({
   /*
    * Sync visible month when controlled `value.from` changes externally
    * (form reset, preset buttons, sync-from-URL). Sync runs whenever
-   * `value` is defined — including when `value.from` is cleared — so a
+   * `value` is defined, including when `value.from` is cleared, so a
    * parent reset (`setValue({ from: undefined })`) actually unpins the
    * calendar. Uncontrolled mode (value === undefined) skips entirely.
    */
@@ -144,7 +144,7 @@ export function RangePicker({
 
   /*
    * Ensures two months are visible even when the current month is the last
-   * allowed month (endMonth). Skips when `currentMonth` is undefined —
+   * allowed month (endMonth). Skips when `currentMonth` is undefined,
    * `dayjs(undefined)` returns "now" and would falsely match `endMonth` if
    * endMonth happens to be the current month, forcing the calendar away
    * from its own default.
@@ -208,7 +208,7 @@ export function RangePicker({
     }
 
     if (newField !== currentRangeField) setCurrentRangeField(newField);
-    // Only update internal state when uncontrolled — controlled consumers own `value`.
+    // Only update internal state when uncontrolled, since controlled consumers own `value`.
     if (!isControlled) setInternalValue(newRange);
     onSelect(newRange);
     if (shouldClose) popover.disengage();
@@ -254,7 +254,7 @@ export function RangePicker({
    * Always wrap the trigger in a `<div>` so the rendered outer element is
    * never a `<button>`. This keeps `nativeButton={false}` correct regardless
    * of what the consumer passes (string, host element, React component that
-   * happens to render a button, etc.) — avoiding Base UI's button-nesting
+   * happens to render a button, etc.), avoiding Base UI's button-nesting
    * warning.
    */
   const triggerContent =
@@ -284,7 +284,7 @@ export function RangePicker({
         <div data-slot='range-picker-content'>
           <Calendar
             /*
-             * No `captionLayout` default — 'dropdown' renders Apsara Selects
+             * No `captionLayout` default, since 'dropdown' renders Apsara Selects
              * inside the popover whose unmount loops ("Maximum update depth").
              * Consumers can opt in via `calendarProps.captionLayout`.
              */

--- a/packages/raystack/components/calendar/use-picker-popover.ts
+++ b/packages/raystack/components/calendar/use-picker-popover.ts
@@ -25,7 +25,7 @@ export interface UsePickerPopoverReturn {
    * readOnly inputs) should engage on open via `useEffect`.
    */
   engage: () => void;
-  // Programmatic close — does NOT fire `onOutsideClick`.
+  // Programmatic close. Does NOT fire `onOutsideClick`.
   disengage: () => void;
 }
 
@@ -40,7 +40,7 @@ export interface UsePickerPopoverReturn {
  * renders Selects inside the popover; their portals look "outside" to a naive
  * dismiss handler. The hook carves that out via `markDropdownOpen`.
  *
- * `onOpenChange` reads `isOpen` via ref so its identity stays stable —
+ * `onOpenChange` reads `isOpen` via ref so its identity stays stable,
  * Base UI's store subscriber re-binds on identity change, which caused an
  * updateStoreInstance loop on mount.
  */
@@ -56,7 +56,7 @@ export function usePickerPopover({
   const isEngagedRef = useRef(false);
 
   /*
-   * True while the Calendar's year/month dropdown is open — its clicks
+   * True while the Calendar's year/month dropdown is open, whose clicks
    * are not "outside".
    */
   const isDropdownOpenRef = useRef(false);
@@ -125,7 +125,7 @@ export function usePickerPopover({
         return;
       }
       // Not yet engaged. If the user tab'd straight to an outside element,
-      // close immediately — otherwise keyboard users get stuck with the
+      // close immediately, since otherwise keyboard users get stuck with the
       // popover open until they mouse-click somewhere.
       if (el && isElementOutside(el)) {
         onOutsideClickRef.current();
@@ -149,10 +149,10 @@ export function usePickerPopover({
      * Base UI's `Popover.Trigger` wires `useClick`, which *toggles* the popover
      * on every trigger click. The input's `onFocus` already opens the picker, so
      * a single click both opens (focus) and then toggles back closed
-     * (trigger-press) — the popover flickers shut on the first click and only
+     * (trigger-press), so the popover flickers shut on the first click and only
      * sticks open on the second. Ignore trigger-press *closes*: opening stays
      * owned by focus (and trigger-press open), while closing is owned by our
-     * outside-click / blur / Enter / day-select logic — plus Base UI's own
+     * outside-click / blur / Enter / day-select logic, plus Base UI's own
      * Escape/outside-press, which still flow through below.
      */
     if (reason === 'trigger-press' && open === false) return;

--- a/packages/raystack/components/callout/__tests__/callout.test.tsx
+++ b/packages/raystack/components/callout/__tests__/callout.test.tsx
@@ -136,7 +136,7 @@ describe('Callout', () => {
 
       fireEvent.click(screen.getByRole('button', { name: 'Dismiss message' }));
 
-      // Consumer owns removal — the callout must not hide itself.
+      // Consumer owns removal, and the callout must not hide itself.
       expect(screen.getByText('Controlled message')).toBeInTheDocument();
     });
 

--- a/packages/raystack/components/callout/callout.module.css
+++ b/packages/raystack/components/callout/callout.module.css
@@ -202,7 +202,7 @@
  * Gradient + outline (no high contrast): keep the gradient fill and add a
  * translucent border tinted to the gradient's warm endpoint. Intended behavior.
  * The border is a one-off literal (no token) because the gradient itself is
- * untokenized — keep the two in sync if the gradient stops ever change.
+ * untokenized, so keep the two in sync if the gradient stops ever change.
  */
 .callout-outline.callout-gradient {
   background: radial-gradient(
@@ -217,7 +217,7 @@
 /*
  * High contrast gradient should match normal high contrast.
  * Figma defines only one gradient variant (no outline/high-contrast states), so
- * in high contrast — both on its own and combined with outline — we intentionally
+ * in high contrast, both on its own and combined with outline, we intentionally
  * drop the gradient for the solid "normal" high-contrast surface. A gradient
  * callout in high-contrast mode therefore reads identically to a normal one.
  */

--- a/packages/raystack/components/chat-panel/__tests__/chat-panel.test.tsx
+++ b/packages/raystack/components/chat-panel/__tests__/chat-panel.test.tsx
@@ -370,8 +370,8 @@ describe('ChatPanel', () => {
           screen.getByRole('button', { name: 'Minimize chat panel' })
         );
 
-        // The bubble starts over the middle of the docked box it replaces —
-        // centre (820, 400) against its own (978, 722) — at its own size, so
+        // The bubble starts over the middle of the docked box it replaces,
+        // centre (820, 400) against its own (978, 722), at its own size, so
         // its icon is never stretched.
         const panel = screen.getByTestId('panel');
         expect(panel).toHaveAttribute('data-mode-from', 'docked');

--- a/packages/raystack/components/chat-panel/chat-panel-root.tsx
+++ b/packages/raystack/components/chat-panel/chat-panel-root.tsx
@@ -116,8 +116,8 @@ function readBox(node: HTMLElement): MorphBox {
 }
 
 /**
- * Draws the panel back over the box it just left — an inverse translate and
- * scale off its top-left corner — and lets go a frame later, so the two modes
+ * Draws the panel back over the box it just left, with an inverse translate and
+ * scale off its top-left corner, and lets go a frame later, so the two modes
  * read as one shape moving. The old box has to be read while the DOM still
  * shows the old mode, hence the measurement in render; the inverse can only be
  * worked out once the new mode has laid out, hence the layout effect.
@@ -150,7 +150,7 @@ function useMorph(
     if (!to.width || !to.height) return;
     // Minimized is the one mode whose whole content is a single small control.
     // Blowing the bubble up to the panel's box would stretch its icon into mush
-    // for the length of the tween, so it only travels — from the middle of the
+    // for the length of the tween, so it only travels, from the middle of the
     // box it is replacing, since there is no shape left to line its edges up
     // with.
     if (mode === 'minimized') {
@@ -229,7 +229,7 @@ export interface ChatPanelRootProps extends ComponentProps<'aside'> {
   /**
    * Largest allowed floating size, always additionally clamped by the
    * viewport.
-   * @defaultValue the initial floating size — out of the box the window can
+   * @defaultValue the initial floating size, so by default the window can
    * only shrink; pass a larger `maxSize` to let it grow.
    */
   maxSize?: ChatPanelSize;

--- a/packages/raystack/components/chat-panel/chat-panel.module.css
+++ b/packages/raystack/components/chat-panel/chat-panel.module.css
@@ -75,7 +75,7 @@
 /* ------------------------------ mode changes ------------------------------ */
 
 /* A morph draws the panel outside its own box on the way in, so the docked
-   panel — in flow, and otherwise painted under its siblings — is raised for the
+   panel, in flow and otherwise painted under its siblings, is raised for the
    trip. */
 .root[data-transition="morph"][data-mode="docked"] {
   position: relative;
@@ -98,7 +98,7 @@
       opacity var(--rs-duration-normal) var(--rs-ease-out);
   }
 
-  /* The from-values are jumped to, not tweened into — the tween is the frame
+  /* The from-values are jumped to, not tweened into, since the tween is the frame
      after this rule stops applying. */
   .root[data-mode-starting] {
     transition: none;
@@ -143,7 +143,7 @@
   /* The from-values are the measured inverse of the box the panel just left,
      written inline off its top-left corner, so the origin has to stay there for
      the scale to land back on that box. Real distance to cover, so the longer
-     duration — but still the shared ease-out, which is off the mark on the first
+     duration, but still the shared ease-out, which is off the mark on the first
      frame where a symmetric curve would sit there and read as lag. */
   .root[data-transition="morph"] {
     transform-origin: top left;
@@ -151,7 +151,7 @@
   }
 
   /* Docked and floating are close enough in shape to morph outright. The bubble
-     is a tenth of their size, so its two pairs cross-fade as well — covering
+     is a tenth of their size, so its two pairs cross-fade as well, covering
      the content stretched on the way out of it, and a whole panel swapped for
      one small control on the way in. */
   .root[data-transition="morph"][data-mode-starting][data-mode="minimized"],

--- a/packages/raystack/components/chat/chat-attachment.tsx
+++ b/packages/raystack/components/chat/chat-attachment.tsx
@@ -13,7 +13,7 @@ export interface ChatAttachmentProps
   extends Omit<ComponentProps<'div'>, 'title'> {
   /** File name or main label. */
   title?: ReactNode;
-  /** Secondary line — file size, type, or the error message. */
+  /** Secondary line: file size, type, or the error message. */
   description?: ReactNode;
   /**
    * Content of the leading media square. Defaults to a file icon, or a

--- a/packages/raystack/components/chat/chat-item.tsx
+++ b/packages/raystack/components/chat/chat-item.tsx
@@ -15,7 +15,7 @@ export interface ChatItemProps extends ComponentProps<'div'> {
   /**
    * Marks the item as a scroll anchor: when it mounts inside
    * `Chat.Messages`, the viewport scrolls it near the top so the reply can
-   * stream in below — set it on the latest user message.
+   * stream in below. Set it on the latest user message.
    * @defaultValue false
    */
   scrollAnchor?: boolean;

--- a/packages/raystack/components/chat/chat-messages.tsx
+++ b/packages/raystack/components/chat/chat-messages.tsx
@@ -244,7 +244,7 @@ export function ChatMessages({
 
   // Perform the pending anchor scroll after the spacer has been committed,
   // so the target position exists before the frame paints.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on anchorTick — each anchor request bumps it.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on anchorTick, and each anchor request bumps it.
   useLayoutEffect(() => {
     const pending = pendingAnchorRef.current;
     const viewport = viewportRef.current;

--- a/packages/raystack/components/checkbox/checkbox.module.css
+++ b/packages/raystack/components/checkbox/checkbox.module.css
@@ -90,7 +90,7 @@
   opacity: 0.7;
 }
 
-/* A3: Invalid state — red border for validation errors */
+/* A3: Invalid state, red border for validation errors */
 .checkbox[data-invalid] {
   border-color: var(--rs-color-border-danger-primary);
 }

--- a/packages/raystack/components/color-picker/__tests__/color-picker.test.tsx
+++ b/packages/raystack/components/color-picker/__tests__/color-picker.test.tsx
@@ -91,7 +91,7 @@ describe('ColorPicker', () => {
 
       const area = screen.getByTestId('color-area');
       // Non-oklch modes use a CSS-gradient div, not the canvas-painted
-      // OKLCH plane — the absence of <canvas> is what distinguishes them.
+      // OKLCH plane, where the absence of <canvas> is what distinguishes them.
       // (jsdom rejects `linear-gradient(...)` inline styles, so we can't
       // assert the background string directly.)
       expect(area.querySelector('canvas')).not.toBeInTheDocument();

--- a/packages/raystack/components/color-picker/__tests__/utils.test.ts
+++ b/packages/raystack/components/color-picker/__tests__/utils.test.ts
@@ -44,7 +44,7 @@ describe('color-picker utils', () => {
 
     it('preserves the input hue when the color is achromatic', () => {
       // Internal state may carry a non-zero hue even when chroma is 0; HSL
-      // conversion would normally produce NaN — the helper falls back to the
+      // conversion would normally produce NaN, so the helper falls back to the
       // OKLCH hue so the user's last hue choice isn't lost at the s=0 axis.
       const hsl = oklchToHsl({ l: 0.5, c: 0, h: 200 });
       expect(hsl.s).toBeCloseTo(0, 6);

--- a/packages/raystack/components/color-picker/color-picker-area.tsx
+++ b/packages/raystack/components/color-picker/color-picker-area.tsx
@@ -50,7 +50,7 @@ const OklchArea = ({ className, ...props }: ColorPickerAreaProps) => {
 
   const { lightness, chroma, hue, setColor } = useColorPicker();
   // Use the native CSS oklch() so the thumb renders the actual picked color on
-  // wide-gamut (P3) displays — hex would silently sRGB-clip wide-gamut picks.
+  // wide-gamut (P3) displays, and hex would silently sRGB-clip wide-gamut picks.
   const thumbColor = useMemo(
     () => `oklch(${lightness} ${chroma} ${hue})`,
     [lightness, chroma, hue]

--- a/packages/raystack/components/color-picker/color-picker-hue.tsx
+++ b/packages/raystack/components/color-picker/color-picker-hue.tsx
@@ -39,7 +39,7 @@ export const ColorPickerHue = ({
       className={cx(styles.sliderRoot, className)}
       max={360}
       onValueChange={value => handleValueChange(value as number)}
-      // OKLCH hue is perceptually uniform — sub-degree precision is meaningful
+      // OKLCH hue is perceptually uniform, so sub-degree precision is meaningful
       // when fine-tuning a tone. HSL hue keeps the classic 1° granularity.
       step={isOklch ? 0.1 : 1}
       value={value}

--- a/packages/raystack/components/color-picker/color-picker-root.tsx
+++ b/packages/raystack/components/color-picker/color-picker-root.tsx
@@ -84,7 +84,7 @@ export const ColorPickerRoot = ({
     }),
     [providedColor, internalColor]
   );
-  // clampToSrgb wraps culori's clampChroma, which is iterative — memoize so
+  // clampToSrgb wraps culori's clampChroma, which is iterative, so memoize
   // it doesn't re-run on unrelated re-renders during a drag.
   const display = useMemo(
     () => (mode === 'oklch' ? rawColor : clampToSrgb(rawColor)),
@@ -121,7 +121,7 @@ export const ColorPickerRoot = ({
   );
 
   // Memoize the context value so consumers (Area, Hue, Alpha, Input, Mode) only
-  // re-render when a slice they read actually changes — without this, every
+  // re-render when a slice they read actually changes. Without this, every
   // pointermove during a drag would broadcast a fresh object identity to all
   // subcomponents.
   const contextValue = useMemo<ColorPickerContextValue>(

--- a/packages/raystack/components/color-picker/color-picker.module.css
+++ b/packages/raystack/components/color-picker/color-picker.module.css
@@ -110,7 +110,7 @@
   position: relative;
   width: 100%;
   height: 100%;
-  /* Fallback dimensions when the parent doesn't constrain height — the OKLCH
+  /* Fallback dimensions when the parent doesn't constrain height, where the OKLCH
      canvas used to anchor size via its intrinsic 96×96, but the HSL gradient
      branch has no such element. aspect-ratio gives both branches a square
      footprint derived from width. */

--- a/packages/raystack/components/color-picker/utils.ts
+++ b/packages/raystack/components/color-picker/utils.ts
@@ -138,7 +138,7 @@ export const getColorString = (color: ColorObject, mode: ModeType): string => {
     alpha: color.alpha ?? 1
   });
   if (!rgb) return '';
-  // clampRgb is culori's per-channel clip to [0, 1] — identical to the manual
+  // clampRgb is culori's per-channel clip to [0, 1], identical to the manual
   // clamp it replaces, keeping non-oklch output a valid representable value.
   const clipped = clampRgb(rgb);
 
@@ -152,7 +152,7 @@ export const getColorString = (color: ColorObject, mode: ModeType): string => {
 
 /**
  * Converts an OKLCH triple to a culori RGB object. The returned r/g/b channels
- * may fall outside [0, 1] when the input is outside the sRGB gamut — callers
+ * may fall outside [0, 1] when the input is outside the sRGB gamut, so callers
  * use that signal to detect and mark the gamut boundary.
  */
 export const oklchToRgb = (l: number, c: number, h: number) =>

--- a/packages/raystack/components/command/command.module.css
+++ b/packages/raystack/components/command/command.module.css
@@ -30,7 +30,7 @@
   padding: 0 var(--rs-space-2);
 }
 
-/* Flat items (no groups) — apply section-like vertical padding & gap. */
+/* Flat items (no groups): apply section-like vertical padding & gap. */
 .list:not(:has(.group)) {
   padding: var(--rs-space-3) var(--rs-space-2);
   gap: var(--rs-space-1);

--- a/packages/raystack/components/data-table/data-table.module.css
+++ b/packages/raystack/components/data-table/data-table.module.css
@@ -278,7 +278,7 @@
    permanently stuck and coincides with the first natural group header at
    scroll 0, so "scrolled > 0" is exactly "content is underneath it".
    (.stickySectionHeader is intentionally NOT gated: its many instances stick
-   at per-element offsets a scroll() timeline can't express — revisit with
+   at per-element offsets a scroll() timeline can't express. Revisit with
    @container scroll-state(stuck: top) when support matures.) */
 @supports (animation-timeline: scroll()) {
   .stickyGroupAnchor {

--- a/packages/raystack/components/data-table/hooks/useStickyGroupAnchor.tsx
+++ b/packages/raystack/components/data-table/hooks/useStickyGroupAnchor.tsx
@@ -24,7 +24,7 @@ interface UseStickyGroupAnchorResult<TData> {
  * anchor's content stays in sync with the natural section header underneath.
  *
  * Returns the current group's data plus the row index of its natural section
- * header — the consumer hides that row in the virtualized body so the natural
+ * header, and the consumer hides that row in the virtualized body so the natural
  * header doesn't visually slide past the anchor (matching the non-virtualized
  * table where CSS sticky pins each section header at the offset).
  *

--- a/packages/raystack/components/data-view/__tests__/data-view.test.tsx
+++ b/packages/raystack/components/data-view/__tests__/data-view.test.tsx
@@ -55,7 +55,7 @@ beforeAll(() => {
     ioInstances.push(this);
   }) as unknown as typeof IntersectionObserver;
 
-  // jsdom doesn't implement ResizeObserver — TanStack Virtual uses it for
+  // jsdom doesn't implement ResizeObserver, and TanStack Virtual uses it for
   // measureElement.
   // biome-ignore lint/suspicious/noExplicitAny: jsdom lacks ResizeObserver
   (global as any).ResizeObserver =
@@ -500,7 +500,7 @@ describe('DataView', () => {
         { value: 'table', label: 'Table' },
         { value: 'list', label: 'List' }
       ];
-      // In `list` view, mark email as defaultHidden — the column gates itself.
+      // In `list` view, mark email as defaultHidden, so the column gates itself.
       const listFields = mockFields.map(f =>
         f.accessorKey === 'email' ? { ...f, defaultHidden: true } : f
       );
@@ -748,7 +748,7 @@ describe('DataView', () => {
           <DataView.List variant='table' columns={mockColumns} />
         </DataView>
       );
-      // Two group headers (active, inactive) — counted via class
+      // Two group headers (active, inactive), counted via class
       const groupHeaders = container.querySelectorAll(
         '[class*="listGroupHeader"]'
       );
@@ -1028,7 +1028,7 @@ describe('DataView', () => {
 
   describe('Virtualization', () => {
     it('accepts estimatedRowHeight as the initial size hint', () => {
-      // Smoke test — render with virtualized + estimatedRowHeight and verify
+      // Smoke test: render with virtualized + estimatedRowHeight and verify
       // the listGrid mounts. The exact pixel math is exercised by
       // @tanstack/react-virtual; we only confirm the prop is honoured.
       const { container } = render(
@@ -1129,7 +1129,7 @@ describe('DataView', () => {
 
   describe('Unmanaged display columns', () => {
     // Selection / row-action / drag-handle columns aren't declared as fields
-    // (no filter/sort/group/visibility semantics) — they're presentation only.
+    // (no filter/sort/group/visibility semantics), so they're presentation only.
     // Such accessors must still render via their column spec.
     it('renders header + cells for a column whose accessor is absent from fields', async () => {
       const user = userEvent.setup();

--- a/packages/raystack/components/data-view/__tests__/debug.test.tsx
+++ b/packages/raystack/components/data-view/__tests__/debug.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest';
 
-// placeholder — was used for bisecting Filter trigger render issue.
+// placeholder, used for bisecting a Filter trigger render issue.
 describe.skip('debug', () => {
   it('noop', () => {});
 });

--- a/packages/raystack/components/data-view/__tests__/group-data.test.ts
+++ b/packages/raystack/components/data-view/__tests__/group-data.test.ts
@@ -4,7 +4,7 @@ import { groupData } from '../utils';
 
 /**
  * `groupData` produces the sections every renderer walks, so its bucket order
- * *is* the rendered section order — `DataView.List`'s bands and
+ * *is* the rendered section order, so `DataView.List`'s bands and
  * `DataView.Timeline`'s group sections both read it.
  */
 interface Task {

--- a/packages/raystack/components/data-view/__tests__/helpers.ts
+++ b/packages/raystack/components/data-view/__tests__/helpers.ts
@@ -6,7 +6,7 @@
  * cannot drift, and two copies of an LCG eventually stop agreeing.
  */
 
-/** Seeded LCG — a failing case has to be reproducible. */
+/** Seeded LCG, so a failing case is reproducible. */
 export function seededRandom(seed: number) {
   let state = seed;
   return () => {

--- a/packages/raystack/components/data-view/__tests__/order-by-x.test.ts
+++ b/packages/raystack/components/data-view/__tests__/order-by-x.test.ts
@@ -5,8 +5,8 @@ import { seededRandom } from './helpers';
 /**
  * `orderByX` returns indices ascending by `x`, ties broken by input order.
  *
- * It has two implementations behind one signature — a comparison sort below 64
- * items, a counting sort at or above it — so most of these run a differential
+ * It has two implementations behind one signature: a comparison sort below 64
+ * items, and a counting sort at or above it, so most of these run a differential
  * against `Array#sort`, which is the specification the counting sort has to
  * reproduce exactly (including the tie-break, which lane packing depends on).
  */
@@ -39,7 +39,7 @@ describe('orderByX', () => {
 
   it('agrees with itself either side of the counting-sort threshold', () => {
     // The implementation is chosen by item count, so the same data must order
-    // identically at 63 items and at 64 — otherwise adding one card silently
+    // identically at 63 items and at 64, since otherwise adding one card silently
     // repacks the lanes. Ties are dense here to put the tie-break under load.
     const items = Array.from({ length: BUCKET_SORT_MIN_ITEMS }, (_, i) => ({
       x: (i % 8) * 50
@@ -61,7 +61,7 @@ describe('orderByX', () => {
 
   it('matches a comparison sort when every x is negative', () => {
     // `minX` is negative, so the bucket index is driven entirely by the offset
-    // rather than by x itself — the case where a missing `- minX` still looks
+    // rather than by x itself, the case where a missing `- minX` still looks
     // correct on non-negative data.
     const random = seededRandom(13);
     const items = Array.from({ length: 400 }, () => ({
@@ -71,7 +71,7 @@ describe('orderByX', () => {
   });
 
   it('keeps input order when every item shares one x', () => {
-    // Zero extent — nothing to bucket by, and the tie-break is input order.
+    // Zero extent: nothing to bucket by, and the tie-break is input order.
     const items = Array.from({ length: 100 }, () => ({ x: 42 }));
     expect(Array.from(orderByX(items))).toEqual(
       Array.from({ length: 100 }, (_, i) => i)
@@ -102,7 +102,7 @@ describe('orderByX', () => {
   });
 
   it('still returns a usable permutation for non-finite x', () => {
-    // Non-finite geometry shouldn't reach here — x comes from the time scale —
+    // Non-finite geometry shouldn't reach here, since x comes from the time scale,
     // but a NaN must not corrupt the ordering of the cards around it or drop
     // an index, which would lose a card from the canvas entirely. Ordering
     // *among* non-finite values is not asserted: `a.x - b.x` is NaN for those

--- a/packages/raystack/components/data-view/__tests__/pack-lanes.test.ts
+++ b/packages/raystack/components/data-view/__tests__/pack-lanes.test.ts
@@ -6,8 +6,8 @@ import { digest, randomItems } from './helpers';
  * `packLanes` is greedy first-fit interval scheduling: items are visited in
  * ascending x and dropped into the lowest-numbered lane free at that point.
  *
- * It has two implementations behind one signature — a direct lane scan below 64
- * items, an O(n) sweep at or above it — so most of these are differentials
+ * It has two implementations behind one signature: a direct lane scan below 64
+ * items, and an O(n) sweep at or above it, so most of these are differentials
  * against the scan. The scan is the specification: it is the pre-rewrite
  * implementation, transcribed, and lane assignment is visible output (a card's
  * lane is its vertical position, and `context.laneIndex` is public API through
@@ -17,7 +17,7 @@ import { digest, randomItems } from './helpers';
 const SWEEP_MIN_ITEMS = 64;
 const DEFAULT_GAP_PX = 8;
 
-/** First-fit by scanning every lane end — the pre-rewrite implementation. */
+/** First-fit by scanning every lane end, the pre-rewrite implementation. */
 function packByScanReference(
   items: { x: number; width: number }[],
   gapPx = DEFAULT_GAP_PX
@@ -43,7 +43,7 @@ function packByScanReference(
 /* ─────────────────── characterisation: lane assignment ───────────────────
    Goldens pinning `packLanes` output at sizes too large to hand-write. They
    were recorded from the implementation before the O(n) rewrite, so a digest
-   mismatch means lane assignment moved — which is a visible change.
+   mismatch means lane assignment moved, which is a visible change.
 
    Digests rather than 500-element literals: the arrays are only ever compared,
    never read, and an unreadable wall of numbers hides what the test is for. */
@@ -70,7 +70,7 @@ describe('packLanes (characterisation)', () => {
   });
 
   it('pins lane assignment when every item overlaps every other', () => {
-    // No lane is ever reusable, so lane count tracks item count — the shape
+    // No lane is ever reusable, so lane count tracks item count, and the shape
     // that makes the lane scan quadratic.
     const items = Array.from({ length: 400 }, (_, i) => ({
       x: i,
@@ -101,7 +101,7 @@ describe('packLanes (characterisation)', () => {
 
   it('pins lane assignment across the gap boundary', () => {
     // Alternates releases landing exactly on the gap boundary (reusable) with
-    // ones a pixel short (not) — the comparison most at risk from a rewrite.
+    // ones a pixel short (not), the comparison most at risk from a rewrite.
     const items = Array.from({ length: 300 }, (_, i) => ({
       x: i * 108 + (i % 2),
       width: 100
@@ -268,8 +268,8 @@ describe('packLanes', () => {
   });
 
   it('survives non-finite geometry without losing a card', () => {
-    // Non-finite geometry shouldn't reach here — x and width come from the
-    // time scale — but a NaN must not throw or drop an item, which would leave
+    // Non-finite geometry shouldn't reach here, since x and width come from the
+    // time scale, but a NaN must not throw or drop an item, which would leave
     // a card unplaced on the canvas. The assignment itself is not pinned: NaN
     // comparisons are false in both directions, so "first fit" has no meaning
     // for those items and the two implementations are free to disagree.
@@ -331,7 +331,7 @@ describe('packLanesBySortValue', () => {
     });
   });
 
-  it("orders buckets first-seen — the caller's order", () => {
+  it("orders buckets first-seen, in the caller's order", () => {
     const items = [item('Low', 0), item('High', 0), item('Medium', 0)];
     expect(packLanesBySortValue(items).lanes).toEqual([0, 1, 2]);
     // Same values, caller-sorted differently → lanes follow the new order.

--- a/packages/raystack/components/data-view/__tests__/timeline.test.tsx
+++ b/packages/raystack/components/data-view/__tests__/timeline.test.tsx
@@ -16,7 +16,7 @@ import { useDataView } from '../hooks/useDataView';
 import { buildAxis, createTimeScale, toTimestamp } from '../utils/time-scale';
 
 beforeAll(() => {
-  // jsdom doesn't implement ResizeObserver — the timeline observes its scroll
+  // jsdom doesn't implement ResizeObserver, and the timeline observes its scroll
   // container when viewport tracking is enabled.
   // biome-ignore lint/suspicious/noExplicitAny: jsdom lacks ResizeObserver
   (global as any).ResizeObserver =
@@ -96,7 +96,7 @@ describe('createTimeScale', () => {
   });
 
   it('reaches minWidth on calendar scales with uneven unit lengths', () => {
-    // Months render at (actual ms × pxPerMs), not exactly unitWidth — the
+    // Months render at (actual ms × pxPerMs), not exactly unitWidth, so the
     // fill must land at or past minWidth despite short months.
     const ts = createTimeScale({
       minTime: dayjs('2025-01-15').valueOf(),
@@ -391,7 +391,7 @@ describe('DataView.Timeline', () => {
   it('exposes the scroll region as a focusable, labelled region', () => {
     renderTimeline();
     const region = screen.getByRole('region', { name: 'Timeline' });
-    // Focusable so keyboard users can scroll the pane with arrow keys —
+    // Focusable so keyboard users can scroll the pane with arrow keys,
     // drag-to-pan is pointer-only.
     expect(region.tabIndex).toBe(0);
   });
@@ -409,7 +409,7 @@ describe('DataView.Timeline', () => {
     // lane 0 at laneGap 16, lane 1 at 16 + 66 + 16.
     expect(screen.getByTestId('card-o1').parentElement!.style.top).toBe('16px');
     expect(screen.getByTestId('card-o3').parentElement!.style.top).toBe('98px');
-    // Height is content-driven — the wrapper never hard-sizes the card.
+    // Height is content-driven, and the wrapper never hard-sizes the card.
     expect(screen.getByTestId('card-o1').parentElement!.style.height).toBe('');
   });
 
@@ -603,7 +603,7 @@ describe('DataView.Timeline', () => {
   });
 
   it('extends the domain so the grid fills a container wider than the data span', () => {
-    // jsdom's clientWidth is 0 by default — pretend the scroll container is
+    // jsdom's clientWidth is 0 by default, so pretend the scroll container is
     // 1000px wide. The explicit range renders 620px, so the domain end
     // extends Feb 1 → Feb 20 and ticks run Jan 1 … Feb 20 = 51 gridlines.
     vi.spyOn(Element.prototype, 'clientWidth', 'get').mockReturnValue(1000);
@@ -664,13 +664,13 @@ describe('DataView.Timeline', () => {
     expect(root.scrollTop).toBe(20);
     expect(root.dataset.dragging).toBe('true');
 
-    // Hold still past the stale window, then release — no glide.
+    // Hold still past the stale window, then release, with no glide.
     await act(async () => {
       await new Promise(resolve => setTimeout(resolve, 100));
     });
     fireEvent.pointerUp(root, { pointerId: 1 });
     expect(root.dataset.dragging).toBeUndefined();
-    // Released — further movement no longer pans.
+    // Released, so further movement no longer pans.
     fireEvent.pointerMove(root, { pointerId: 1, clientX: 100, clientY: 0 });
     await act(async () => {
       await new Promise(resolve => setTimeout(resolve, 50));
@@ -689,7 +689,7 @@ describe('DataView.Timeline', () => {
       clientY: 100
     });
     fireEvent.pointerMove(root, { pointerId: 1, clientX: 250, clientY: 100 });
-    // Release mid-motion — the pan keeps scrolling and decays.
+    // Release mid-motion: the pan keeps scrolling and decays.
     fireEvent.pointerUp(root, { pointerId: 1 });
     expect(root.scrollLeft).toBe(50);
     await act(async () => {
@@ -709,7 +709,7 @@ describe('DataView.Timeline', () => {
   it('does not start a pan from a card or from touch pointers', () => {
     const { container } = renderTimeline();
     const root = container.firstElementChild as HTMLElement;
-    // Press on a card (row-click territory) — no pan.
+    // Press on a card (row-click territory), so no pan.
     fireEvent.pointerDown(screen.getByTestId('card-o1'), {
       pointerType: 'mouse',
       button: 0,
@@ -720,7 +720,7 @@ describe('DataView.Timeline', () => {
     fireEvent.pointerMove(root, { pointerId: 1, clientX: 200, clientY: 100 });
     expect(root.scrollLeft).toBe(0);
 
-    // Touch pans natively — the drag handler must not hijack it.
+    // Touch pans natively, so the drag handler must not hijack it.
     fireEvent.pointerDown(root, {
       pointerType: 'touch',
       button: 0,
@@ -757,7 +757,7 @@ describe('DataView.Timeline', () => {
     // Viewport's left edge sits at Jan 11 (200px / 20px-per-day from Jan 1).
     root.scrollLeft = 200;
 
-    // Extend the range a month to the left — t0 moves to Dec 1.
+    // Extend the range a month to the left, so t0 moves to Dec 1.
     rerender(
       <DataView<Order>
         data={orders}
@@ -849,7 +849,7 @@ describe('DataView.Timeline', () => {
     expect(from.getTime()).toBe(dayjs('2025-01-06').valueOf());
 
     // Sub-pixel drift (scroll anchoring's float round-trip, device-pixel
-    // quantization of scrollLeft) is noise, not a scroll — no re-fire.
+    // quantization of scrollLeft) is noise, not a scroll, so no re-fire.
     root.scrollLeft = 100.4;
     await act(async () => {
       fireEvent.scroll(root);
@@ -998,7 +998,7 @@ describe('DataView.Timeline', () => {
     expect(screen.queryByTestId('card-o1')).toBeNull();
 
     rerender(makeUI('gantt'));
-    // The DOM is recreated at scroll 0 — the stashed position must come back
+    // The DOM is recreated at scroll 0, so the stashed position must come back
     // instead of stranding the user at the domain start.
     const newRoot = container.firstElementChild as HTMLElement;
     expect(screen.getByTestId('card-o1')).toBeInTheDocument();
@@ -1086,7 +1086,7 @@ describe('DataView.Timeline (characterisation)', () => {
 
   it('keeps chronological DOM order under one-per-row packing', () => {
     // Lanes follow row-model order here, so DOM order and lane order disagree
-    // — worth pinning separately from the packed case above.
+    // Worth pinning separately from the packed case above.
     renderTimeline({ lanePacking: 'one-per-row' });
     expect(cardIds()).toEqual(['o1', 'o3', 'o2']);
     expect(screen.getByTestId('card-o2').dataset.lane).toBe('1');
@@ -1096,7 +1096,7 @@ describe('DataView.Timeline (characterisation)', () => {
   it('falls back to the overscan floor with no measurable viewport', () => {
     // jsdom reports a zero-size client box, as does SSR. Overscan collapses to
     // its 200px floor, so the window is [-200, 200] horizontally and unbounded
-    // vertically — o2 at x=220 falls outside, o1 and o3 don't.
+    // vertically: o2 at x=220 falls outside, o1 and o3 don't.
     renderTimeline({ virtualized: true });
     expect(cardIds()).toEqual(['o1', 'o3']);
   });
@@ -1106,7 +1106,7 @@ describe('DataView.Timeline (characterisation)', () => {
     // this same setup re-stacks lane 1 to 122px on the measured 90px height
     // (see "re-stacks lanes to the tallest measured card height"). Virtualized,
     // a culled card never mounts and so never measures, so honouring
-    // measurements would resize lanes under the user mid-scroll — lanes hold
+    // measurements would resize lanes under the user mid-scroll, so lanes hold
     // the estimate instead, putting lane 1 back at 16 + 66 + 16.
     vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockImplementation(
       function (this: HTMLElement) {
@@ -1157,7 +1157,7 @@ describe('DataView.Timeline (characterisation)', () => {
 /* ─────────────────── characterisation: axis chrome ───────────────────────
    Counts of the non-card furniture: tick labels, month bands, marker badges
    and lines, group slots. Cards and gridlines already cull; the rest is what
-   Phase 2 changes, so these pin where it stands first — unvirtualized, where
+   Phase 2 changes, so these pin where it stands first, unvirtualized, where
    nothing may move, and virtualized, where it should. */
 
 describe('DataView.Timeline chrome (characterisation)', () => {
@@ -1264,7 +1264,7 @@ describe('DataView.Timeline chrome (characterisation)', () => {
 
 /* ──────────────────────────── virtualization ─────────────────────────────
    `virtualized` culls on both axes. Vertical culling needs a pane height and
-   jsdom does no layout, so these stub the scroll container's client box — with
+   jsdom does no layout, so these stub the scroll container's client box, with
    the deliberate exception of the last test, covering the unmeasured fallback.
    Lane pitch under virtualization is fixed: estimatedRowHeight (66) + laneGap
    (16) = 82, lane 0 starting at 16. */
@@ -1289,7 +1289,7 @@ function stubPane({ width = 600, height = 200 } = {}) {
 }
 
 describe('DataView.Timeline virtualization', () => {
-  /** One lane per row, every card at the same x — isolates vertical culling. */
+  /** One lane per row, every card at the same x, which isolates vertical culling. */
   const stackedOrders: Order[] = Array.from({ length: 12 }, (_, i) => ({
     id: `r${String(i + 1).padStart(2, '0')}`,
     title: String(i + 1).padStart(2, '0'),
@@ -1385,7 +1385,7 @@ describe('DataView.Timeline virtualization', () => {
       await new Promise(resolve => setTimeout(resolve, 30));
     });
     // Window [2100, 3300]. Culling searches by x, which is ordered, while
-    // width isn't — so each lane widens its left bound by its own widest card
+    // width isn't, so each lane widens its left bound by its own widest card
     // and then re-checks the right edge exactly.
     expect(screen.getByTestId('card-wide')).toBeInTheDocument(); // 2000 → 2600
     expect(screen.queryByTestId('card-narrow')).toBeNull(); // 2000 → 2020
@@ -1393,7 +1393,7 @@ describe('DataView.Timeline virtualization', () => {
 
   it('skips vertical culling when the pane reports no height', () => {
     // No stub: jsdom leaves clientHeight 0, as does SSR. A zero height would
-    // otherwise cull to a sliver of lanes — horizontal culling carries on.
+    // otherwise cull to a sliver of lanes, and horizontal culling carries on.
     renderTimeline(
       { virtualized: true, lanePacking: 'one-per-row' },
       stackedOrders
@@ -1405,7 +1405,7 @@ describe('DataView.Timeline virtualization', () => {
 /* ───────────────────────────── ordering contract ─────────────────────────
    Sort can't move a card horizontally (x is locked to time), so it only shows
    up where vertical order is free: `lanePacking="one-per-row"`. `auto` packing
-   stays purely chronological — these two tests are the regression guard. */
+   stays purely chronological, and these two tests are the regression guard. */
 
 describe('DataView.Timeline ordering', () => {
   const laneOf = (id: string) =>
@@ -1501,7 +1501,7 @@ const bands = (container: HTMLElement) =>
 describe('DataView.Timeline grouping', () => {
   it('renders one band per group, in row-model order, with label and count', () => {
     const { container } = renderGrouped();
-    // First-occurrence order from `groupData` — the same order List renders.
+    // First-occurrence order from `groupData`, the same order List renders.
     expect(bands(container).map(band => band.textContent)).toEqual([
       'Eng2',
       'Design1'
@@ -1559,7 +1559,7 @@ describe('DataView.Timeline grouping', () => {
 
   it('keeps a card in its own section when it starts under another group', () => {
     renderGrouped();
-    // Same x as a1 (80px) — proves packing never leaks across sections.
+    // Same x as a1 (80px), which proves packing never leaks across sections.
     expect(screen.getByTestId('card-b1').parentElement!.style.left).toBe(
       '80px'
     );
@@ -1604,7 +1604,7 @@ describe('DataView.Timeline grouping', () => {
     const { container } = renderGrouped({}, [
       ...groupedOrders,
       // A third Eng row outside the range: culled from the canvas, but the
-      // badge still reports `GroupedData.count` — same as List.
+      // badge still reports `GroupedData.count`, the same as List.
       {
         id: 'a3',
         title: 'A3',
@@ -1730,7 +1730,7 @@ describe('DataView.Timeline actionsRef', () => {
       behavior: 'auto'
     });
     expect(root.scrollLeft).toBe(596);
-    // Clamped to t0 (x 0) — the inset yields to the scroll floor.
+    // Clamped to t0 (x 0), so the inset yields to the scroll floor.
     actionsRef.current!.scrollTo('1999-01-01', {
       align: 'start',
       behavior: 'auto'
@@ -1794,7 +1794,7 @@ describe('DataView.Timeline actionsRef', () => {
 describe('DataView.Timeline sort-value lanes', () => {
   // Jan 5 → 80px, Jan 6 → 100px (overlaps Jan 5's span), Jan 12 → 220px (clear).
   // `rank` is the numeric ranking of `priority`, for sorts that need High before
-  // Medium before Low — alphabetically that order is impossible.
+  // Medium before Low, which alphabetically is impossible.
   const tasks: Order[] = [
     {
       id: 't1',
@@ -1884,7 +1884,7 @@ describe('DataView.Timeline sort-value lanes', () => {
   });
 
   it('relanes when the sort field changes', () => {
-    // Sorting by title instead lanes by title — every value distinct, so one
+    // Sorting by title instead lanes by title, where every value is distinct, so one
     // lane per row, in title order.
     renderSortValueLanes(undefined, tasks, {
       sort: { name: 'title', order: 'asc' }
@@ -2114,7 +2114,7 @@ describe('DataView.Timeline sort-value lanes', () => {
 
   it('lanes by a dotted accessorKey the way the sort reads it', () => {
     // TanStack treats a dotted key as a path, so the lane value has to come
-    // through the row — `original['meta.rank']` would be undefined for every
+    // through the row, since `original['meta.rank']` would be undefined for every
     // row and pile them all onto the no-value lane.
     renderSortValueLanes(
       undefined,

--- a/packages/raystack/components/data-view/components/clear-filters.tsx
+++ b/packages/raystack/components/data-view/components/clear-filters.tsx
@@ -25,7 +25,7 @@ export interface DataViewClearFiltersProps {
  * filters); a bordered panel in the empty state. Shared between the List footer
  * and `DataView.ClearFilters` so the markup lives in one place.
  *
- * Internal — not exported from the package.
+ * Internal, not exported from the package.
  */
 export function FilterSummary({ className }: DataViewClearFiltersProps) {
   const {
@@ -110,7 +110,7 @@ FilterSummary.displayName = 'DataView.FilterSummary';
 
 /**
  * Surfaces the bordered "Clear Filters" panel in the empty state (a query
- * returned no rows). Place it as a sibling of `DataView.List` — separate from
+ * returned no rows). Place it as a sibling of `DataView.List`, separate from
  * `DataView.EmptyState`. Renders nothing outside the empty state; the flat
  * footer for the data state is rendered automatically by `DataView.List`.
  */

--- a/packages/raystack/components/data-view/components/display-controls.tsx
+++ b/packages/raystack/components/data-view/components/display-controls.tsx
@@ -23,7 +23,7 @@ interface DisplayControlsProps {
 }
 
 /**
- * `DataView.DisplayControls` — the popover housing the view switcher, Ordering,
+ * `DataView.DisplayControls`, the popover housing the view switcher, Ordering,
  * Grouping, Display Properties (column visibility), and Reset. The view switcher
  * appears at the top whenever `views.length > 1`. Each section can be hidden
  * individually via `hideViewSwitcher` / `hideOrdering` / `hideGrouping` /

--- a/packages/raystack/components/data-view/components/display-properties.tsx
+++ b/packages/raystack/components/data-view/components/display-properties.tsx
@@ -9,7 +9,7 @@ import { useDataView } from '../hooks/useDataView';
 /**
  * Reads visibility from context's single global `columnVisibility` map (RFC §
  * "Unified Column Visibility via DisplayAccess"). Renderers honour the same
- * state — columnar via TanStack column hides, free-form via `DisplayAccess`.
+ * state: columnar via TanStack column hides, free-form via `DisplayAccess`.
  */
 export function DisplayProperties<TData>({
   fields

--- a/packages/raystack/components/data-view/components/filters.tsx
+++ b/packages/raystack/components/data-view/components/filters.tsx
@@ -26,7 +26,7 @@ interface AddFilterProps<TData> {
   appliedFiltersSet: Set<string>;
   onAddFilter: (field: DataViewField<TData>) => void;
   children?: Trigger<TData>;
-  /** Applied to the default trigger only — a custom `trigger`/`children` owns its own className. */
+  /** Applied to the default trigger only. A custom `trigger`/`children` owns its own className. */
   className?: string;
 }
 

--- a/packages/raystack/components/data-view/components/list.tsx
+++ b/packages/raystack/components/data-view/components/list.tsx
@@ -95,7 +95,7 @@ export function DataViewList<TData, TValue = unknown>({
   // Render order from `columns`. TanStack-managed accessors (those declared in
   // root `fields`) gate on the current visibility map. Accessors with no
   // matching field are "unmanaged" display columns (selection, row actions,
-  // drag handles, …) — render unconditionally.
+  // drag handles, …), so render unconditionally.
   const allLeafIds = useMemo(
     () => new Set(table.getAllLeafColumns().map(c => c.id)),
     [table, visibleLeafColumns]
@@ -130,7 +130,7 @@ export function DataViewList<TData, TValue = unknown>({
   // Measure the column-header row so sticky group elements sit directly under it.
   const [headerMeasureRef, headerHeight] = useElementHeight();
 
-  // Group offsets — needed for sticky group anchor under virtualization.
+  // Group offsets, needed for the sticky group anchor under virtualization.
   const group_by = tableQuery?.group_by?.[0];
   const isGrouped = Boolean(group_by) && group_by !== defaultGroupOption.id;
 
@@ -210,7 +210,7 @@ export function DataViewList<TData, TValue = unknown>({
   );
 
   if (!isActive) return null;
-  // Render nothing when there's truly no data and no loading — sibling
+  // Render nothing when there's truly no data and no loading. The sibling
   // `<DataView.EmptyState>` / `<DataView.ZeroState>` handle messaging.
   if (!hasData) return null;
 
@@ -239,7 +239,7 @@ export function DataViewList<TData, TValue = unknown>({
                   : header.column.columnDef.header;
               content = flexRender(source, header.getContext());
             } else if (spec?.header !== undefined) {
-              // Unmanaged column (e.g. selection): no TanStack header — render
+              // Unmanaged column (e.g. selection): no TanStack header, so render
               // the spec's header with a minimal context.
               content =
                 typeof spec.header === 'function'
@@ -282,7 +282,7 @@ export function DataViewList<TData, TValue = unknown>({
           ? flexRender(spec.cell, cell.getContext())
           : ((cell.getValue() as React.ReactNode) ?? null);
       } else if (spec?.cell !== undefined) {
-        // Unmanaged column (e.g. selection): no TanStack cell — render the
+        // Unmanaged column (e.g. selection): no TanStack cell, so render the
         // spec's cell with a synthetic context covering the common reads.
         content =
           typeof spec.cell === 'function'
@@ -515,7 +515,7 @@ export function DataViewList<TData, TValue = unknown>({
         {renderHeaderRow()}
         {virtualized ? renderVirtualBody() : renderFlatBody()}
         {renderLoaderRows()}
-        {/* Sentinel — triggers onLoadMore via IntersectionObserver in server mode. */}
+        {/* Sentinel: triggers onLoadMore via IntersectionObserver in server mode. */}
         <div
           ref={sentinelRef}
           className={styles.listSentinel}

--- a/packages/raystack/components/data-view/components/timeline.tsx
+++ b/packages/raystack/components/data-view/components/timeline.tsx
@@ -42,8 +42,8 @@ const DEFAULT_ROW_HEIGHT = 66;
 const DEFAULT_LANE_GAP = 16;
 /**
  * Height (px) of a group section's header band: `DataView.List`'s group header
- * box exactly — `--rs-space-3` padding above and below a small `Badge` (8 + 22
- * + 8) — so the band reads identically when switching between the two
+ * box exactly, `--rs-space-3` padding above and below a small `Badge` (8 + 22
+ * + 8), so the band reads identically when switching between the two
  * renderers. Fixed rather than measured because lane tops are derived from it,
  * so a content-driven height would feed back into the geometry it seeds. (List
  * only needs its own 36 as a virtualizer estimate, which it corrects by
@@ -65,11 +65,11 @@ const MOMENTUM_MIN_SPEED = 0.05;
 const MOMENTUM_MAX_SPEED = 4;
 /** Exponential decay constant (ms) of the post-release glide. */
 const MOMENTUM_DECAY_TAU = 325;
-/** Releasing this long (ms) after the last move means "held still" — no glide. */
+/** Releasing this long (ms) after the last move means "held still", so there is no glide. */
 const MOMENTUM_STALE_MS = 80;
 /**
  * Breathing room between an edge-aligned scroll target ('start'/'end') and
- * the viewport edge — a card flush against the edge reads as clipped. The
+ * the viewport edge, since a card flush against the edge reads as clipped. The
  * domain clamp wins when there's no room, so targets at the domain edges
  * still sit flush instead of revealing space past the domain.
  */
@@ -147,7 +147,7 @@ const LANE_SCAN_MAX = 8;
 
 /**
  * Overscan floor, in px, on each side of the viewport. Also sets how far the
- * pane may travel before the culling window is recomputed — see `readViewport`.
+ * pane may travel before the culling window is recomputed. See `readViewport`.
  */
 const MIN_OVERSCAN_PX = 200;
 
@@ -155,7 +155,7 @@ const MIN_OVERSCAN_PX = 200;
  * Overscan as a fraction of the viewport, per side. The mounted set covers
  * `(1 + 2r)²` viewports of canvas, so the cost of a commit grows with the
  * *square* of this while the distance it buys before the next commit grows
- * only linearly — a full viewport each side (r = 1) mounts 9 viewports' worth
+ * only linearly. A full viewport each side (r = 1) mounts 9 viewports' worth
  * to save one viewport of travel. Half is the better trade: 4 viewports
  * mounted, commits roughly twice as cheap, twice as often.
  */
@@ -167,7 +167,7 @@ const overscanFor = (extent: number) =>
 
 /**
  * Lane tops as an arithmetic series, when the stack is uninterrupted enough to
- * have one — see where it's built in the geometry memo.
+ * have one. See where it's built in the geometry memo.
  */
 interface UniformPitch {
   /** Top of lane 0. */
@@ -180,7 +180,7 @@ interface UniformPitch {
 
 /**
  * Lanes intersecting the vertical window `[min, max]`, as a `[start, end)`
- * range. Uniform geometry inverts the series arithmetically — O(1), no search
+ * range. Uniform geometry inverts the series arithmetically in O(1), with no search
  * at all; anything else binary-searches the lane boxes.
  */
 function resolveLaneRange(
@@ -236,7 +236,7 @@ interface TimedItem<TData> {
   /** Null when `endField` is omitted (point marker). */
   endTime: number | null;
   /**
-   * Bucket the row falls in under `lanePacking="one-per-sort-value"` — its
+   * Bucket the row falls in under `lanePacking="one-per-sort-value"`. Its
    * `laneField` value as a string, or null for no usable value (that bucket
    * lanes last). Null throughout for every other packing mode.
    */
@@ -247,7 +247,7 @@ interface TimedItem<TData> {
 interface PositionedItem<TData> extends TimedItem<TData> {
   x: number;
   spanWidth: number;
-  /** Null for point cards — the wrapper sizes to its content. */
+  /** Null for point cards, where the wrapper sizes to its content. */
   renderWidth: number | null;
   /** Width the lane packer and the culling window assume. */
   packWidth: number;
@@ -255,13 +255,13 @@ interface PositionedItem<TData> extends TimedItem<TData> {
 
 /**
  * A positioned row with its lane resolved, ready to render. The lane fields
- * are filled in after packing rather than at construction — see the `cards`
- * memo — so they are mutable and zero until then.
+ * are filled in after packing rather than at construction (see the `cards`
+ * memo), so they are mutable and zero until then.
  */
 interface LaidOutCard<TData> extends PositionedItem<TData> {
-  /** Section-relative — what `renderCard` sees as `context.laneIndex`. */
+  /** Section-relative: what `renderCard` sees as `context.laneIndex`. */
   laneIndex: number;
-  /** Global across sections — indexes `laneTops` and the card index. */
+  /** Global across sections: indexes `laneTops` and the card index. */
   lane: number;
 }
 
@@ -280,7 +280,7 @@ interface TimelineCardViewProps<TData> {
   row: Row<TData>;
   x: number;
   top: number;
-  /** Null for point cards — the wrapper sizes to its content. */
+  /** Null for point cards, where the wrapper sizes to its content. */
   renderWidth: number | null;
   spanWidth: number;
   collapsed: boolean;
@@ -291,7 +291,7 @@ interface TimelineCardViewProps<TData> {
   renderCard: DataViewTimelineProps<TData>['renderCard'];
   /**
    * False under a fixed lane pitch (virtualized), where nothing consumes the
-   * measurement — skipping it drops one ResizeObserver per rendered card.
+   * measurement, and skipping it drops one ResizeObserver per rendered card.
    */
   measure: boolean;
   /** Reports the wrapper's rendered height so lanes can size to content. */
@@ -302,7 +302,7 @@ interface TimelineCardViewProps<TData> {
 
 /**
  * Memoized positioning wrapper for one card. Isolates `renderCard` from the
- * root's per-frame re-renders (hover cursor, viewport tracking) — a card only
+ * root's per-frame re-renders (hover cursor, viewport tracking). A card only
  * re-renders when its own row or geometry changes. All props except `row`,
  * `renderCard`, `onMeasure`, and `onRowClick` are primitives, so the default
  * shallow compare holds as long as those identities are stable across renders.
@@ -407,7 +407,7 @@ function cursorLabel(time: number, scale: TimelineScale): string {
  * Time-positioned card renderer. The Timeline owns the time scale (date → x,
  * span → width), lane packing, the sticky two-tier axis (ticks, month/year
  * bands, today + custom markers, gridlines), and native x/y scrolling. The
- * card interior is entirely consumer-owned via `renderCard` — analogous to how
+ * card interior is entirely consumer-owned via `renderCard`, analogous to how
  * `columns[].cell` owns cell interiors in `DataView.List`.
  */
 export function DataViewTimeline<TData>({
@@ -468,7 +468,7 @@ export function DataViewTimeline<TData>({
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
-  // Viewport fill — when the domain renders narrower than the scroll
+  // Viewport fill. When the domain renders narrower than the scroll
   // container, the domain end extends so the axis/gridlines span the full
   // visible width (see `minWidth` in createTimeScale). Extension only ever
   // widens, so an explicit `range` wider than the container is untouched.
@@ -497,7 +497,7 @@ export function DataViewTimeline<TData>({
   // Sections walked out of the row model exactly as `DataView.List` reads it: a
   // row with `subRows` is a group header (its `original` is the `groupData`
   // entry), the leaf rows after it are that group's rows. Section order,
-  // labels, and counts therefore match List for free — in client *and* server
+  // labels, and counts therefore match List for free, in client *and* server
   // mode, since the root groups unconditionally. Ungrouped data has no group
   // rows, so the walk yields one implicit section with no band and the
   // geometry below degenerates to the flat single-section layout.
@@ -524,7 +524,7 @@ export function DataViewTimeline<TData>({
 
   // `one-per-sort-value` lanes by the field the view is *sorted* by: the row model
   // already arrives grouped and ranked by it, so lane membership and lane order
-  // both fall out of the active sort — no second ordering vocabulary, and the
+  // both fall out of the active sort, so there is no second ordering vocabulary, and the
   // Ordering control repositions lanes live. Falls back to 'auto' if the query
   // somehow carries no sort (the root requires `defaultSort`, so this is a
   // guard rather than a mode).
@@ -537,7 +537,7 @@ export function DataViewTimeline<TData>({
   // cached (`_valuesCache` is written only after the lookup succeeds), so a sort
   // key naming no field logged one `[Table] Column with id ... does not exist.`
   // per row per recompute. Looked up on the flat column list instead of through
-  // `table.getColumn`, which logs that error itself — the warning below says the
+  // `table.getColumn`, which logs that error itself. The warning below says the
   // same thing and names the fix. Hidden columns are included, so a sorted field
   // the user has toggled off still lanes.
   const laneColumn = sortValueLanes
@@ -550,7 +550,7 @@ export function DataViewTimeline<TData>({
     if (process.env.NODE_ENV === 'production') return;
     if (!sortValueLanes || !table || laneColumn) return;
     console.warn(
-      `[DataView.Timeline] lanePacking="one-per-sort-value" is sorted by "${laneField}", which matches no field — every card lands on one lane. Sort by a declared field.`
+      `[DataView.Timeline] lanePacking="one-per-sort-value" is sorted by "${laneField}", which matches no field, so every card lands on one lane. Sort by a declared field.`
     );
   }, [sortValueLanes, laneColumn, laneField, table]);
 
@@ -574,7 +574,7 @@ export function DataViewTimeline<TData>({
           endTime = toTimestamp(original?.[endField]);
           if (endTime !== null && endTime < startTime) endTime = startTime;
         }
-        // Lane bucket — the sorted-by field's value. Resolved here so packing
+        // Lane bucket: the sorted-by field's value. Resolved here so packing
         // below is pure geometry. Only a primitive identifies a lane; anything
         // else (an object, an array) shares the no-value lane rather than
         // collapsing into one "[object Object]" bucket.
@@ -582,7 +582,7 @@ export function DataViewTimeline<TData>({
         if (sortValueLanes) {
           // Read through the row, not `original`: TanStack treats a dotted
           // `accessorKey` as a path, so `original['meta.rank']` is undefined
-          // for the very key it sorted by — every row would look valueless and
+          // for the very key it sorted by, so every row would look valueless and
           // pile onto one lane. `getValue` yields exactly what the sort saw, and
           // is skipped outright when the key names no column (see `laneColumn`).
           const value = laneColumn
@@ -609,13 +609,13 @@ export function DataViewTimeline<TData>({
     }
     if (process.env.NODE_ENV !== 'production' && unlaned > 0) {
       console.warn(
-        `[DataView.Timeline] ${unlaned} row(s) have a non-primitive "${laneField}" value and share the last lane — the sorted-by field should resolve to a string or number under lanePacking="one-per-sort-value".`
+        `[DataView.Timeline] ${unlaned} row(s) have a non-primitive "${laneField}" value and share the last lane. The sorted-by field should resolve to a string or number under lanePacking="one-per-sort-value".`
       );
     }
     return list;
   }, [sections, startField, endField, sortValueLanes, laneField, laneColumn]);
 
-  // Data extent, for the domain below — grouping never changes the time domain.
+  // Data extent, for the domain below. Grouping never changes the time domain.
   // Reduced in place rather than through a flattened copy: the extent is two
   // numbers, and materialising every row again to find them doubled the
   // pipeline's peak allocation for nothing.
@@ -698,12 +698,12 @@ export function DataViewTimeline<TData>({
     [timeScale, scale, effectiveUnitWidth, tickInterval]
   );
 
-  // Gridline thinning is visual only — positioning (cards, today, cursor
+  // Gridline thinning is visual only. Positioning (cards, today, cursor
   // snapping) stays at full `scale`-unit granularity.
   const gridlineEvery = Math.max(1, Math.floor(gridlineInterval));
 
   // Card geometry, per section. `renderWidth` is null for point markers (no
-  // endField) — the wrapper sizes to its content instead of the time span. Rows
+  // endField), so the wrapper sizes to its content instead of the time span. Rows
   // entirely outside the domain are dropped: with an explicit `range`, fetched
   // data routinely extends past the window (e.g. whole-month API buckets), and
   // those rows must not render beyond the axis or occupy lanes. A section left
@@ -726,7 +726,7 @@ export function DataViewTimeline<TData>({
         const renderWidth =
           item.endTime !== null ? Math.max(spanWidth, MIN_RENDER_WIDTH) : null;
         // Point cards (no endField) size to their content, so the packer can't
-        // know their width — `estimatedPointWidth` stands in for lane packing
+        // know their width, so `estimatedPointWidth` stands in for lane packing
         // and culling so wide chips don't overlap within a lane.
         const packWidth = renderWidth ?? estimatedPointWidth;
         // Lane fields are declared here, filled by the `cards` memo once
@@ -784,7 +784,7 @@ export function DataViewTimeline<TData>({
 
   /**
    * Virtualizing vertically means a card off-screen never mounts and so never
-   * measures — leaving lanes to resize under the user as they scroll. Lanes
+   * measures, leaving lanes to resize under the user as they scroll. Lanes
    * therefore take `estimatedRowHeight` as their exact height while
    * virtualized: geometry stays stable, and cards taller than it overflow
    * their lane rather than growing it.
@@ -793,13 +793,13 @@ export function DataViewTimeline<TData>({
 
   // Measured card heights by row id, `estimatedRowHeight` standing in until a
   // card reports (same estimate-then-measure contract as `DataView.List`).
-  // Kept in a ref — measurements arrive per card per paint, and a version
+  // Kept in a ref, since measurements arrive per card per paint, and a version
   // counter batches them into one lane-geometry recompute. Entries survive
   // virtualization unmounts so scrolling back doesn't shift lanes.
   const measuredHeightsRef = useRef<Map<string, number>>(new Map());
   const [measureVersion, setMeasureVersion] = useState(0);
   const handleCardMeasure = useCallback((rowId: string, height: number) => {
-    // 0/negative = not laid out (display:none, jsdom) — keep the estimate.
+    // 0/negative = not laid out (display:none, jsdom), so keep the estimate.
     if (height <= 0) return;
     const map = measuredHeightsRef.current;
     if (map.get(rowId) === height) return;
@@ -810,7 +810,7 @@ export function DataViewTimeline<TData>({
   // All sections' cards flattened and sorted ascending by x, which is what
   // lets per-frame culling search for its window instead of scanning every
   // item. Lane semantics (packing order, one-per-row row order) are unaffected
-  // — lanes are assigned before the sort.
+  // Lanes are assigned before the sort.
   //
   // DOM order is chronological, except under vertical culling: that path emits
   // lane by lane, so cards come out grouped by lane and chronological within
@@ -835,7 +835,7 @@ export function DataViewTimeline<TData>({
         list.push(item);
       }
     }
-    // Counting sort rather than `Array#sort` — see `orderByX`.
+    // Counting sort rather than `Array#sort`. See `orderByX`.
     const order = orderByX(list);
     const sorted = new Array<LaidOutCard<TData>>(list.length);
     // Widest card, folded into this pass: culling widens its left bound by it,
@@ -852,7 +852,7 @@ export function DataViewTimeline<TData>({
   // Drop measurements for rows that left the data set so a shrunk lane
   // doesn't stay sized to a card that no longer exists. Under a fixed pitch
   // nothing reads the map and cards never report into it, so the whole
-  // O(rows) sweep — and the row-id Set it builds — is skipped.
+  // O(rows) sweep, and the row-id Set it builds, is skipped.
   useEffect(() => {
     if (fixedLaneHeight) return;
     const ids = new Set(cards.map(item => item.row.id));
@@ -867,8 +867,8 @@ export function DataViewTimeline<TData>({
     if (changed) setMeasureVersion(version => version + 1);
   }, [cards, fixedLaneHeight]);
 
-  // Vertical geometry. Each lane is as tall as its tallest card — measured
-  // height when known, `estimatedRowHeight` until then — so lane tops are
+  // Vertical geometry. Each lane is as tall as its tallest card, using the measured
+  // height when known and `estimatedRowHeight` until then, so lane tops are
   // cumulative rather than a fixed pitch. Sections stack: band, then that
   // section's lanes, then the next section's band. `groupBands` carries each
   // band's slot (top + full section height) for the sticky pin below.
@@ -888,7 +888,7 @@ export function DataViewTimeline<TData>({
     // Measured lanes only outside virtualization: a culled card never reports
     // a height, so lanes would resize as the user scrolls and shift every lane
     // below them. The fixed pitch also drops this pass from O(cards) to
-    // O(lanes) — it stops depending on the measurements entirely.
+    // O(lanes), and stops depending on the measurements entirely.
     if (!fixedLaneHeight) {
       heights.fill(0);
       for (const item of cards) {
@@ -932,7 +932,7 @@ export function DataViewTimeline<TData>({
     // reserving one lane's worth of canvas so the pane doesn't collapse.
     if (laneCount === 0) y = estimatedRowHeight + laneGap * 2;
     // Lane tops are an arithmetic series only when nothing interrupts the
-    // stack — one section (a second one inserts its own leading gap) and no
+    // stack: one section (a second one inserts its own leading gap) and no
     // band above it. That's the shape that scales to thousands of lanes, and
     // it lets vertical culling map a scroll offset straight to a lane index;
     // anything else falls back to a binary search over `tops`.
@@ -1027,7 +1027,7 @@ export function DataViewTimeline<TData>({
     return list;
   }, [todayTime, markers, timeScale]);
 
-  // Viewport tracking — drives horizontal culling (`virtualized`) and
+  // Viewport tracking. Drives horizontal culling (`virtualized`) and
   // `onVisibleRangeChange`. rAF-throttled so the state update runs at most
   // once per frame regardless of scroll event rate.
   const needsViewport = virtualized || Boolean(onVisibleRangeChange);
@@ -1040,8 +1040,8 @@ export function DataViewTimeline<TData>({
   const rafIdRef = useRef<number | null>(null);
   /**
    * The pane's live client box, unquantized. `viewport` state lags it on
-   * purpose (see below); anything needing the true offset — the visible-range
-   * callback — reads this instead.
+   * purpose (see below); anything needing the true offset, such as the visible-range
+   * callback, reads this instead.
    */
   const viewportRef = useRef<{
     left: number;
@@ -1083,7 +1083,7 @@ export function DataViewTimeline<TData>({
     });
   }, []);
 
-  // Hover cursor — a crosshair line snapped to the sub-interval (tick unit)
+  // Hover cursor: a crosshair line snapped to the sub-interval (tick unit)
   // under the pointer, with a date badge pinned to the axis. Updates are
   // rAF-throttled and recomputed on scroll too (the content moves under a
   // stationary pointer).
@@ -1128,7 +1128,7 @@ export function DataViewTimeline<TData>({
     setCursorTime(null);
   }, []);
 
-  // Drag-to-pan — press the background and drag to scroll both axes. Mouse
+  // Drag-to-pan: press the background and drag to scroll both axes. Mouse
   // only: touch already pans via native scrolling, and starting only on the
   // background keeps cards (row click) and footer controls interactive.
   const dragRef = useRef<{
@@ -1145,7 +1145,7 @@ export function DataViewTimeline<TData>({
   } | null>(null);
   const [isDragging, setIsDragging] = useState(false);
 
-  // Post-release glide — the pan carries its release velocity and decays
+  // Post-release glide: the pan carries its release velocity and decays
   // exponentially instead of stopping dead. Any new interaction cancels it.
   const momentumRafRef = useRef<number | null>(null);
 
@@ -1192,7 +1192,7 @@ export function DataViewTimeline<TData>({
 
   const handleDragPointerDown = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
-      // Any press grabs the content — even ones that don't start a pan.
+      // Any press grabs the content, even ones that don't start a pan.
       stopMomentum();
       if (event.pointerType !== 'mouse' || event.button !== 0) return;
       const el = scrollRef.current;
@@ -1224,7 +1224,7 @@ export function DataViewTimeline<TData>({
       } catch {
         /* noop */
       }
-      // Panning, not selecting — suppress native text-selection drag.
+      // Panning, not selecting, so suppress native text-selection drag.
       event.preventDefault();
     },
     [stopMomentum]
@@ -1275,7 +1275,7 @@ export function DataViewTimeline<TData>({
     [startMomentum]
   );
 
-  // Last known scroll offsets — stashed on every scroll (and on programmatic
+  // Last known scroll offsets, stashed on every scroll (and on programmatic
   // scrolls) so the position survives the DOM being unmounted while hidden
   // (inactive view / no data) and restored on re-activation, instead of the
   // recreated DOM stranding the user at scroll 0 (the domain start).
@@ -1331,17 +1331,17 @@ export function DataViewTimeline<TData>({
 
   // Reads the *measured* offset, not the quantized `viewport` state: culling
   // can coast on a stale window because it overscans, but a consumer fetching
-  // by visible range cannot — it would be handed a window the user scrolled
+  // by visible range cannot, since it would be handed a window the user scrolled
   // past. Running off the ref also keeps this off React's critical path
   // entirely: a timeline with only `onVisibleRangeChange` set now re-renders
   // on nothing at all while scrolling.
   //
-  // Deduped within one pixel of time — `timeScale` identity churn (a resize, a
+  // Deduped within one pixel of time, because `timeScale` identity churn (a resize, a
   // domain rebuild from streamed-in rows) must not re-fire consumers with an
   // unchanged window; each fire typically triggers a fetch check. Exact
   // equality is too strict for "unchanged": the px→time→px round-trip of
   // scroll anchoring isn't bit-exact in floats, and browsers quantize an
-  // anchored scrollLeft to device pixels — either can drift the recomputed
+  // anchored scrollLeft to device pixels, and either can drift the recomputed
   // edges without the window visibly moving. Anything under one pixel's worth
   // of time is that noise, not a scroll (the baseline is the last *notified*
   // window, so slow sub-pixel scrolling still accumulates past the threshold
@@ -1378,7 +1378,7 @@ export function DataViewTimeline<TData>({
 
   // Time-target resolution shared by `defaultScrollTo` and the imperative
   // handle. 'today' resolves to the today-line when shown, else the actual
-  // current date — both get clamped into the domain by `scrollToTime`.
+  // current date. Both get clamped into the domain by `scrollToTime`.
   const resolveScrollTarget = useCallback(
     (target: NonNullable<DataViewTimelineProps<TData>['defaultScrollTo']>) => {
       if (target === 'start') return timeScale.t0;
@@ -1394,7 +1394,7 @@ export function DataViewTimeline<TData>({
     [timeScale, todayTime]
   );
 
-  // Programmatic scroll — clamps the target into the domain, aligns it in the
+  // Programmatic scroll. Clamps the target into the domain, aligns it in the
   // viewport, and cancels any in-flight momentum glide. Direct scrollLeft
   // assignment for 'auto' keeps jsdom (no Element.scrollTo) working.
   const scrollToTime = useCallback(
@@ -1416,7 +1416,7 @@ export function DataViewTimeline<TData>({
         0,
         Math.min(targetX, timeScale.totalWidth - el.clientWidth)
       );
-      // Stash eagerly — programmatic scrolls must survive a view switch even
+      // Stash eagerly, since programmatic scrolls must survive a view switch even
       // when no scroll event follows (e.g. the target equals the current
       // position, or jsdom).
       savedScrollRef.current = { left, top: el.scrollTop };
@@ -1431,7 +1431,7 @@ export function DataViewTimeline<TData>({
 
   // Filter/search-driven auto-scroll (`scrollToResults`). Applying a filter
   // while scrolled away from the matches would leave the user parked on empty
-  // canvas — when the query changes and no matching card intersects the
+  // canvas. When the query changes and no matching card intersects the
   // viewport, bring the earliest match into view. A query change that keeps a
   // card on screen doesn't move the view. Compared by value: `tableQuery`
   // identity churns on unrelated updates (sort, grouping); the ref seeds with
@@ -1470,7 +1470,7 @@ export function DataViewTimeline<TData>({
         if (!scrollRef.current) {
           if (process.env.NODE_ENV !== 'production') {
             console.warn(
-              '[DataView.Timeline] scrollTo() ignored — the timeline is not rendered (inactive view or no data).'
+              '[DataView.Timeline] scrollTo() ignored: the timeline is not rendered (inactive view or no data).'
             );
           }
           return;
@@ -1502,17 +1502,17 @@ export function DataViewTimeline<TData>({
     [resolveScrollTarget, scrollToTime, timeScale]
   );
 
-  // Initial scroll position — runs when the renderer (re)mounts its DOM. The
+  // Initial scroll position. Runs when the renderer (re)mounts its DOM. The
   // first activation applies `defaultScrollTo`; re-activations restore the
   // stashed position, because the recreated scroll container starts back at
-  // (0, 0) — without the restore a returning user would land at the domain
+  // (0, 0), and without the restore a returning user would land at the domain
   // start instead of where they left off.
   const didInitScrollRef = useRef(false);
   // biome-ignore lint/correctness/useExhaustiveDependencies: `isActive`/`hasData` re-run the attempt when the renderer (re)mounts its DOM (the ref is null while hidden).
   useLayoutEffect(() => {
     const el = scrollRef.current;
     if (!el) {
-      // Hidden (inactive view or no data): the DOM is gone — arm the next
+      // Hidden (inactive view or no data): the DOM is gone, so arm the next
       // activation to restore or re-init.
       didInitScrollRef.current = false;
       return;
@@ -1548,7 +1548,7 @@ export function DataViewTimeline<TData>({
     hasData
   ]);
 
-  // Scroll anchoring — when the time domain shifts (rows prepended by
+  // Scroll anchoring. When the time domain shifts (rows prepended by
   // range-window fetching, `range` extended, zoom change), keep the time under
   // the viewport's left edge stable instead of letting content jump.
   const scrollAnchorRef = useRef<{ t0: number; pxPerMs: number } | null>(null);
@@ -1562,7 +1562,7 @@ export function DataViewTimeline<TData>({
     ) {
       const leftEdgeTime = prev.t0 + el.scrollLeft / prev.pxPerMs;
       el.scrollLeft = Math.max(0, timeScale.x(leftEdgeTime));
-      // Anchoring moved the content under the culling window — resync it in
+      // Anchoring moved the content under the culling window, so resync it in
       // the same layout pass rather than a frame later.
       readViewport();
     }
@@ -1573,11 +1573,11 @@ export function DataViewTimeline<TData>({
   }, [timeScale, readViewport]);
 
   if (!isActive) return null;
-  // Render nothing when there's truly no data and no loading — sibling
+  // Render nothing when there's truly no data and no loading. The sibling
   // `<DataView.EmptyState>` / `<DataView.ZeroState>` handle messaging.
   if (!hasData) return null;
 
-  // Horizontal culling window — half a viewport on each side as overscan.
+  // Horizontal culling window: half a viewport on each side as overscan.
   const overscan = viewport ? overscanFor(viewport.width) : 0;
   const cullRange =
     virtualized && viewport
@@ -1612,14 +1612,14 @@ export function DataViewTimeline<TData>({
    * Vertical span for the grid, marker, and cursor lines.
    *
    * The stylesheet pins them `top: 0; bottom: 0`, so each is a one-pixel-wide
-   * element as tall as the whole canvas — 28,798px at 10k rows, 139,170px at
+   * element as tall as the whole canvas: 28,798px at 10k rows, 139,170px at
    * 50k. Rasterizing a dashed sub-pixel border over that height costs the same
    * whether one card is on screen or four hundred, which is why culling their
    * *count* (183 -> 31) never moved frame time. Clamped to the vertical window
    * they cost what a viewport costs. Measured on a 10k-row canvas: p95 frame
    * 291.7ms -> 20.9ms, frames over 50ms 40 -> 0.
    *
-   * Only under `virtualized` — `needsViewport` leaves `viewport` null
+   * Only under `virtualized`, since `needsViewport` leaves `viewport` null
    * otherwise, and lines then keep their full-canvas span as before.
    */
   const lineTop = verticalRange ? Math.max(0, verticalRange.min) : 0;
@@ -1645,7 +1645,7 @@ export function DataViewTimeline<TData>({
   // - Without one (unmeasured height), the old global slice over the
   //   x-ascending `cards`.
   //
-  // Both widen the left bound by the widest card — x is ordered, width isn't —
+  // Both widen the left bound by the widest card, since x is ordered and width isn't,
   // so every candidate still gets an exact right-edge check.
   let cardSlice: LaidOutCard<TData>[];
   if (cullRange && laneRange && laneIndex) {
@@ -1688,7 +1688,7 @@ export function DataViewTimeline<TData>({
       )
     : ticks;
   // Bands tile the domain edge to edge, so the one straddling the left bound
-  // starts before it — step back one from the first band past the bound rather
+  // starts before it, so step back one from the first band past the bound rather
   // than widening by a max width the way the cards do.
   const visibleBands = cullRange
     ? bands.slice(
@@ -1702,8 +1702,8 @@ export function DataViewTimeline<TData>({
         marker => marker.x >= cullRange.min && marker.x <= cullRange.max
       )
     : resolvedMarkers;
-  // Group slots stack the same way lanes do — ascending, contiguous, each
-  // spanning its whole section — so the vertical window slices them directly.
+  // Group slots stack the same way lanes do: ascending, contiguous, each
+  // spanning its whole section, so the vertical window slices them directly.
   // The section under the pin line always intersects the window, which is what
   // keeps its sticky band pinned.
   const visibleGroupBands = verticalRange
@@ -1804,7 +1804,7 @@ export function DataViewTimeline<TData>({
           `overflow: hidden` would neutralize the sticky positioning below.
           The layer is absolute inside the scroll container, so it scrolls with
           the content while each band sticks vertically within its own section
-          slot — pinned under the axis, pushed out by the next section's band. */}
+          slot, pinned under the axis and pushed out by the next section's band. */}
       {groupBands.length > 0 ? (
         <div
           className={styles.timelineGroupLayer}

--- a/packages/raystack/components/data-view/components/toolbar.tsx
+++ b/packages/raystack/components/data-view/components/toolbar.tsx
@@ -14,7 +14,7 @@ interface ToolbarProps {
 
 /**
  * Toolbar container for `DataView`. Visible whenever there is data OR an active
- * query — pure zero state keeps it hidden. Consumers compose children
+ * query, and pure zero state keeps it hidden. Consumers compose children
  * (`<DataView.Search>`, `<DataView.Filters>`, `<DataView.DisplayControls>`,
  * custom actions); omitting children renders the default
  * `<Filters> + <DisplayControls>` pair.

--- a/packages/raystack/components/data-view/components/view-switcher.tsx
+++ b/packages/raystack/components/data-view/components/view-switcher.tsx
@@ -9,7 +9,7 @@ interface ViewSwitcherProps {
 
 /**
  * Tab-based switcher for the configured `views`. Internal to
- * `DataView.DisplayControls` — reads `views` and `activeView` from context and
+ * `DataView.DisplayControls`. Reads `views` and `activeView` from context and
  * writes through `setActiveView`. Renders nothing when `views` is unset or has
  * fewer than two entries. Each tab shows the view's optional `leadingIcon`.
  */

--- a/packages/raystack/components/data-view/data-view.module.css
+++ b/packages/raystack/components/data-view/data-view.module.css
@@ -72,7 +72,7 @@
   flex: 1;
 }
 
-/* Filter container — chips wrap onto a new line when they overflow. */
+/* Filter container: chips wrap onto a new line when they overflow. */
 .filterContainer {
   flex-wrap: wrap;
 }
@@ -202,7 +202,7 @@
   background: var(--rs-color-background-base-primary-hover);
 }
 
-/* Virtual row variant — positioned absolutely; gridTemplateColumns is set
+/* Virtual row variant: positioned absolutely; gridTemplateColumns is set
    inline so columns line up with the header. */
 .listRowVirtual {
   display: grid;
@@ -273,7 +273,7 @@
   box-sizing: border-box;
 }
 
-/* Virtualized group header — absolutely positioned within `.listBodyVirtual`. */
+/* Virtualized group header: absolutely positioned within `.listBodyVirtual`. */
 .listGroupHeaderVirtual {
   display: flex;
   align-items: center;
@@ -300,7 +300,7 @@
   z-index: 1;
 }
 
-/* Virtualized sticky group anchor — single element that swaps content as the
+/* Virtualized sticky group anchor: a single element that swaps content as the
    user scrolls past each natural group header. `top` is set inline. */
 .listGroupAnchor {
   position: sticky;
@@ -330,13 +330,13 @@
   box-sizing: border-box;
 }
 
-/* Lets <Skeleton/> fill the available width inside a flex .listCell —
+/* Lets <Skeleton/> fill the available width inside a flex .listCell,
    matches DataTable's virtualized skeleton container. */
 .skeletonFill {
   flex: 1;
 }
 
-/* IntersectionObserver sentinel — sits below the loader rows. Non-visual. */
+/* IntersectionObserver sentinel: sits below the loader rows. Non-visual. */
 .listSentinel {
   grid-column: 1 / -1;
   height: 1px;
@@ -344,7 +344,7 @@
   pointer-events: none;
 }
 
-/* Timeline renderer — cards absolutely positioned on a continuous time axis.
+/* Timeline renderer: cards absolutely positioned on a continuous time axis.
    The root is the single scroll container for both axes; the axis strip
    sticks to the top on vertical scroll and moves with the canvas on
    horizontal scroll because both share the same explicit content width. */
@@ -362,7 +362,7 @@
   background: var(--rs-color-background-base-primary);
 }
 
-/* The pane stays focusable (tabIndex=0) so arrow/page keys scroll it — but it
+/* The pane stays focusable (tabIndex=0) so arrow/page keys scroll it, but it
    never draws a focus ring. A ring around a canvas this large reads as a stray
    blue line rather than a focus indicator: an inset outline is painted over by
    the absolutely-positioned cards, leaving broken segments down the left edge
@@ -374,7 +374,7 @@
   outline: none;
 }
 
-/* Drag-to-pan in progress — grabbing cursor everywhere (descendants too, so
+/* Drag-to-pan in progress: grabbing cursor everywhere (descendants too, so
    cards' own cursor styles don't flicker mid-drag) and selection locked. */
 .timelineRoot[data-dragging],
 .timelineRoot[data-dragging] * {
@@ -413,7 +413,7 @@
 }
 
 /* Sticks to the viewport's left edge while its band is in view (the nearest
-   scroll container is the timeline root). No overflow:hidden on the band —
+   scroll container is the timeline root). No overflow:hidden on the band,
    that would break the sticky behavior. */
 .timelineAxisBandLabel {
   position: sticky;
@@ -442,7 +442,7 @@
   display: flex;
 }
 
-/* Hover-cursor date badge — above marker badges, never intercepts events. */
+/* Hover-cursor date badge: above marker badges, never intercepts events. */
 .timelineAxisCursor {
   position: absolute;
   top: var(--rs-space-2);
@@ -466,7 +466,7 @@
 
 /* One slot per section, spanning that section's full height. The band sticks
    within it, so scrolling past a section slides its band out exactly as the
-   next section's band reaches the pin line — no JS scroll tracking. */
+   next section's band reaches the pin line, with no JS scroll tracking. */
 .timelineGroupSlot {
   position: absolute;
   left: 0;
@@ -475,7 +475,7 @@
 
 /* Pins directly under the sticky axis while its section is in view. Same
    treatment as `.listGroupHeader` (background, typography, count Badge) so the
-   band is visually identical across renderers — including no hairline, which
+   band is visually identical across renderers, including no hairline, which
    List's sticky header also does without. Height comes in inline from
    GROUP_BAND_HEIGHT: lane tops are derived from it, so the band must not size
    to its content. */
@@ -494,7 +494,7 @@
   letter-spacing: var(--rs-letter-spacing-small);
 }
 
-/* Sticks to the viewport's left edge while its band spans the viewport — same
+/* Sticks to the viewport's left edge while its band spans the viewport, the same
    trick as the axis month/year band labels. No overflow:hidden on the band or
    the slot: either would break this.
 
@@ -511,7 +511,7 @@
   white-space: nowrap;
 }
 
-/* `flex: 1 0 auto` — grow into the pane's leftover height so gridlines and
+/* `flex: 1 0 auto` grows into the pane's leftover height so gridlines and
    marker lines run its full height even with only a few lanes, but never
    shrink below the explicit lane geometry (that would clip cards). Growth is
    bounded by the real free space, so a rendered footer is accounted for.
@@ -536,7 +536,7 @@
 }
 
 /* Gridlines, marker lines, and the cursor line all paint beneath cards (DOM
-   order, no z-index) by design — lines are context, cards are content, and a
+   order, no z-index) by design: lines are context, cards are content, and a
    line crossing a card would read as part of it. The axis badge stays visible
    even where a card occludes the line. */
 .timelineMarkerLine {
@@ -556,7 +556,7 @@
   border-left-color: var(--rs-color-border-danger-emphasis);
 }
 
-/* Hover crosshair — darker than gridlines so the snapped position reads
+/* Hover crosshair: darker than gridlines so the snapped position reads
    clearly while tracking the pointer. */
 .timelineCursorLine {
   position: absolute;
@@ -567,7 +567,7 @@
   pointer-events: none;
 }
 
-/* Positioning wrapper only — visually neutral. The card interior (chrome,
+/* Positioning wrapper only, visually neutral. The card interior (chrome,
    states, truncation) is consumer-owned via `renderCard`. */
 .timelineCard {
   position: absolute;
@@ -576,7 +576,7 @@
 }
 
 /* Sticky-left so the filter-summary footer stays aligned to the viewport
-   (not the full canvas width) under horizontal scroll. Never shrinks — the
+   (not the full canvas width) under horizontal scroll. Never shrinks, since the
    canvas absorbs the free height instead. */
 .timelineFooter {
   position: sticky;

--- a/packages/raystack/components/data-view/data-view.tsx
+++ b/packages/raystack/components/data-view/data-view.tsx
@@ -206,7 +206,7 @@ function DataViewRoot<TData>({
     data: groupedData as unknown as TData[],
     columns: columnDefs,
     getRowId: resolveRowId,
-    // Group rows render without cells, so they have no checkbox — keeping them
+    // Group rows render without cells, so they have no checkbox, so keeping them
     // unselectable keeps `rowSelection` one key per data row.
     enableRowSelection: row => !isGroupRowData(row.original),
     getCoreRowModel: getCoreRowModel(),

--- a/packages/raystack/components/data-view/data-view.types.tsx
+++ b/packages/raystack/components/data-view/data-view.types.tsx
@@ -96,7 +96,7 @@ export interface DataViewField<TData = any> {
   groupLabelsMap?: Record<string, string>;
   /**
    * Section order when this field is the active `group_by`, keyed by raw group
-   * value (the same keys `groupLabelsMap` uses) — e.g.
+   * value (the same keys `groupLabelsMap` uses), for example
    * `['High', 'Medium', 'Low']` for a priority field, which text sorting alone
    * can't produce.
    *
@@ -166,7 +166,7 @@ export interface DataViewProps<TData> {
   /**
    * Fires with the new selection map whenever rows are selected or deselected
    * (`row.toggleSelected()`, `table.toggleAllRowsSelected()`, …). Selection
-   * itself lives on the table instance — read it through
+   * itself lives on the table instance, so read it through
    * `useDataView().table`; this is only for mirroring it outside the tree.
    * Keys are `getRowId` values (row indices when `getRowId` is omitted).
    */
@@ -189,7 +189,7 @@ export interface DataViewProps<TData> {
   groupByResolvers?: Record<string, GroupByResolver<TData>>;
 }
 
-/** @deprecated Every key here has an equivalent `[data-slot]` selector — see the List slot table in the DataView docs. Prefer styling by `data-slot` over threading class names through props. */
+/** @deprecated Every key here has an equivalent `[data-slot]` selector. See the List slot table in the DataView docs. Prefer styling by `data-slot` over threading class names through props. */
 export type DataViewListClassNames = {
   /** @deprecated Use `[data-slot="data-view-list"]` instead. */
   root?: string;
@@ -233,7 +233,7 @@ export interface DataViewListProps<TData, TValue = unknown> {
   showGroupHeaders?: boolean;
   /** When true, group headers stick under the table header while scrolling. Default false. */
   stickyGroupHeader?: boolean;
-  /** @deprecated Style rendered parts by `[data-slot]` instead — see `DataViewListClassNames`. */
+  /** @deprecated Style rendered parts by `[data-slot]` instead. See `DataViewListClassNames`. */
   classNames?: DataViewListClassNames;
 }
 
@@ -261,12 +261,12 @@ export interface TimelineCardContext {
   width: number;
   /**
    * True when the span is narrower than `minCardWidth`. Always false for
-   * point cards (no `endField`) — they size to their content instead.
+   * point cards (no `endField`), which size to their content instead.
    */
   collapsed: boolean;
   /**
    * Lane (row) index assigned by packing. Relative to the card's own group
-   * section when `group_by` is active — every section's first lane is 0.
+   * section when `group_by` is active, so every section's first lane is 0.
    */
   laneIndex: number;
   start: Date;
@@ -278,7 +278,7 @@ export interface TimelineCardContext {
  * Imperative navigation surface exposed through `actionsRef` on
  * `DataView.Timeline` (same pattern as Tour's `actionsRef`). Available for the
  * lifetime of the component; methods no-op (with a dev warning) while the
- * renderer is hidden — inactive view or no data.
+ * renderer is hidden, whether by an inactive view or no data.
  */
 export interface TimelineActions {
   /**
@@ -293,7 +293,7 @@ export interface TimelineActions {
     target: TimelineDateInput | 'today' | 'start' | 'end',
     options?: {
       align?: 'start' | 'center' | 'end';
-      /** Default `'smooth'` — a navigation action should visibly travel. */
+      /** Default `'smooth'`, since a navigation action should visibly travel. */
       behavior?: 'auto' | 'smooth';
     }
   ) => void;
@@ -301,7 +301,7 @@ export interface TimelineActions {
   getVisibleRange: () => [Date, Date] | null;
 }
 
-/** @deprecated Every key here has an equivalent `[data-slot]` selector — see the Timeline slot table in the DataView docs. Prefer styling by `data-slot` over threading class names through props. */
+/** @deprecated Every key here has an equivalent `[data-slot]` selector. See the Timeline slot table in the DataView docs. Prefer styling by `data-slot` over threading class names through props. */
 export type DataViewTimelineClassNames = {
   /** @deprecated Use `[data-slot="data-view-timeline"]` instead. */
   root?: string;
@@ -348,11 +348,11 @@ export interface DataViewTimelineProps<TData> {
   /**
    * Renders the card interior. The Timeline owns positioning (x from start,
    * width from span, lane from packing, scroll); the consumer owns the card
-   * visual entirely — chrome, states, truncation, and the collapsed variant.
+   * visual entirely: chrome, states, truncation, and the collapsed variant.
    * Compose `<DataView.DisplayAccess>` inside for Display Properties support.
    *
    * Keep the reference stable (define outside the component or wrap in
-   * `useCallback`) — cards are memoized against it, and an inline function
+   * `useCallback`), because cards are memoized against it and an inline function
    * defeats the memo so every visible card re-renders on each scroll frame.
    * The same applies to `onRowClick` on the `DataView` root.
    */
@@ -363,7 +363,7 @@ export interface DataViewTimelineProps<TData> {
 
   /** Tick granularity of the time axis. Default 'day'. */
   scale?: TimelineScale;
-  /** Pixel width of one `scale` unit — density/zoom override. */
+  /** Pixel width of one `scale` unit, as a density or zoom override. */
   unitWidth?: number;
   /**
    * Explicit time domain. Defaults to the data extent (plus today when shown)
@@ -386,7 +386,7 @@ export interface DataViewTimelineProps<TData> {
   tickInterval?: number;
   /**
    * Draw a gridline every Nth `scale` unit, counted from the domain start.
-   * Independent of `tickInterval` and purely visual — cards, the today line,
+   * Independent of `tickInterval` and purely visual: cards, the today line,
    * and the hover cursor still land on every unit. Default 1.
    */
   gridlineInterval?: number;
@@ -399,7 +399,7 @@ export interface DataViewTimelineProps<TData> {
   defaultScrollTo?: TimelineDateInput | 'today' | 'start' | 'end';
   /**
    * After a filter or search change, scroll the earliest matching card into
-   * view when no match intersects the current viewport — otherwise a filter
+   * view when no match intersects the current viewport. Otherwise a filter
    * whose results are off-screen leaves the user parked on empty canvas. A
    * query change that keeps at least one card on screen doesn't move the
    * view. Default true.
@@ -415,7 +415,7 @@ export interface DataViewTimelineProps<TData> {
    * interval scheduling); 'one-per-row' gives every row its own lane, in
    * row-model (sorted) order; 'one-per-sort-value' gives every distinct value of
    * the **sorted-by** field its own lane, packing that value's cards by date
-   * within it. All apply per group section when `group_by` is active — cards
+   * within it. All apply per group section when `group_by` is active, so cards
    * never share a lane across sections.
    *
    * Under 'one-per-sort-value' the active sort does double duty: it picks the field
@@ -435,7 +435,7 @@ export interface DataViewTimelineProps<TData> {
    * sizing to its tallest card.
    *
    * With `virtualized` it is exact. A culled card never mounts and so never
-   * measures, so measured lanes would resize under the user as they scroll —
+   * measures, so measured lanes would resize under the user as they scroll,
    * lanes take this value instead, and a card taller than it overflows its
    * lane rather than growing it. Set it to your card's height.
    */
@@ -447,14 +447,14 @@ export interface DataViewTimelineProps<TData> {
   /**
    * Assumed width (px) of point-marker cards (rows without `endField`) for
    * lane packing. Point cards size to their content, so the packer can't know
-   * their width — set this to roughly the widest point card to prevent
+   * their width, so set this to roughly the widest point card to prevent
    * horizontal overlap within a lane. Default 120.
    */
   estimatedPointWidth?: number;
 
   /**
    * Render only the cards and gridlines near the visible viewport, culling on
-   * both axes — a frame costs what's on screen rather than what's in the data.
+   * both axes, so a frame costs what's on screen rather than what's in the data.
    * Recommended whenever the domain is long or rows are numerous.
    *
    * Lane heights become fixed to `estimatedRowHeight`; see the note there.
@@ -464,10 +464,10 @@ export interface DataViewTimelineProps<TData> {
   /**
    * Render the group header band above each section when `group_by` is active.
    * Same contract as `DataViewListProps.showGroupHeaders`: false hides the
-   * bands only — rows stay grouped into their sections. Default true.
+   * bands only, and rows stay grouped into their sections. Default true.
    */
   showGroupHeaders?: boolean;
-  /** @deprecated Style rendered parts by `[data-slot]` instead — see `DataViewTimelineClassNames`. */
+  /** @deprecated Style rendered parts by `[data-slot]` instead. See `DataViewTimelineClassNames`. */
   classNames?: DataViewTimelineClassNames;
 }
 
@@ -498,7 +498,7 @@ export type DataViewContextType<TData> = {
   columnVisibility: VisibilityState;
   setColumnVisibility: (value: Updater<VisibilityState>) => void;
 
-  // selection — lifted so a selection change invalidates this context value
+  // selection, lifted so a selection change invalidates this context value
   // (the table instance identity is stable, so it can't do that on its own).
   rowSelection: RowSelectionState;
   setRowSelection: (value: Updater<RowSelectionState>) => void;
@@ -513,7 +513,7 @@ export type DataViewContextType<TData> = {
     fields: DataViewField<TData>[]
   ) => () => void;
 
-  // global derived state — shared across all renderers and sibling components
+  // global derived state, shared across all renderers and sibling components
   hasData: boolean;
   hasActiveQuery: boolean;
   isZeroState: boolean;

--- a/packages/raystack/components/data-view/hooks/useVirtualRows.tsx
+++ b/packages/raystack/components/data-view/hooks/useVirtualRows.tsx
@@ -27,7 +27,7 @@ const DEFAULT_OVERSCAN = 8;
  * content settles correctly.
  *
  * When `enabled` is false the hook still calls `useVirtualizer` (so hook order
- * stays stable) but reports `count: 0` and surfaces empty values — the
+ * stays stable) but reports `count: 0` and surfaces empty values, so the
  * consumer renders rows in natural flow instead.
  */
 export function useVirtualRows<TRow>({

--- a/packages/raystack/components/data-view/utils/index.tsx
+++ b/packages/raystack/components/data-view/utils/index.tsx
@@ -88,7 +88,7 @@ export function fieldsToColumnDefs<TData>(
  *
  * Sections come out in the field's `groupOrder` where it declares one, with
  * undeclared values following in first-seen order and the null-valued bucket
- * last — see `orderBucketKeys`.
+ * last. See `orderBucketKeys`.
  */
 export function groupData<TData>(
   data: TData[],

--- a/packages/raystack/components/data-view/utils/order-bucket-keys.tsx
+++ b/packages/raystack/components/data-view/utils/order-bucket-keys.tsx
@@ -11,13 +11,13 @@ export const EMPTY_BUCKET_KEY = '';
  * empty bucket last.
  *
  * `keys` arrives in first-seen order (a `Map`'s key order, which is insertion
- * order), and only keys that are actually present are emitted — a declared
+ * order), and only keys that are actually present are emitted, so a declared
  * value with no rows produces no section and no lane, so ordering never
  * conjures empty bands. The empty bucket is pinned last regardless of where it
  * appears in `order`, so a declared list doesn't have to mention it.
  *
  * Shared by `groupData`, which passes the grouped field's declared `groupOrder`,
- * and by `packLanesBySortValue`, which passes nothing — timeline lanes follow
+ * and by `packLanesBySortValue`, which passes nothing, so timeline lanes follow
  * the active sort, so only the empty-bucket-last half of the rule applies
  * there. One field that is both grouped and sorted can therefore rank its
  * sections and its lanes differently; that's the documented contract of
@@ -36,7 +36,7 @@ export function orderBucketKeys(keys: string[], order?: string[]): string[] {
       ordered.push(key);
     }
   }
-  // Undeclared keys keep first-seen order — `keys`, not the Set, drives this.
+  // Undeclared keys keep first-seen order, and `keys`, not the Set, drives this.
   for (const key of keys) {
     if (!present.has(key)) continue;
     present.delete(key);

--- a/packages/raystack/components/data-view/utils/order-by-x.tsx
+++ b/packages/raystack/components/data-view/utils/order-by-x.tsx
@@ -13,7 +13,7 @@ const BUCKET_SORT_MIN_ITEMS = 64;
 /**
  * A bucket deeper than this would drag insertion sort towards O(m²) (thousands
  * of cards landing in one pixel column), so it hands off to a comparison sort
- * instead — bounding the pathological case at O(n log n).
+ * instead, bounding the pathological case at O(n log n).
  */
 const INSERTION_SORT_MAX_BUCKET = 32;
 
@@ -21,7 +21,7 @@ const INSERTION_SORT_MAX_BUCKET = 32;
  * Item indices ordered ascending by `x`, ties broken by input order.
  *
  * Counting sort over uniform x buckets. `x` is affine in time, so cards spread
- * near-uniformly across the domain and buckets stay ~1 deep — O(n) at the
+ * near-uniformly across the domain and buckets stay ~1 deep, at O(n) for the
  * sizes that matter, where a comparison sort is O(n log n). Clustered input
  * degrades gracefully rather than falling off a cliff (see the two constants
  * above).
@@ -58,7 +58,7 @@ export function orderByX(items: readonly XPositioned[]): Int32Array {
     return order;
   }
 
-  // One bucket per item — the density that keeps buckets ~1 deep.
+  // One bucket per item, the density that keeps buckets ~1 deep.
   const bucketCount = n;
   const scale = bucketCount / span;
   const bucketOf = new Int32Array(n);
@@ -72,7 +72,7 @@ export function orderByX(items: readonly XPositioned[]): Int32Array {
     // rather than misplacing one item: `bucketOf` is an Int32Array, so NaN
     // stores as 0, while `starts[NaN + 1]++` is a silent no-op on a typed
     // array. Bucket 0 then receives an item it never reserved a slot for and
-    // the scatter overwrites its neighbour — one index duplicated, one lost,
+    // the scatter overwrites its neighbour, leaving one index duplicated and one lost,
     // which downstream means one card packed twice and another left unplaced.
     if (!(bucket >= 0)) bucket = 0;
     else if (bucket >= bucketCount) bucket = bucketCount - 1;
@@ -83,7 +83,7 @@ export function orderByX(items: readonly XPositioned[]): Int32Array {
     starts[bucket + 1] += starts[bucket];
   }
 
-  // Stable scatter — within a bucket, items stay in input order, which is the
+  // Stable scatter: within a bucket, items stay in input order, which is the
   // tie-break the comparison path applies for equal x.
   const cursor = Int32Array.from(starts.subarray(0, bucketCount));
   for (let i = 0; i < n; i++) order[cursor[bucketOf[i]]++] = i;

--- a/packages/raystack/components/data-view/utils/pack-lanes.tsx
+++ b/packages/raystack/components/data-view/utils/pack-lanes.tsx
@@ -16,13 +16,13 @@ export interface PackLanesResult {
 
 /**
  * Horizontal gap between cards sharing a lane. Not the vertical gap between
- * lanes — that's the `laneGap` prop (default 16) applied in timeline.tsx.
+ * lanes. That's the `laneGap` prop (default 16) applied in timeline.tsx.
  */
 const DEFAULT_CARD_GAP_PX = 8;
 
 /**
  * Below this, scanning `laneEnds` linearly beats the sweep's typed-array
- * setup — the scan is only quadratic once both the item count and the lane
+ * setup, since the scan is only quadratic once both the item count and the lane
  * count are large.
  */
 const SWEEP_MIN_ITEMS = 64;
@@ -31,7 +31,7 @@ const SWEEP_MIN_ITEMS = 64;
  * Greedy interval scheduling. Items are visited in ascending `x` order and
  * each is dropped into the first lane whose last occupant ends at least
  * `gapPx` before the item starts; a new lane is opened when none fits.
- * Produces the dense "packed" layout of the timeline design — many
+ * Produces the dense "packed" layout of the timeline design: many
  * non-overlapping cards share a lane.
  *
  * Two implementations, identical output: a direct scan for small inputs, and
@@ -59,7 +59,7 @@ export interface PackSortValueLaneItem extends PackLaneItem {
  * cards overlap in time. Backs `lanePacking="one-per-sort-value"`.
  *
  * Buckets come out in first-seen order, with the no-value bucket last. Lane
- * order is therefore the caller's row order — the timeline hands over the sorted
+ * order is therefore the caller's row order, and the timeline hands over the sorted
  * row model, so lanes follow the active sort and nothing else. That's
  * deliberately *not* `groupData`'s rule, which ranks sections by the field's
  * declared `groupOrder`: a field that is both grouped and sorted can order its
@@ -76,7 +76,7 @@ export function packLanesBySortValue(
   if (items.length === 0) return { lanes: [], laneCount: 0 };
   const lanes = new Array<number>(items.length).fill(0);
 
-  // Indices per bucket, in input order — Map insertion order is the first-seen
+  // Indices per bucket, in input order, since Map insertion order is the first-seen
   // (caller-sorted) order `orderBucketKeys` preserves.
   const buckets = new Map<string, number[]>();
   for (let index = 0; index < items.length; index++) {
@@ -92,7 +92,7 @@ export function packLanesBySortValue(
   let laneCount = 0;
   for (const key of orderBucketKeys([...buckets.keys()])) {
     const bucket = buckets.get(key) as number[];
-    // A bucket of one can't collide with itself, so skip the pack — `orderByX`
+    // A bucket of one can't collide with itself, so skip the pack, since `orderByX`
     // is a sort plus two typed arrays, and a high-cardinality sort field (which
     // the Ordering control lets a user pick at runtime) makes that most buckets.
     if (bucket.length === 1) {
@@ -114,7 +114,7 @@ export function packLanesBySortValue(
   return { lanes, laneCount };
 }
 
-/** First-fit by scanning every lane end — O(items × lanes). */
+/** First-fit by scanning every lane end, at O(items × lanes). */
 function packByScan(
   items: PackLaneItem[],
   gapPx: number,
@@ -136,7 +136,7 @@ function packByScan(
 }
 
 /**
- * First-fit as a left-to-right sweep — same assignment as `packByScan`, in
+ * First-fit as a left-to-right sweep, with the same assignment as `packByScan`, in
  * O(n) rather than O(items × lanes).
  *
  * Two structures replace the linear `findIndex`:
@@ -179,7 +179,7 @@ function packBySweep(
     const col = Math.floor((value - minX) * colScale);
     // Negated rather than `col < 0` so a NaN files into column 0 as well.
     // Unguarded it returns NaN, and a NaN index on a typed array reads
-    // undefined and writes nothing — the lane would be filed into no column at
+    // undefined and writes nothing, so the lane would be filed into no column at
     // all and never released, leaking it for the rest of the sweep.
     if (!(col >= 0)) return 0;
     return col >= colCount ? colCount - 1 : col;
@@ -190,7 +190,7 @@ function packBySweep(
   // lanes never exceed items.
   const releaseHead = new Int32Array(colCount).fill(-1);
   const releaseNext = new Int32Array(n).fill(-1);
-  /** Time (px) at which each lane's occupant frees it — end + gap. */
+  /** Time (px) at which each lane's occupant frees it, meaning end + gap. */
   const laneRelease = new Float64Array(n);
 
   // Free-lane bitmap. `summary` bit s.w is set when word w of block s has any
@@ -215,7 +215,7 @@ function packBySweep(
     freeLanes++;
   };
 
-  /** Lowest set bit's index. Undefined for 0 — callers guard. */
+  /** Lowest set bit's index. Undefined for 0, so callers guard. */
   const lowestBit = (bits: number) => 31 - Math.clz32(bits & -bits);
 
   const takeSmallestFree = () => {
@@ -227,7 +227,7 @@ function packBySweep(
         const word = (block << 5) + wordOffset;
         const bits = words[word];
         if (bits === 0) {
-          // Word emptied without its summary bit clearing — can't happen
+          // Word emptied without its summary bit clearing, which can't happen
           // below, but clearing here keeps the loop finite regardless.
           summary[block] = blockBits & ~(1 << wordOffset);
           continue;

--- a/packages/raystack/components/data-view/utils/time-scale.tsx
+++ b/packages/raystack/components/data-view/utils/time-scale.tsx
@@ -22,7 +22,7 @@ export const TIMELINE_DEFAULT_UNIT_WIDTH: Record<TimelineScale, number> = {
   quarter: 140
 };
 
-/** Minimum px between rendered tick labels — denser ticks skip labels. */
+/** Minimum px between rendered tick labels. Denser ticks skip labels. */
 const TICK_LABEL_MIN_SPACE = 28;
 
 /** Coerce a consumer-provided date (Date | epoch ms | parseable string) to ms. */
@@ -64,7 +64,7 @@ export interface TimelineTimeScale {
   totalWidth: number;
   /** Time (ms) → x offset (px) from the canvas left edge. */
   x: (time: number) => number;
-  /** Inverse of `x` — px offset → time (ms). */
+  /** Inverse of `x`: px offset → time (ms). */
   timeAt: (px: number) => number;
 }
 
@@ -101,7 +101,7 @@ export function createTimeScale(params: {
     padUnits + 1
   );
   // Viewport fill: bulk-add the estimated deficit in one step, then correct
-  // for calendar drift (short months, DST days) — at most a few iterations.
+  // for calendar drift (short months, DST days), at most a few iterations.
   const deficitPx = minWidth - (end.valueOf() - t0) * pxPerMs;
   if (deficitPx > 0) {
     end = addUnits(end, scale, Math.ceil(deficitPx / unitWidth));
@@ -126,7 +126,7 @@ export interface TimelineTick {
   label: string;
   /** False when labels are thinned out at dense zoom levels. */
   showLabel: boolean;
-  /** Sequential unit index from the domain start — drives interval thinning. */
+  /** Sequential unit index from the domain start. Drives interval thinning. */
   index: number;
 }
 
@@ -152,7 +152,7 @@ function tickLabel(date: Dayjs, scale: TimelineScale): string {
 /**
  * Generates the two-tier axis: minor ticks at `scale` granularity and major
  * bands one level up (months over day/week ticks, years over month/quarter
- * ticks). The first band — and any band starting a new year — carries the
+ * ticks). The first band, and any band starting a new year, carries the
  * year in its label ("Jan 2025", then "Feb").
  *
  * `labelEvery` labels every Nth unit, counted from the domain start. The
@@ -160,7 +160,7 @@ function tickLabel(date: Dayjs, scale: TimelineScale): string {
  * applies, so a too-dense request degrades instead of overlapping.
  *
  * Cost note: this materializes one tick per `scale` unit across the whole
- * domain on every rebuild — `virtualized` culls what renders, not what gets
+ * domain on every rebuild, since `virtualized` culls what renders, not what gets
  * built here. Fine at the intended densities (weeks/months, a few years of
  * days); a `day` scale over a decade-wide `range` allocates ~3.6k ticks per
  * rebuild and would need windowed generation instead.

--- a/packages/raystack/components/drawer/drawer.module.css
+++ b/packages/raystack/components/drawer/drawer.module.css
@@ -139,7 +139,7 @@
   height: 100%;
 }
 
-/* Positioning only — IconButton supplies the chrome, states and focus ring. */
+/* Positioning only. IconButton supplies the chrome, states and focus ring. */
 .close {
   position: absolute;
   top: var(--rs-space-3);

--- a/packages/raystack/components/editor/editor.module.css
+++ b/packages/raystack/components/editor/editor.module.css
@@ -1,11 +1,11 @@
 /* The editing host. A contentEditable div grows with its content natively, so
-   there is no `field-sizing` here — that property applies to form controls. */
+   there is no `field-sizing` here, since that property applies to form controls. */
 .editor {
   /* One line box has to be tall enough to hold a whole chip, or inserting one
      would grow the composer and nudge the page under it. The small font's own
      16px line box is shorter than a chip's icon and trailing slots, so the
      editor pairs the small font with the regular line height and sizes the chip
-     to match — the line box is then the same height whatever a line holds. */
+     to match, so the line box is the same height whatever a line holds. */
   --editor-line-height: var(--rs-line-height-regular);
 
   box-sizing: border-box;
@@ -28,12 +28,12 @@
   margin: 0;
 }
 
-/* prosemirror-view ships a stylesheet the editor deliberately does not load —
+/* prosemirror-view ships a stylesheet the editor deliberately does not load,
    it brings its own type, layout and selection treatment. Two of those rules
    are load-bearing rather than cosmetic, so they are mirrored here. */
 
 /* ProseMirror appends a zero-size placeholder <img> after a paragraph that ends
-   in a `contentEditable="false"` node — a chip — so the browser can draw a
+   in a `contentEditable="false"` node, a chip, so the browser can draw a
    caret past it. An app-level `img { display: block }` reset (Tailwind's
    preflight carries one) turns that placeholder into a block box, which reads
    as a phantom empty line under the chip and swallows a Backspace. */
@@ -53,7 +53,7 @@
   background: transparent;
 }
 
-/* Read from the same emptiness predicate as `data-empty` — a ProseMirror-empty
+/* Read from the same emptiness predicate as `data-empty`, a ProseMirror-empty
    paragraph still holds a trailing <br>, so `:empty` would never match. */
 .placeholder::before {
   content: attr(data-placeholder);
@@ -71,7 +71,7 @@
 }
 
 /* Chip. Chip's tokens on the editor's own type scale, so the line box does not
-   jump, and inert — removal is editing-only, so there is no hover or active
+   jump, and inert, since removal is editing-only, so there is no hover or active
    treatment to advertise a press that does nothing. */
 .mention {
   display: inline-flex;
@@ -126,7 +126,7 @@
   height: var(--rs-space-4);
 }
 
-/* NodeSelection — clicking a chip selects it as one unit. */
+/* NodeSelection: clicking a chip selects it as one unit. */
 .mention[data-selected] {
   outline: var(--rs-focus-ring);
   outline-offset: 1px;

--- a/packages/raystack/components/editor/markup.ts
+++ b/packages/raystack/components/editor/markup.ts
@@ -13,7 +13,7 @@ import {
 } from './schema';
 
 export interface EditorDocDetails {
-  /** Round-trippable markup — `"check @[DataTable](component:data-table)"`. */
+  /** Round-trippable markup, as in `"check @[DataTable](component:data-table)"`. */
   markup: string;
   /** Plain text with each label inlined behind its trigger. */
   text: string;
@@ -82,7 +82,7 @@ function readMention(source: string, start: number): MentionMatch | null {
   return { attrs: { id, label, type, trigger }, next: index + 1 };
 }
 
-/** Inline content for a plain string — newlines become hard breaks. */
+/** Inline content for a plain string, where newlines become hard breaks. */
 export function inlineFragmentFromText(text: string): Fragment {
   const nodes: PMNode[] = [];
   const lines = text.split('\n');
@@ -95,7 +95,7 @@ export function inlineFragmentFromText(text: string): Fragment {
 
 /**
  * Parses the markup dialect into a document. Called only for `value` /
- * `defaultValue` — never for typed or pasted input, so ordinary prose that
+ * `defaultValue`, never for typed or pasted input, so ordinary prose that
  * happens to contain `@[…](…)` stays literal while it is being written.
  */
 export function docFromMarkup(markup: string): PMNode {

--- a/packages/raystack/components/editor/mention-node-view.ts
+++ b/packages/raystack/components/editor/mention-node-view.ts
@@ -6,7 +6,7 @@ import { mentionType } from './schema';
 
 /**
  * One live chip. The node view owns the element and writes the label into it
- * synchronously — there is never an empty chip frame — while React portals the
+ * synchronously, so there is never an empty chip frame, while React portals the
  * consumer's `icon` and `trailing` nodes into the two slots, so those render in
  * the host tree and see Theme and any other provider context.
  */

--- a/packages/raystack/components/editor/mention.ts
+++ b/packages/raystack/components/editor/mention.ts
@@ -1,5 +1,5 @@
 /**
- * The parts of the mention model that are pure strings and offsets — no
+ * The parts of the mention model that are pure strings and offsets, with no
  * ProseMirror. Kept in its own module so `PromptInput`'s root, its textarea and
  * the mention registry can share the vocabulary without pulling the editor
  * engine into their module graph.
@@ -9,7 +9,7 @@
 export interface MentionAttrs {
   id: string;
   label: string;
-  /** Entity kind — `"project"`, `"user"`, … */
+  /** Entity kind: `"project"`, `"user"`, … */
   type: string;
   /** The character that opened the menu this mention was picked from. */
   trigger: string;
@@ -32,7 +32,7 @@ export function mentionKey(trigger: string, type: string, id: string): string {
 /**
  * A trigger is a single ASCII punctuation character. `[`, `]` and `\` are
  * excluded because the dialect uses them as delimiters, and `_` because it
- * reads as a word character — so a bare markdown link (`[label](a:b)`) and a
+ * reads as a word character, so a bare markdown link (`[label](a:b)`) and a
  * snake_cased word are never mistaken for a mention.
  */
 const TRIGGER_PATTERN = new RegExp(
@@ -51,7 +51,7 @@ function escapeRef(value: string): string {
   return value.replace(/[\\:)]/g, match => `\\${match}`);
 }
 
-/** Serializes one mention — `@[label](type:id)`. */
+/** Serializes one mention as `@[label](type:id)`. */
 export function serializeMention(attrs: MentionAttrs): string {
   return `${attrs.trigger}[${escapeLabel(attrs.label)}](${escapeRef(
     attrs.type
@@ -59,8 +59,8 @@ export function serializeMention(attrs: MentionAttrs): string {
 }
 
 /**
- * Drops whitespace at the document edges — including the space auto-inserted
- * after a chip — while leaving mentions alone, then re-bases the offsets. A
+ * Drops whitespace at the document edges, including the space auto-inserted
+ * after a chip, while leaving mentions alone, then re-bases the offsets. A
  * chip is never at an edge in the whitespace sense, so trimming can only ever
  * remove text.
  */

--- a/packages/raystack/components/editor/schema.ts
+++ b/packages/raystack/components/editor/schema.ts
@@ -3,7 +3,7 @@ import type { MentionAttrs } from './mention';
 
 /**
  * A deliberately tiny schema: one paragraph of text, hard breaks, and atomic
- * mentions. Nothing else, so pasted HTML sanitizes to plain text for free —
+ * mentions. Nothing else, so pasted HTML sanitizes to plain text for free,
  * there is no mark or block the parser could keep.
  */
 export const editorSchema = new Schema({
@@ -55,7 +55,7 @@ export const editorSchema = new Schema({
           }
         }
       ],
-      // Only used for the clipboard's `text/html` flavour — on screen the node
+      // Only used for the clipboard's `text/html` flavour. On screen the node
       // view owns the element. Pasting this back restores the chip with its id.
       toDOM: node => {
         const { id, label, type, trigger } = node.attrs as MentionAttrs;

--- a/packages/raystack/components/editor/suggestion-menu.tsx
+++ b/packages/raystack/components/editor/suggestion-menu.tsx
@@ -51,7 +51,7 @@ export interface SuggestionMenuProps {
   loadingRowCount?: number;
   /** @defaultValue "No results" */
   emptyMessage?: ReactNode;
-  /** Width the popup takes, in pixels — the composer frame's width. */
+  /** Width the popup takes, in pixels, matching the composer frame's width. */
   width?: number;
   'aria-label'?: string;
 }
@@ -86,7 +86,7 @@ export function SuggestionMenu({
         align='start'
         side='bottom'
         sideOffset={6}
-        // Focus never leaves the editor — the query lives in the document
+        // Focus never leaves the editor, since the query lives in the document
         // because it is the text the chip replaces.
         initialFocus={false}
         finalFocus={false}

--- a/packages/raystack/components/editor/suggestion-plugin.ts
+++ b/packages/raystack/components/editor/suggestion-plugin.ts
@@ -16,7 +16,7 @@ export interface SuggestionState {
   query: string;
   /** Document position of the trigger character. */
   from: number;
-  /** Document position of the caret — the end of the query. */
+  /** Document position of the caret, at the end of the query. */
   to: number;
 }
 
@@ -36,7 +36,7 @@ export interface SuggestionPluginOptions {
   onStateChange: (state: SuggestionState | null) => void;
   /**
    * Called for every keydown while a query is active. Return true to consume
-   * the key — the handler owns `preventDefault` and `stopPropagation`.
+   * the key, and the handler owns `preventDefault` and `stopPropagation`.
    */
   onKeyDown: (event: KeyboardEvent, state: SuggestionState) => boolean;
 }
@@ -60,7 +60,7 @@ function isBoundary(char: string): boolean {
 
 /**
  * Looks backwards from the caret for a trigger at a word boundary. Stops at
- * whitespace, so only a single-word query can *start* a menu — a query that
+ * whitespace, so only a single-word query can *start* a menu. A query that
  * already contains a space is carried forward by the active state instead.
  */
 function detect(
@@ -100,7 +100,7 @@ function detect(
 
 /**
  * Carries an active query across a transaction. Returns null when the query
- * can no longer be extended — the trigger was deleted, the caret left the
+ * can no longer be extended, because the trigger was deleted, the caret left the
  * range, or a chip or line break landed inside it.
  */
 function carry(

--- a/packages/raystack/components/editor/use-editor.ts
+++ b/packages/raystack/components/editor/use-editor.ts
@@ -49,7 +49,7 @@ export interface UseEditorOptions {
   placeholder?: string;
   disabled?: boolean;
   spellCheck?: boolean;
-  /** Cap on the derived plain text — a chip counts as its label. */
+  /** Cap on the derived plain text, where a chip counts as its label. */
   maxLength?: number;
   /** Trigger characters currently registered by a `Mentions` part. */
   getTriggers?: () => string[];
@@ -121,7 +121,7 @@ function deleteAdjacentMention(direction: -1 | 1): Command {
 /**
  * Arrow keys step over a chip in one press. ProseMirror's default for a
  * selectable inline atom is to make it a NodeSelection first, which puts a
- * selection ring on the chip on the way past it — a stop the user never asked
+ * selection ring on the chip on the way past it, a stop the user never asked
  * for while moving the caret through a sentence. Clicking a chip still selects
  * it, which is where the ring belongs.
  */
@@ -240,7 +240,7 @@ export function useEditor(options: UseEditorOptions): UseEditorResult {
 
     // A bare `focus()` on an editing host places no caret. When focus arrives
     // from the frame rather than from a press inside the editor, drop the caret
-    // at the end — the way clicking past the end of a textarea's text behaves.
+    // at the end, the way clicking past the end of a textarea's text behaves.
     const focusPlugin = new Plugin({
       props: {
         handleDOMEvents: {

--- a/packages/raystack/components/filter-chip/__tests__/filter-chip.test.tsx
+++ b/packages/raystack/components/filter-chip/__tests__/filter-chip.test.tsx
@@ -185,7 +185,7 @@ describe('FilterChip', () => {
     });
 
     it('forwards calendarProps to the underlying DatePicker', () => {
-      // dateFormat is the easiest forwarded prop to observe — the formatted
+      // dateFormat is the easiest forwarded prop to observe, since the formatted
       // string in the input changes when it lands on DatePicker.
       render(
         <FilterChip

--- a/packages/raystack/components/filter-chip/filter-chip.tsx
+++ b/packages/raystack/components/filter-chip/filter-chip.tsx
@@ -36,7 +36,7 @@ const chip = cva(styles.chip, {
 export type FilterChipValue = string | string[] | number | Date;
 
 /**
- * Coerce a `FilterChipValue` to the `Date` the DatePicker expects — filter
+ * Coerce a `FilterChipValue` to the `Date` the DatePicker expects, since filter
  * state hydrated from a serialized query arrives as a string or epoch number.
  * Unparseable values leave the field unselected.
  */
@@ -113,7 +113,7 @@ export const FilterChip = ({
   const [operation, setOperation] = useState<FilterOperation | undefined>(
     computedOperations?.[0]
   );
-  // `??` not `||` — a falsy option value like `0` is a real selection.
+  // `??` not `||`, since a falsy option value like `0` is a real selection.
   const [filterValue, setFilterValue] = useState<any>(value ?? '');
 
   const showOnRemove = typeof onRemove === 'function';

--- a/packages/raystack/components/image/__tests__/image.test.tsx
+++ b/packages/raystack/components/image/__tests__/image.test.tsx
@@ -132,7 +132,7 @@ describe('Image', () => {
       fireEvent.error(img);
       expect(img.src).toContain('/fallback.jpg');
 
-      // The fallback itself fails to load — must not re-assign it again.
+      // The fallback itself fails to load, so it must not be re-assigned.
       fireEvent.error(img);
       expect(img.src).toContain('/fallback.jpg');
     });

--- a/packages/raystack/components/image/image.module.css
+++ b/packages/raystack/components/image/image.module.css
@@ -3,7 +3,7 @@
   max-width: 100%;
   height: auto;
   /* Hairline media edge so pale images keep a shape on light surfaces.
-     Outline, not inset shadow — the decoded image paints over a shadow. */
+     Outline, not inset shadow, since the decoded image paints over a shadow. */
   outline: 0.5px solid var(--rs-color-overlay-base-a2);
   outline-offset: -0.5px;
 }

--- a/packages/raystack/components/image/image.tsx
+++ b/packages/raystack/components/image/image.tsx
@@ -55,7 +55,7 @@ export function Image({
   useIsomorphicLayoutEffect(() => {
     hasFallenBackRef.current = false;
     const node = imgRef.current;
-    // Already-decoded (cached/SSR-painted) images stay visible — no fade.
+    // Already-decoded (cached/SSR-painted) images stay visible, with no fade.
     setLoadState(node && !node.complete ? 'loading' : 'static');
   }, [src]);
 

--- a/packages/raystack/components/label/label.tsx
+++ b/packages/raystack/components/label/label.tsx
@@ -17,7 +17,7 @@ export interface LabelProps extends useRender.ComponentProps<'label'> {
   optionalText?: string;
   /**
    * Text rendered next to the label when `required={true}`. No indicator is
-   * rendered if this is omitted — preserving apsara's existing behaviour of
+   * rendered if this is omitted, preserving apsara's existing behaviour of
    * not surfacing a required marker by default. Pass any non-empty string
    * (`"(required)"`, `"*"`, etc.) to opt in.
    */

--- a/packages/raystack/components/link/link.module.css
+++ b/packages/raystack/components/link/link.module.css
@@ -15,7 +15,7 @@
   }
 
   /* Press dims at the snappy press tier; releasing eases back at the base
-     (fast) tier above — quick press, gentle release. */
+     (fast) tier above: quick press, gentle release. */
   .link:active {
     transition: opacity var(--rs-duration-press) var(--rs-ease-out);
   }

--- a/packages/raystack/components/message/message-bubble.tsx
+++ b/packages/raystack/components/message/message-bubble.tsx
@@ -35,7 +35,7 @@ export interface MessageBubbleProps
     VariantProps<typeof bubble> {
   /**
    * Visual style of the message surface. `"ghost"` drops the surface
-   * entirely — no background, border or padding — and renders the message as
+   * entirely, so there is no background, border or padding, and it renders the message as
    * full-width body copy.
    * @defaultValue "solid"
    */

--- a/packages/raystack/components/meter/meter.module.css
+++ b/packages/raystack/components/meter/meter.module.css
@@ -41,7 +41,7 @@
   transform-origin: left;
 }
 
-/* Circular variant — viewBox is 72×72, SVG scales to container size */
+/* Circular variant. viewBox is 72×72, SVG scales to container size */
 .meter-variant-circular {
   align-items: center;
   justify-content: center;

--- a/packages/raystack/components/preview-card/preview-card.module.css
+++ b/packages/raystack/components/preview-card/preview-card.module.css
@@ -1,7 +1,7 @@
 /* Default mode (no PreviewCard.Viewport): Base UI positions the positioner
    via transform (floating-ui). Don't transition that transform, or the card
    eases toward every reposition and swims behind its anchor. The popup owns
-   the entrance (scale below); the positioner only fades — like popover/menu/tooltip. */
+   the entrance (scale below); the positioner only fades, like popover/menu/tooltip. */
 .positioner {
   --easing: var(--rs-ease-out);
   --animation-duration: var(--rs-duration-moderate);

--- a/packages/raystack/components/progress/progress.module.css
+++ b/packages/raystack/components/progress/progress.module.css
@@ -41,7 +41,7 @@
   transform-origin: left;
 }
 
-/* Circular variant — viewBox is 72×72, SVG scales to container size */
+/* Circular variant. viewBox is 72×72, SVG scales to container size */
 .progress-variant-circular {
   align-items: center;
   justify-content: center;

--- a/packages/raystack/components/prompt-input/__tests__/prompt-input-editor.test.tsx
+++ b/packages/raystack/components/prompt-input/__tests__/prompt-input-editor.test.tsx
@@ -7,7 +7,7 @@ import type { PromptInputActions } from '../prompt-input-root';
 
 /**
  * The editor host. ProseMirror owns its subtree, so tests reach it the way a
- * user does — through events on this element — rather than through React.
+ * user does, through events on this element, rather than through React.
  */
 function editorOf(container: HTMLElement): HTMLElement {
   const node = container.querySelector('[role="textbox"]');
@@ -429,8 +429,8 @@ describe('PromptInput.Editor', () => {
       );
       const editor = editorOf(container);
 
-      // The derived text is "@Button" — exactly 7 characters counting the
-      // trigger the chip does not render — so nothing more fits.
+      // The derived text is "@Button", exactly 7 characters counting the
+      // trigger the chip does not render, so nothing more fits.
       type(editor, '!');
       expect(editor.textContent).toBe('Button');
     });
@@ -446,7 +446,7 @@ describe('PromptInput.Editor', () => {
     });
 
     it('allows an edit that shrinks an already over-long document', () => {
-      // Over the cap from the start — a restored draft, or a lowered cap. The
+      // Over the cap from the start, whether a restored draft or a lowered cap. The
       // filter has to let it shrink or the composer would be frozen.
       const { container } = render(
         <PromptInput defaultValue='abcdefgh@[Button](component:button)'>

--- a/packages/raystack/components/prompt-input/__tests__/prompt-input-mentions.test.tsx
+++ b/packages/raystack/components/prompt-input/__tests__/prompt-input-mentions.test.tsx
@@ -182,8 +182,8 @@ describe('PromptInput.Mentions', () => {
       expect(screen.getByText('Users')).toBeInTheDocument();
     });
 
-    // Only a single-word query can *open* the menu — the backward scan stops at
-    // whitespace — so a multi-word query is carried forward by the active state,
+    // Only a single-word query can *open* the menu, since the backward scan stops at
+    // whitespace, so a multi-word query is carried forward by the active state,
     // exactly as it is when a user types the space.
     it('keeps a multi-word query filterable', async () => {
       const { container } = render(<Composer />);
@@ -676,7 +676,7 @@ describe('PromptInput.Mentions', () => {
       });
       expect(onSearch).not.toHaveBeenCalled();
 
-      // New inline `mentions` object, same data — the config must not churn.
+      // New inline `mentions` object, same data, so the config must not churn.
       rerender(
         <Composer status='error' mentions={{ items: undefined, onSearch }} />
       );
@@ -707,7 +707,7 @@ describe('PromptInput.Mentions', () => {
         />
       );
 
-      // Label-only until it resolves — never a skeleton, never an error state.
+      // Label-only until it resolves, never a skeleton and never an error state.
       expect(container.querySelector('[data-mention]')?.textContent).toBe(
         'DataTable'
       );

--- a/packages/raystack/components/prompt-input/__tests__/prompt-input-parity.test.tsx
+++ b/packages/raystack/components/prompt-input/__tests__/prompt-input-parity.test.tsx
@@ -13,7 +13,7 @@ import type { PromptInputMessage } from '../prompt-input-context';
 interface Substrate {
   name: string;
   render: (props: Partial<Parameters<typeof PromptInput>[0]>) => ReactElement;
-  /** The element that receives keys — a textarea or an editing host. */
+  /** The element that receives keys: a textarea or an editing host. */
   input: (container: HTMLElement) => HTMLElement;
   /** Enters text the way that substrate accepts it in jsdom. */
   type: (element: HTMLElement, text: string) => void;
@@ -90,7 +90,7 @@ const substrates: Substrate[] = [
   }
 ];
 
-describe.each(substrates)('PromptInput shared contract — $name', substrate => {
+describe.each(substrates)('PromptInput shared contract: $name', substrate => {
   const setup = (props: Partial<Parameters<typeof PromptInput>[0]> = {}) => {
     const result = render(substrate.render(props));
     return { ...result, input: substrate.input(result.container) };

--- a/packages/raystack/components/prompt-input/__tests__/prompt-input.test.tsx
+++ b/packages/raystack/components/prompt-input/__tests__/prompt-input.test.tsx
@@ -234,7 +234,7 @@ describe('PromptInput', () => {
   // The header and footer carry `pointer-events: none`, so in a browser a press
   // on their padding is hit-tested to the form and arrives here with the form as
   // its target. jsdom applies no stylesheet and does no hit testing, so these
-  // press the form directly — the slots' own presses cannot be simulated.
+  // press the form directly, since the slots' own presses cannot be simulated.
   describe('Click to focus', () => {
     it('focuses the textarea when the frame is pressed', () => {
       const { container } = render(<BasicPromptInput />);

--- a/packages/raystack/components/prompt-input/prompt-input-context.tsx
+++ b/packages/raystack/components/prompt-input/prompt-input-context.tsx
@@ -18,7 +18,7 @@ export interface PromptInputMention extends EditorMention {
 export interface PromptInputMessage {
   /** Plain text with each label inlined behind its trigger. */
   text: string;
-  /** Round-trippable markup — feeds straight back into `value`. */
+  /** Round-trippable markup that feeds straight back into `value`. */
   markup: string;
   /** Document order; duplicates preserved. */
   mentions: PromptInputMention[];
@@ -51,7 +51,7 @@ export interface PromptInputInputApi {
 export type PromptInputPartKind = 'textarea' | 'editor';
 
 export interface PromptInputContextValue {
-  /** Markup — opaque to Root, interpreted only by `Editor`. */
+  /** Markup, opaque to Root and interpreted only by `Editor`. */
   value: string;
   details: PromptInputValueDetails;
   /** No mentions, and text that trims to `""`. */
@@ -71,7 +71,7 @@ export interface PromptInputContextValue {
   ) => void;
   requestSubmit: () => void;
   mentions: PromptInputMentionRegistry;
-  /** Whether an `Editor` part is mounted — `Mentions` requires one. */
+  /** Whether an `Editor` part is mounted. `Mentions` requires one. */
   editorMounted: boolean;
 }
 

--- a/packages/raystack/components/prompt-input/prompt-input-editor.tsx
+++ b/packages/raystack/components/prompt-input/prompt-input-editor.tsx
@@ -41,7 +41,7 @@ export interface PromptInputEditorProps
   /** Disables just the editor. Inherits the root `disabled` by default. */
   disabled?: boolean;
   /**
-   * Cap on the derived plain text — a chip counts as its label. Enforced by a
+   * Cap on the derived plain text, where a chip counts as its label. Enforced by a
    * transaction filter, so paste and IME are covered, not just keystrokes.
    */
   maxLength?: number;
@@ -53,9 +53,9 @@ export interface PromptInputEditorProps
 }
 
 /**
- * The ProseMirror sibling to `PromptInput.Textarea`: same outward contract —
+ * The ProseMirror sibling to `PromptInput.Textarea`: the same outward contract,
  * Enter submits, Shift+Enter breaks, placeholder, auto-grow, `disabled`, frame
- * focus — on a contentEditable that can host inline mention chips.
+ * focus, on a contentEditable that can host inline mention chips.
  */
 export function PromptInputEditor({
   className,
@@ -161,7 +161,7 @@ export function PromptInputEditor({
   // `--anchor-width`; it takes the composer's width instead, re-measured as the
   // panel resizes. Deliberately a passive effect rather than a layout one: the
   // frame is this part's ancestor, and React attaches an ancestor's ref *after*
-  // running a descendant's layout effects — measuring there would read a null
+  // running a descendant's layout effects, and measuring there would read a null
   // frame once and never look again.
   const frameRef = context.frameRef;
   useEffect(() => {

--- a/packages/raystack/components/prompt-input/prompt-input-mention-registry.ts
+++ b/packages/raystack/components/prompt-input/prompt-input-mention-registry.ts
@@ -13,7 +13,7 @@ export interface PromptInputMentionItem {
    */
   type?: string;
   icon?: ReactNode;
-  /** Trailing metadata — a badge, a shortcut, a timestamp. */
+  /** Trailing metadata: a badge, a shortcut, a timestamp. */
   trailing?: ReactNode;
   /** Section heading. Groups render in first-appearance order. */
   group?: string;
@@ -68,12 +68,12 @@ function sameData(
  * back when assembling a message).
  *
  * `icon`, `trailing` and `data` cannot survive serialization, so they live here
- * rather than on the document — keyed by `trigger|type|id`, filled in when an
+ * rather than on the document, keyed by `trigger|type|id` and filled in when an
  * item is picked from the menu or returned by `resolveMentions`.
  *
  * Registration is split from data on purpose. The trigger is established once,
  * while the data is pushed after every `Mentions` render and compared field by
- * field — so an inline `items` array stays live without a config object whose
+ * field, so an inline `items` array stays live without a config object whose
  * identity churns and restarts an in-flight search.
  */
 export class PromptInputMentionRegistry {
@@ -142,7 +142,7 @@ export class PromptInputMentionRegistry {
   /**
    * Bumped by every mutation. Read as a `useSyncExternalStore` snapshot, so a
    * reader that mounts after a writer has already emitted still sees the
-   * change — `Mentions` registers its trigger in an effect that runs before a
+   * change, since `Mentions` registers its trigger in an effect that runs before a
    * later sibling `Editor` has subscribed.
    */
   getRevision = (): number => this.revision;

--- a/packages/raystack/components/prompt-input/prompt-input-mentions.tsx
+++ b/packages/raystack/components/prompt-input/prompt-input-mentions.tsx
@@ -14,10 +14,10 @@ export interface PromptInputMentionsProps {
    * @defaultValue "@"
    */
   trigger?: string;
-  /** Sync data — filtered internally with match-sorter on the label. */
+  /** Sync data, filtered internally with match-sorter on the label. */
   items?: PromptInputMentionItem[];
   /**
-   * Async data — debounced ~150 ms, superseded requests aborted through
+   * Async data, debounced ~150 ms, with superseded requests aborted through
    * `signal`, stale resolutions discarded. Wins over `items`.
    */
   onSearch?: (
@@ -47,7 +47,7 @@ export interface PromptInputMentionsProps {
 }
 
 /**
- * Declares a trigger and supplies its data. Renders nothing itself — the
+ * Declares a trigger and supplies its data. Renders nothing itself, since the
  * caret-anchored menu belongs to `PromptInput.Editor`, which owns the document
  * the query lives in, because the query is the text the chip replaces.
  *
@@ -92,7 +92,7 @@ export function PromptInputMentions({
   }, [registry, trigger]);
 
   // `Editor` registers itself during the commit that mounts it, which can land
-  // after this effect — so the check waits for the tree to settle, and the
+  // after this effect, so the check waits for the tree to settle, and the
   // cleanup cancels it the moment an editor does show up.
   const sawEditorRef = useRef(false);
   useEffect(() => {
@@ -114,7 +114,7 @@ export function PromptInputMentions({
 
   // Pushed after every render and compared field by field, so an inline `items`
   // array or an inline `onSearch` stays live without churning the config
-  // identity — which would restart an in-flight debounce on every keystroke.
+  // identity, which would restart an in-flight debounce on every keystroke.
   useEffect(() => {
     registry.setData(trigger, {
       items,

--- a/packages/raystack/components/prompt-input/prompt-input-root.tsx
+++ b/packages/raystack/components/prompt-input/prompt-input-root.tsx
@@ -54,7 +54,7 @@ export interface PromptInputActions {
 export interface PromptInputRootProps
   extends Omit<ComponentProps<'form'>, 'onSubmit'> {
   /**
-   * Controlled markup string — the same dialect `onValueChange` reports and
+   * Controlled markup string, the same dialect `onValueChange` reports and
    * `PromptInput.Editor` parses. Most consumers should stay uncontrolled.
    */
   value?: string;
@@ -72,7 +72,7 @@ export interface PromptInputRootProps
     details: { text: string; mentions: PromptInputMention[] }
   ) => void;
   /**
-   * Called with the trimmed message when the prompt is submitted — Enter in the
+   * Called with the trimmed message when the prompt is submitted. Enter in the
    * input or a click on `PromptInput.Submit`. Call
    * `event.currentTarget.reset()` to clear the composer after sending.
    */
@@ -250,7 +250,7 @@ export function PromptInputRoot({
     [setValueUnwrapped, withData]
   );
 
-  /** A value Root itself pushed — a form reset, or `actionsRef.clear()`. */
+  /** A value Root itself pushed, such as a form reset or `actionsRef.clear()`. */
   const applyValue = useCallback(
     (markup: string) => {
       const derived =
@@ -272,7 +272,7 @@ export function PromptInputRoot({
 
   // Reconciles a value that did not come from the part: a controlled prop the
   // consumer changed, or a controlled prop they did *not* change after a
-  // keystroke — in which case the part is asked to revert, which is what
+  // keystroke, in which case the part is asked to revert, which is what
   // `Textarea` has always done by rendering `value` straight through. Runs after
   // every render, because a controlled prop that stays put still needs it.
   useLayoutEffect(() => {
@@ -334,7 +334,7 @@ export function PromptInputRoot({
   // input. The header and footer are out of hit testing (see the stylesheet),
   // so a press on their padding lands on the form itself while their contents
   // keep their own. Handled on mousedown so focus never leaves the input and
-  // back again — that round trip would dismiss anything anchored to it.
+  // back again, since that round trip would dismiss anything anchored to it.
   const handleMouseDown = (event: MouseEvent<HTMLFormElement>) => {
     onMouseDown?.(event);
     if (event.defaultPrevented || disabled || event.button !== 0) return;

--- a/packages/raystack/components/prompt-input/prompt-input-textarea.tsx
+++ b/packages/raystack/components/prompt-input/prompt-input-textarea.tsx
@@ -38,7 +38,7 @@ export function PromptInputTextarea({
 
   // A plain textarea reports the same shape `Editor` does, so Root's callbacks
   // have one signature either way: markup *is* text and there are never any
-  // mentions — a literal `@[x](y:z)` typed in here stays literal.
+  // mentions, so a literal `@[x](y:z)` typed in here stays literal.
   const api = useMemo<PromptInputInputApi>(
     () => ({
       focus: () => nodeRef.current?.focus(),

--- a/packages/raystack/components/prompt-input/prompt-input.module.css
+++ b/packages/raystack/components/prompt-input/prompt-input.module.css
@@ -66,8 +66,8 @@
   padding: var(--rs-space-3);
 }
 
-/* `PromptInput.Editor` shares the textarea's box inside the frame — same
-   padding, same floor, same cap — minus `field-sizing`, which applies to form
+/* `PromptInput.Editor` shares the textarea's box inside the frame, with the same
+   padding, floor and cap, minus `field-sizing`, which applies to form
    controls only: a contentEditable grows with its content natively. */
 .root .editor {
   max-height: var(--prompt-input-textarea-max-height);
@@ -86,8 +86,8 @@
   display: none;
 }
 
-/* The frame reads as one field, so a press on the slots' own padding — or on
-   the gap between their controls — has to focus the input. Taking the slots out
+/* The frame reads as one field, so a press on the slots' own padding, or on
+   the gap between their controls, has to focus the input. Taking the slots out
    of hit testing hands those presses to the form, which is the element that
    focuses; their contents take hit testing back, so a button or a label the
    consumer drops in keeps its own press. */

--- a/packages/raystack/components/prompt-input/use-mention-menu.ts
+++ b/packages/raystack/components/prompt-input/use-mention-menu.ts
@@ -32,7 +32,7 @@ const NO_ITEMS: PromptInputMentionItem[] = [];
  * Re-renders whatever reads the registry when a config or an item lands.
  * `useSyncExternalStore` rather than a subscribe-and-bump effect, because
  * `Mentions` registers its trigger from an effect that runs *before* a later
- * sibling `Editor` gets to subscribe — the store re-reads its snapshot after
+ * sibling `Editor` gets to subscribe, and the store re-reads its snapshot after
  * subscribing, so that first registration is never missed.
  */
 export function useMentionRegistryVersion(
@@ -77,7 +77,7 @@ export function toGroups(items: PromptInputMentionItem[]): SuggestionGroup[] {
   return groups;
 }
 
-/** Sync data filtering — match-sorter on the label, best matches first. */
+/** Sync data filtering: match-sorter on the label, best matches first. */
 export function filterItems(
   items: PromptInputMentionItem[],
   query: string
@@ -293,7 +293,7 @@ export function useMentionMenu({
 
   // The last rect the caret actually had. Selecting an item takes the query
   // range out of the document in the same breath as it closes the menu, but the
-  // popup is still animating out and the positioner keeps measuring — without
+  // popup is still animating out and the positioner keeps measuring. Without
   // something to hand back, it would read a zero rect and the closing menu
   // would jump to the top-left corner of the viewport and flicker there.
   const lastRectRef = useRef<DOMRect | null>(null);
@@ -343,7 +343,7 @@ export function useMentionMenu({
       const consume = () => {
         event.preventDefault();
         // Enter must not reach the form and Escape must not reach ChatPanel,
-        // Dialog or Drawer — either would destroy the draft.
+        // Dialog or Drawer, either of which would destroy the draft.
         event.stopPropagation();
       };
 
@@ -402,7 +402,7 @@ export function useMentionMenu({
 /**
  * `icon`, `trailing` and `data` cannot survive serialization, so a chip parsed
  * from `defaultValue` starts label-only and fills in when the consumer's
- * `resolveMentions` resolves — the same progressive enhancement `Select.Value`
+ * `resolveMentions` resolves, the same progressive enhancement `Select.Value`
  * uses when it falls back to the raw value until an item registers. A rejection
  * or a missing item leaves the chip label-only; it is never an error state and
  * the chip is never removed.

--- a/packages/raystack/components/radio/radio.module.css
+++ b/packages/raystack/components/radio/radio.module.css
@@ -1,4 +1,4 @@
-/* Group layout — uses flex to arrange radio items */
+/* Group layout. Uses flex to arrange radio items */
 .group {
   display: flex;
   flex-direction: column;
@@ -9,7 +9,7 @@
   flex-direction: row;
 }
 
-/* Radio button — uses inline-flex to center the indicator dot */
+/* Radio button. Uses inline-flex to center the indicator dot */
 .radioitem {
   all: unset;
   border-radius: var(--rs-radius-full);
@@ -25,7 +25,7 @@
     border-color var(--rs-duration-fast) var(--rs-ease-out);
 }
 
-/* Group-level size — low specificity via :where() so item-level size wins */
+/* Group-level size, low specificity via :where() so item-level size wins */
 :where(.group-large) .radioitem,
 .radioitem.large {
   width: var(--rs-space-5);
@@ -126,7 +126,7 @@
   background: var(--rs-color-foreground-base-emphasis);
 }
 
-/* Scale indicator dot for small size — group-level and item-level */
+/* Scale indicator dot for small size, group-level and item-level */
 :where(.group-small) .indicator::after,
 .radioitem.small .indicator::after {
   width: var(--rs-radius-2);

--- a/packages/raystack/components/reasoning/reasoning.tsx
+++ b/packages/raystack/components/reasoning/reasoning.tsx
@@ -36,7 +36,7 @@ export interface ReasoningProps
   /**
    * Whether the reasoning is still being produced. While `true` the default
    * trigger shows a shimmering "Thinking…" label and the panel auto-opens;
-   * when it flips back to `false` the panel auto-collapses — unless the user
+   * when it flips back to `false` the panel auto-collapses, unless the user
    * has toggled it themselves.
    * @defaultValue false
    */

--- a/packages/raystack/components/scroll-area/__tests__/data-slots.test.tsx
+++ b/packages/raystack/components/scroll-area/__tests__/data-slots.test.tsx
@@ -11,7 +11,7 @@ describe('ScrollArea data-slot contract', () => {
       </ScrollArea>
     );
     // Corner only mounts when Base UI detects overflow on both axes, which
-    // jsdom's unmeasured layout never reports — its slot is exercised via
+    // jsdom's unmeasured layout never reports, so its slot is exercised via
     // source inspection rather than a DOM assertion here.
     expectSlots(container, [
       'scroll-area',

--- a/packages/raystack/components/scroll-area/scroll-area.module.css
+++ b/packages/raystack/components/scroll-area/scroll-area.module.css
@@ -2,7 +2,7 @@
   --rs-scrollbar-size: 6px; /* track + hit area, and the expanded thumb */
   --rs-scrollbar-thumb-rest: var(
     --rs-space-2
-  ); /* 4px — visible thumb at rest */
+  ); /* 4px, a visible thumb at rest */
 }
 
 .root {
@@ -52,7 +52,7 @@
 
 /* The drawn bar. The thumb stays the full-size hit area; this pseudo is what
    you see. It's a pseudo because Base UI writes an inline transform on the
-   thumb to position it — so the thumb's own transform can't be used to size it,
+   thumb to position it, so the thumb's own transform can't be used to size it,
    and animating the thumb's transform would make it lag while scrolling. */
 .thumb::before {
   content: "";

--- a/packages/raystack/components/select/select.module.css
+++ b/packages/raystack/components/select/select.module.css
@@ -172,7 +172,7 @@
   letter-spacing: var(--rs-letter-spacing-small);
 }
 
-/* Static up/down caret — the pop-up-button affordance ("pick a value").
+/* Static up/down caret, the pop-up-button affordance ("pick a value").
    It does not rotate on open; the menu appearing is the feedback. */
 .triggerIcon {
   width: var(--rs-space-5);

--- a/packages/raystack/components/sidebar/__tests__/sidebar.test.tsx
+++ b/packages/raystack/components/sidebar/__tests__/sidebar.test.tsx
@@ -263,7 +263,7 @@ describe('Sidebar', () => {
       const nav = screen.getByRole('navigation');
       fireEvent.mouseEnter(nav);
       expect(onMouseEnter).toHaveBeenCalled();
-      // The consumer handler must not replace ours — the peek still starts.
+      // The consumer handler must not replace ours, and the peek still starts.
       await waitFor(() => {
         expect(screen.getByTestId('peek-status')).toHaveTextContent(
           'expanded:peeking'
@@ -340,7 +340,7 @@ describe('Sidebar', () => {
       });
 
       // `open` is still false during a peek, so the handle still reads as
-      // "Expand sidebar" — clicking it pins the sidebar open for real.
+      // "Expand sidebar". Clicking it pins the sidebar open for real.
       const handle = screen.getByRole('button', { name: 'Expand sidebar' });
       fireEvent.click(handle);
 
@@ -402,7 +402,7 @@ describe('Sidebar', () => {
 
       fireEvent.click(screen.getByRole('button', { name: 'Expand sidebar' }));
 
-      // Opening for real supersedes the peek — the peek shadow and state
+      // Opening for real supersedes the peek, so the peek shadow and state
       // must drop immediately, without waiting for the mouse to leave.
       expect(nav).not.toHaveAttribute('data-peeking');
       expect(screen.getByTestId('peek-status')).toHaveTextContent(
@@ -434,7 +434,7 @@ describe('Sidebar', () => {
       expect(screen.getByText('Extra')).toBeInTheDocument();
 
       // The menu portals to document.body, so moving the pointer into it
-      // fires mouseleave on the sidebar — the peek must survive that.
+      // fires mouseleave on the sidebar, and the peek must survive that.
       fireEvent.mouseLeave(nav);
 
       expect(screen.getByTestId('peek-status')).toHaveTextContent(

--- a/packages/raystack/components/sidebar/sidebar-group.tsx
+++ b/packages/raystack/components/sidebar/sidebar-group.tsx
@@ -23,7 +23,7 @@ export interface SidebarNavigationGroupProps extends ComponentProps<'section'> {
   onOpenChange?: (open: boolean) => void;
   leadingIcon?: ReactNode;
   trailingIcon?: ReactNode;
-  /** @deprecated Every key here has an equivalent `[data-slot]` — see the Slots table in the Sidebar docs. */
+  /** @deprecated Every key here has an equivalent `[data-slot]`. See the Slots table in the Sidebar docs. */
   classNames?: {
     /** @deprecated Use `[data-slot="sidebar-group-header"]` instead. */
     header?: string;

--- a/packages/raystack/components/sidebar/sidebar-header.tsx
+++ b/packages/raystack/components/sidebar/sidebar-header.tsx
@@ -6,7 +6,7 @@ import { Flex } from '../flex';
 import styles from './sidebar.module.css';
 
 /**
- * Free-form slot at the top of the sidebar — an avatar, a workspace switcher,
+ * Free-form slot at the top of the sidebar: an avatar, a workspace switcher,
  * a search box, whatever the header needs to hold. Because its content is
  * arbitrary, it isn't hidden automatically when the sidebar collapses; add
  * `data-collapse-hidden` to any child that should disappear on collapse

--- a/packages/raystack/components/sidebar/sidebar-item.tsx
+++ b/packages/raystack/components/sidebar/sidebar-item.tsx
@@ -23,7 +23,7 @@ export interface SidebarItemProps extends ComponentProps<'a'> {
   active?: boolean;
   disabled?: boolean;
   render?: ReactElement;
-  /** @deprecated Every key here has an equivalent `[data-slot]` — see the Slots table in the Sidebar docs. */
+  /** @deprecated Every key here has an equivalent `[data-slot]`. See the Slots table in the Sidebar docs. */
   classNames?: {
     /** @deprecated Use `[data-slot="sidebar-item"]` instead. */
     root?: string;
@@ -119,7 +119,7 @@ export function SidebarItem({
     return <Menu.Item disabled={disabled} render={content} />;
   }
 
-  // One prop opts out of every tooltip the library adds to items — the
+  // One prop opts out of every tooltip the library adds to items:
   // collapsed label tooltip and the expanded clipped-label tooltip.
   if (hideItemTooltips) return content;
 

--- a/packages/raystack/components/sidebar/sidebar-more.tsx
+++ b/packages/raystack/components/sidebar/sidebar-more.tsx
@@ -24,7 +24,7 @@ export interface SidebarMoreProps {
     /**
      * Not deprecated: `Menu.Content` portals to `document.body`, so a
      * `[data-slot="menu-content"]` selector can't be scoped to just this
-     * instance's dropdown — this prop remains the only way to target it.
+     * instance's dropdown, so this prop remains the only way to target it.
      */
     menuContent?: string;
   };

--- a/packages/raystack/components/sidebar/sidebar-root.tsx
+++ b/packages/raystack/components/sidebar/sidebar-root.tsx
@@ -42,7 +42,7 @@ export function useSidebar(): SidebarContextValue {
 // Subcomponents rendered outside a <Sidebar> (stories, isolated tests,
 // standalone reuse of an item) worked before the context became nullable,
 // so they fall back to an expanded left sidebar instead of throwing.
-// Internal only — consumers get the throwing hook above.
+// Internal only. Consumers get the throwing hook above.
 const FALLBACK_CONTEXT: SidebarContextValue = {
   isCollapsed: false,
   isPeeking: false,
@@ -187,7 +187,7 @@ export function SidebarRoot({
     setIsPeeking(false);
   }, [open]);
 
-  // data-open/data-closed drive the visuals, so a peek counts as open —
+  // data-open/data-closed drive the visuals, so a peek counts as open,
   // every collapse-hiding CSS rule turns off during a peek for free. The
   // real state stays in `open` (and the toggle controls' aria-expanded).
   const visualOpen = open || isPeeking;

--- a/packages/raystack/components/theme-provider/__tests__/theme.test.tsx
+++ b/packages/raystack/components/theme-provider/__tests__/theme.test.tsx
@@ -39,7 +39,7 @@ Object.defineProperty(window, 'matchMedia', {
 });
 
 beforeEach(() => {
-  // mockReset clears implementations too — vital for isolation since tests
+  // mockReset clears implementations too, which is vital for isolation since tests
   // set `mockReturnValue`/`mockImplementation` and mockClear alone would let
   // those leak into subsequent tests.
   localStorageMock.getItem.mockReset();
@@ -440,7 +440,7 @@ describe('Theme (scoped)', () => {
       </Theme>
     );
 
-    // The child's parent is the test container — no scope wrapper in between.
+    // The child's parent is the test container, with no scope wrapper in between.
     expect(screen.getByTestId('child').parentElement).toBe(container);
   });
 
@@ -541,7 +541,7 @@ describe('useTheme inside a stateless scope', () => {
     );
 
     fireEvent.click(screen.getByText('set'));
-    // Scope owns its own state — call updates the scope, root's storage is
+    // Scope owns its own state, so the call updates the scope, root's storage is
     // untouched.
     expect(localStorageMock.setItem).not.toHaveBeenCalledWith('theme', 'dark');
     expect(screen.getByTestId('theme')).toHaveTextContent('dark');
@@ -562,7 +562,7 @@ describe('useTheme inside a stateless scope', () => {
     );
 
     fireEvent.click(screen.getByText('set root'));
-    // Hook targeted the root by its storageKey — root's storage was written.
+    // Hook targeted the root by its storageKey, so root's storage was written.
     expect(localStorageMock.setItem).toHaveBeenCalledWith('theme', 'dark');
   });
 });

--- a/packages/raystack/components/theme-provider/theme.tsx
+++ b/packages/raystack/components/theme-provider/theme.tsx
@@ -29,7 +29,7 @@ const defaultContext: UseThemeProps = { setTheme: _ => {}, themes: [] };
  * Read the current theme state from the nearest `<Theme>` ancestor (default)
  * or from a specific ancestor by its `storageKey` when one is provided.
  *
- * `setTheme` from the return value updates *that* scope only — it never
+ * `setTheme` from the return value updates *that* scope only. It never
  * propagates outward. To flip the page-level theme from inside a scope,
  * pass the root provider's `storageKey` (default `"theme"`).
  */
@@ -105,7 +105,7 @@ const Scoped = ({
   );
 
   // Every active scope owns its theme state so `useTheme()` always targets
-  // the nearest scope — independent of persistence. Persistent scopes seed
+  // the nearest scope, independent of persistence. Persistent scopes seed
   // their state from localStorage on first mount; stateless ones start from
   // `defaultTheme` (or undefined) and live only in memory.
   const [stored, setStored] = useState<string | undefined>(() =>
@@ -158,7 +158,7 @@ const Scoped = ({
 
   // Layer scope overrides on top of the parent's context so `useTheme()`
   // inside the scope sees the effective values. Every active scope (persistent
-  // or with overrides) owns its own `theme`/`setTheme` — persistence is
+  // or with overrides) owns its own `theme`/`setTheme`, and persistence is
   // orthogonal. Scopes with a `storageKey` register themselves into `scopes`
   // so `useTheme({ storageKey })` can address them past the nearest one.
   const layered = useMemo<UseThemeProps | undefined>(() => {
@@ -198,7 +198,7 @@ const Scoped = ({
   if (!isPersistent && !hasOverrides) return <>{children}</>;
 
   // Mirror the layered (own + inherited) values onto the wrapper so CSS rules
-  // that combine attributes — e.g. `[data-accent-color='orange'][data-theme='dark']` —
+  // that combine attributes, for example `[data-accent-color='orange'][data-theme='dark']`,
   // match even when the consumer overrides only one attribute.
   return (
     <ThemeContext value={layered}>

--- a/packages/raystack/components/theme-provider/types.ts
+++ b/packages/raystack/components/theme-provider/types.ts
@@ -98,12 +98,12 @@ export interface ThemeProviderProps {
   /**
    * The icons inside Apsara's components, and the props applied to every icon.
    *
-   * `components` replaces a drawing by key — `{ ErrorIcon: MyError }`. A partial
+   * `components` replaces a drawing by key, as in `{ ErrorIcon: MyError }`. A partial
    * map changes only the keys it names, and a nested `<Theme icons={…}>` layers
    * on top of an outer one, per key.
    *
    * `props` applies to every icon built by `createIcon`, the consumer's own
-   * included — `{ strokeWidth: 2 }`. The props at the call site still win.
+   * included, as in `{ strokeWidth: 2 }`. The props at the call site still win.
    * Prefer the `data-icon` attribute and CSS where a style rule is enough,
    * because CSS re-renders nothing.
    *

--- a/packages/raystack/components/toast/toast.module.css
+++ b/packages/raystack/components/toast/toast.module.css
@@ -253,7 +253,7 @@
 }
 
 /* Type-based leading icon colors. The toast itself stays visually neutral
-   across all types — only the leading icon changes color per type. */
+   across all types. Only the leading icon changes color per type. */
 .root[data-type="success"] .leadingIcon {
   color: var(--rs-color-foreground-success-primary);
 }

--- a/packages/raystack/components/toggle/toggle.module.css
+++ b/packages/raystack/components/toggle/toggle.module.css
@@ -127,7 +127,7 @@
   overflow: clip;
 }
 
-/* Toggle inside Group — strip standalone container styles.
+/* Toggle inside Group: strip standalone container styles.
    Border-radius is handled by the group's overflow: clip. */
 .group .toggle {
   background-color: transparent;
@@ -145,7 +145,7 @@
 }
 
 /* In a group the container carries the pressed fill, so keep the inner content
-   transparent — otherwise the standalone content fill paints a second, darker
+   transparent, since otherwise the standalone content fill paints a second, darker
    box inside the 2px padding (a halo) and doubles the inset shadow. */
 .group .toggle[data-pressed] .toggleContent,
 .group .toggle[data-pressed]:hover .toggleContent {

--- a/packages/raystack/components/tooltip/tooltip.module.css
+++ b/packages/raystack/components/tooltip/tooltip.module.css
@@ -70,7 +70,7 @@
       transform var(--rs-duration-fast) var(--rs-ease-out);
   }
 
-  /* Per-side directional offset — same vectors as the old keyframes */
+  /* Per-side directional offset, the same vectors as the old keyframes */
   .content[data-side="top"][data-starting-style],
   .content[data-side="top"][data-ending-style] {
     transform: translateY(calc(-1 * var(--rs-space-1)));
@@ -91,7 +91,7 @@
     transform: translateX(calc(-1 * var(--rs-space-1)));
   }
 
-  /* Aligned variants get a diagonal offset — same vectors as before.
+  /* Aligned variants get a diagonal offset, the same vectors as before.
      Higher specificity (0,4,0) than the side rules (0,3,0), so they win
      when data-align is start/end. */
   .content[data-side="top"][data-align="start"][data-starting-style],

--- a/packages/raystack/components/tour/__tests__/tour.test.tsx
+++ b/packages/raystack/components/tour/__tests__/tour.test.tsx
@@ -201,7 +201,7 @@ describe('Tour', () => {
       );
     };
     render(<LateMount />);
-    // Nothing shows while the target is missing — no blank overlay, no card.
+    // Nothing shows while the target is missing: no blank overlay, no card.
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     expect(document.querySelector('[data-status]')).not.toBeInTheDocument();
     fireEvent.click(screen.getByText('mount'));
@@ -280,7 +280,7 @@ describe('Tour', () => {
     );
     // The target disappears while its step is active.
     fireEvent.click(screen.getByText('hide'));
-    // The tour must not strand a broken card on the gone target — it advances.
+    // The tour must not strand a broken card on the gone target; it advances.
     await waitFor(() =>
       expect(screen.getByText('Fallback step')).toBeInTheDocument()
     );
@@ -328,7 +328,7 @@ describe('Tour', () => {
 
     // Resume onto the now-missing target.
     fireEvent.click(screen.getByText('resume'));
-    // No card and — crucially — no orphaned dimmed overlay while waiting.
+    // No card and, crucially, no orphaned dimmed overlay while waiting.
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     expect(document.querySelector('[data-status]')).not.toBeInTheDocument();
     // It resolves cleanly by ending the tour (single step, target gone).
@@ -621,7 +621,7 @@ describe('Tour', () => {
       expect(el).toBeInTheDocument();
       return el as HTMLElement;
     });
-    // The spotlight always cross-fades — it never carries the transition flag,
+    // The spotlight always cross-fades and never carries the transition flag,
     // which is a popover-only concern. Once the target is in view and its rect
     // settles, the dim enters and the cutout opens.
     expect(overlay).not.toHaveAttribute('data-transition');
@@ -644,7 +644,7 @@ describe('Tour', () => {
     // Move affects the popover: it stays visible and glides.
     expect(popup).toHaveAttribute('data-transition', 'move');
     expect(popup).toHaveAttribute('data-visible', 'true');
-    // The spotlight still cross-fades regardless of the mode — no transition
+    // The spotlight still cross-fades regardless of the mode, with no transition
     // flag on the overlay, and its cutout opens once the target settles.
     const overlay = document.querySelector('[data-status]');
     expect(overlay).not.toHaveAttribute('data-transition');

--- a/packages/raystack/components/tour/tour-content.tsx
+++ b/packages/raystack/components/tour/tour-content.tsx
@@ -75,7 +75,7 @@ export function TourContent({
   );
 
   const spotlightClicks = step?.spotlightClicks ?? false;
-  // biome-ignore lint/correctness/useExhaustiveDependencies: `index` is intentional — re-running on step change is how the card refocuses.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `index` is intentional, and re-running on step change is how the card refocuses.
   useEffect(() => {
     if (!popoverOpen || !visible || spotlightClicks) return;
     popupRef.current?.focus({ preventScroll: true });
@@ -99,7 +99,7 @@ export function TourContent({
       modal={false}
       onOpenChange={(nextOpen, eventDetails) => {
         if (nextOpen) return;
-        // Tours are persistent — only Escape dismisses, not outside press/focus.
+        // Tours are persistent: only Escape dismisses, not outside press/focus.
         if (eventDetails.reason === 'escape-key') actions.stop();
       }}
     >

--- a/packages/raystack/components/tour/tour-root.tsx
+++ b/packages/raystack/components/tour/tour-root.tsx
@@ -26,7 +26,7 @@ import { usePrefersReducedMotion } from './use-prefers-reduced-motion';
 import { resolveTourTarget, useTourTarget } from './use-tour-target';
 import { rectsEqual } from './utils';
 
-// Must match --rs-duration-fast — the .spotlightCover fade in tour.module.css.
+// Must match --rs-duration-fast, the .spotlightCover fade in tour.module.css.
 const FADE_OUT_MS = 150;
 
 const REVEAL_TIMEOUT_MS = 2000;
@@ -100,11 +100,11 @@ export interface TourRootProps {
   /**
    * How the popover card travels between steps. `fade` (default) cross-fades it
    * at each target; `move` glides it smoothly from one target to the next. The
-   * spotlight always cross-fades regardless — it never slides. @default 'fade'
+   * spotlight always cross-fades regardless and never slides. @default 'fade'
    */
   transition?: TourTransition;
   /**
-   * Hide the dimmed overlay for the whole tour — only the popover is shown and
+   * Hide the dimmed overlay for the whole tour, so only the popover is shown and
    * the page stays fully interactive. Steps can override with
    * `step.disableOverlay`. @default false
    */
@@ -247,7 +247,7 @@ export function TourRoot({
     }
   }, [emit, setIndex, setOpen]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on open/index, not `step` — inline steps arrays give function targets a fresh identity each render.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on open/index, not `step`, since inline steps arrays give function targets a fresh identity each render.
   const target = useMemo(
     () => (open ? step?.target : undefined),
     [open, index]
@@ -379,7 +379,7 @@ export function TourRoot({
     emit({ type: 'step:active', index, step });
   }, [open, popoverOpen, index, step, emit]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on `index`, not `step` — the per-render `step` identity would re-fire this and fight the user's scroll.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on `index`, not `step`, since the per-render `step` identity would re-fire this and fight the user's scroll.
   useEffect(() => {
     if (!popoverOpen || !step || step.disableScroll) return;
     const el = resolveTourTarget(step.scrollTarget) ?? anchor;

--- a/packages/raystack/components/tour/tour.module.css
+++ b/packages/raystack/components/tour/tour.module.css
@@ -8,7 +8,7 @@
   pointer-events: none;
 }
 
-/* Before the first step reveals, the dim is transparent — its hit strips must
+/* Before the first step reveals, the dim is transparent, so its hit strips must
    not swallow clicks while the page is still usable. */
 .overlay[data-entered="false"] .overlayHit {
   pointer-events: none;
@@ -28,7 +28,7 @@
 }
 
 /* The dimming layer is this element's box-shadow; the element itself is the
-   transparent cutout over the target. It never transitions position — it is
+   transparent cutout over the target. It never transitions position; it is
    repositioned instantly while the cutout is covered (see .spotlightCover). */
 .spotlight {
   position: absolute;
@@ -40,7 +40,7 @@
    and reopen without the surrounding dim ever changing. Open step: transparent
    (clear hole); between steps: opaque (hole dimmed closed). The cutout is
    repositioned to the next target while this cover is opaque, so the move is
-   never seen — a soft fade both ways, never a slide. */
+   never seen: a soft fade both ways, never a slide. */
 .spotlightCover {
   position: absolute;
   pointer-events: none;
@@ -68,7 +68,7 @@
 }
 
 /* Glide between step targets in `move` mode only, and not while the popup is
-   mounting — otherwise the first open would animate in from the viewport
+   mounting, since otherwise the first open would animate in from the viewport
    origin. `fade` mode repositions the card while it is hidden, so no glide. */
 @media (prefers-reduced-motion: no-preference) {
   .positioner[data-transition="move"]:has(.popup:not([data-starting-style])) {

--- a/packages/raystack/components/tour/types.ts
+++ b/packages/raystack/components/tour/types.ts
@@ -18,7 +18,7 @@ export type TourAlign = 'start' | 'center' | 'end';
 /**
  * How the popover card travels between steps. The spotlight always cross-fades
  * (it never slides), regardless of this setting.
- * - `fade` (default): the card cross-fades at each target — it fades out, moves
+ * - `fade` (default): the card cross-fades at each target, so it fades out, moves
  *   while hidden, and fades in once the target is in view. Best for targets that
  *   are far apart or need scrolling, where a glide reads as jank.
  * - `move`: the card glides smoothly from the previous target to the next,
@@ -71,8 +71,8 @@ export interface TourStep {
 export type TourEndStatus = 'finished' | 'skipped' | 'closed';
 
 /**
- * `idle` — the tour is closed. `waiting` — the active step's target is not in
- * the DOM yet and the tour is observing for it to appear. `running` — the
+ * `idle` means the tour is closed. `waiting` means the active step's target is not in
+ * the DOM yet and the tour is observing for it to appear. `running` means the
  * target is resolved and the step is showing.
  */
 export type TourStatus = 'idle' | 'waiting' | 'running';

--- a/packages/raystack/figma/accordion.figma.ts
+++ b/packages/raystack/figma/accordion.figma.ts
@@ -4,7 +4,7 @@
 
 import figma from 'figma';
 
-// State (Collapsed/Hover/Expanded) is visual-only — the Accordion root exposes no
+// State (Collapsed/Hover/Expanded) is visual-only, and the Accordion root exposes no
 // matching prop, so it is not mapped. A composed example uses the public sub-component API.
 
 export default {

--- a/packages/raystack/figma/badge.figma.ts
+++ b/packages/raystack/figma/badge.figma.ts
@@ -16,7 +16,7 @@ const size = figma.selectedInstance.getEnum('Size', {
   Regular: 'regular'
 });
 // "Icon" BOOLEAN toggles the leading icon; resolve the child instance named "Icon"
-// when enabled (guarded — findInstance returns an ErrorHandle when absent).
+// when enabled (guarded, since findInstance returns an ErrorHandle when absent).
 const icon = figma.selectedInstance.getBoolean('Icon', {
   true: (function () {
     const i = figma.selectedInstance.findInstance('Icon');

--- a/packages/raystack/figma/breadcrumb-item.figma.ts
+++ b/packages/raystack/figma/breadcrumb-item.figma.ts
@@ -25,7 +25,7 @@ const dropdownItems = instance.getBoolean('Dropdown', {
   true: " dropdownItems={[{ children: 'Option 1' }, { children: 'Option 2' }]}",
   false: ''
 });
-// `Size` is owned by the Breadcrumb root, not the item — intentionally unmapped.
+// `Size` is owned by the Breadcrumb root, not the item, so it is intentionally unmapped.
 
 export default {
   id: 'Breadcrumb.Item',

--- a/packages/raystack/figma/calendar.figma.ts
+++ b/packages/raystack/figma/calendar.figma.ts
@@ -4,7 +4,7 @@
 
 import figma from 'figma';
 
-// Plain COMPONENT with no Figma properties — emit a simple example with
+// Plain COMPONENT with no Figma properties, so emit a simple example with
 // sensible defaults from the code API (`mode` defaults to 'single').
 
 export default {

--- a/packages/raystack/figma/callout.figma.ts
+++ b/packages/raystack/figma/callout.figma.ts
@@ -22,7 +22,7 @@ const highContrast = figma.selectedInstance.getEnum('High Contrast', {
   True: true
 });
 // children text, `dismissible` and `action` live on the nested ".callout_structure"
-// instance (guarded — findInstance returns an ErrorHandle when absent).
+// instance (guarded, since findInstance returns an ErrorHandle when absent).
 const structure = (function () {
   const nested = figma.selectedInstance.findInstance('.callout_structure');
   if (!nested || nested.type !== 'INSTANCE') {

--- a/packages/raystack/figma/chip.figma.ts
+++ b/packages/raystack/figma/chip.figma.ts
@@ -13,9 +13,9 @@ const size = figma.selectedInstance.getEnum('Size', {
 const color = figma.selectedInstance.getEnum('Style', {
   Accent: 'accent'
 });
-// State (Default/Hover/Active) is visual-only — no code counterpart, intentionally unmapped.
+// State (Default/Hover/Active) is visual-only, with no code counterpart, so it is intentionally unmapped.
 // children, dismiss and the leading/trailing icons live on the nested
-// ".chip_structure" instance (guarded — findInstance returns an ErrorHandle
+// ".chip_structure" instance (guarded, since findInstance returns an ErrorHandle
 // when absent).
 const structure = (function () {
   const nested = figma.selectedInstance.findInstance('.chip_structure');

--- a/packages/raystack/figma/color-picker.figma.ts
+++ b/packages/raystack/figma/color-picker.figma.ts
@@ -4,7 +4,7 @@
 
 import figma from 'figma';
 
-// Plain COMPONENT with no Figma properties — emit a minimal realistic example
+// Plain COMPONENT with no Figma properties, so emit a minimal realistic example
 // composed from the public sub-component API.
 
 export default {

--- a/packages/raystack/figma/command.figma.ts
+++ b/packages/raystack/figma/command.figma.ts
@@ -4,7 +4,7 @@
 
 import figma from 'figma';
 
-// Plain COMPONENT with no Figma properties — emit a minimal realistic example
+// Plain COMPONENT with no Figma properties, so emit a minimal realistic example
 // composed from the public sub-component API.
 
 export default {

--- a/packages/raystack/figma/dialog.figma.ts
+++ b/packages/raystack/figma/dialog.figma.ts
@@ -24,7 +24,7 @@ const footer = instance.getBoolean('Footer', {
   false: ''
 });
 
-// `content` is a SLOT — interpolate the nested sections, with a placeholder fallback.
+// `content` is a SLOT, so interpolate the nested sections, with a placeholder fallback.
 const content = instance.getSlot('content') ?? 'Dialog content';
 
 export default {

--- a/packages/raystack/figma/icon-button.figma.ts
+++ b/packages/raystack/figma/icon-button.figma.ts
@@ -9,7 +9,7 @@ const size = figma.selectedInstance.getEnum('Size', {
   '3': 3,
   '4': 4
 });
-// State Hover/Active are visual-only — only Disabled maps to a code prop.
+// State Hover/Active are visual-only, and only Disabled maps to a code prop.
 const disabled = figma.selectedInstance.getEnum('State', {
   Disabled: true
 });

--- a/packages/raystack/figma/input.figma.ts
+++ b/packages/raystack/figma/input.figma.ts
@@ -9,14 +9,14 @@ const findTextContent = (name: string) => {
   return t && t.type === 'TEXT' ? t.textContent : undefined;
 };
 
-// Variant Normal/Chips have no prefix/suffix code prop — only Prefix/Suffix map.
+// Variant Normal/Chips have no prefix/suffix code prop, and only Prefix/Suffix map.
 const prefix = figma.selectedInstance.getEnum('Variant', {
   Prefix: findTextContent('Prefix')
 });
 const suffix = figma.selectedInstance.getEnum('Variant', {
   Suffix: findTextContent('Suffix')
 });
-// State Hover/Active/Filled Active are visual-only — only Disabled maps.
+// State Hover/Active/Filled Active are visual-only, and only Disabled maps.
 const disabled = figma.selectedInstance.getEnum('State', {
   Disabled: true
 });
@@ -51,7 +51,7 @@ const description = figma.selectedInstance.getBoolean('Helper text', {
 });
 const optional = figma.selectedInstance.getBoolean('Optional');
 // "Leading Icon" BOOLEAN toggles the leading icon; resolve the child instance
-// named "Leading Icon" when enabled (guarded — ErrorHandle when absent).
+// named "Leading Icon" when enabled (guarded, since ErrorHandle is returned when absent).
 const leadingIcon = figma.selectedInstance.getBoolean('Leading Icon', {
   true: (function () {
     const i = figma.selectedInstance.findInstance('Leading Icon');

--- a/packages/raystack/figma/menu.figma.ts
+++ b/packages/raystack/figma/menu.figma.ts
@@ -28,7 +28,7 @@ const cells = instance
   .findConnectedInstances(node => node.name === 'dropdown cell', {
     traverseInstances: true
   })
-  // findConnectedInstances returns reverse document order — flip to top-to-bottom.
+  // findConnectedInstances returns reverse document order, so flip to top-to-bottom.
   .reverse()
   .flatMap(cell =>
     cell && cell.type === 'INSTANCE' ? cell.executeTemplate().example : []

--- a/packages/raystack/figma/meter.figma.ts
+++ b/packages/raystack/figma/meter.figma.ts
@@ -12,7 +12,7 @@ const variant = instance.getEnum('Variant', {
   Circular: 'circular'
 });
 
-// "Value" text layer (present in both variants) reads like "50%" — extract the
+// "Value" text layer (present in both variants) reads like "50%", so extract the
 // leading number so it can be passed as the numeric `value` prop.
 const valueText = instance.findText('Value');
 const valueMatch =

--- a/packages/raystack/figma/navbar.figma.ts
+++ b/packages/raystack/figma/navbar.figma.ts
@@ -4,7 +4,7 @@
 
 import figma from 'figma';
 
-// Navbar has no Figma component properties — compose a minimal realistic
+// Navbar has no Figma component properties, so compose a minimal realistic
 // example using the public sub-components (Start / Center / End).
 
 export default {

--- a/packages/raystack/figma/otp-field.figma.ts
+++ b/packages/raystack/figma/otp-field.figma.ts
@@ -12,8 +12,8 @@ const separator = instance.getBoolean('Seperator', {
   false: undefined
 });
 
-// State (Default / Active / Filled / Placeholder) is purely visual — no matching
-// code prop on OTPField — intentionally not mapped.
+// State (Default / Active / Filled / Placeholder) is purely visual, with no matching
+// code prop on OTPField, so it is intentionally not mapped.
 
 export default {
   id: 'OTPField',

--- a/packages/raystack/figma/preview-card.figma.ts
+++ b/packages/raystack/figma/preview-card.figma.ts
@@ -4,7 +4,7 @@
 
 import figma from 'figma';
 
-// PreviewCard has no Figma component properties — compose a minimal realistic
+// PreviewCard has no Figma component properties, so compose a minimal realistic
 // example using the public sub-components (Trigger / Content).
 
 export default {

--- a/packages/raystack/figma/progress.figma.ts
+++ b/packages/raystack/figma/progress.figma.ts
@@ -12,7 +12,7 @@ const variant = instance.getEnum('Variant', {
   Circular: 'circular'
 });
 
-// "Value" text layer (present in both variants) reads like "50%" — extract the
+// "Value" text layer (present in both variants) reads like "50%", so extract the
 // leading number so it can be passed as the numeric `value` prop.
 const valueText = instance.findText('Value');
 const valueMatch =

--- a/packages/raystack/figma/radio.figma.ts
+++ b/packages/raystack/figma/radio.figma.ts
@@ -4,7 +4,7 @@
 
 import figma from 'figma';
 
-// State Hover is visual-only — only Disabled maps to a code prop.
+// State Hover is visual-only, and only Disabled maps to a code prop.
 const disabled = figma.selectedInstance.getEnum('State', {
   Disabled: true
 });

--- a/packages/raystack/figma/scroll-area.figma.ts
+++ b/packages/raystack/figma/scroll-area.figma.ts
@@ -4,7 +4,7 @@
 
 import figma from 'figma';
 
-// State (Default / Hover) is purely visual (scrollbar visibility) — no matching
+// State (Default / Hover) is purely visual (scrollbar visibility), with no matching
 // code prop, intentionally not mapped. Compose a minimal example.
 
 export default {

--- a/packages/raystack/figma/search.figma.ts
+++ b/packages/raystack/figma/search.figma.ts
@@ -9,7 +9,7 @@ const findTextContent = (name: string) => {
   return t && t.type === 'TEXT' ? t.textContent : undefined;
 };
 
-// State Hover/Active are visual-only — only the filled states surface a typed value.
+// State Hover/Active are visual-only, and only the filled states surface a typed value.
 const placeholder = figma.selectedInstance.getEnum('State', {
   Default: findTextContent('Search...'),
   Active: findTextContent('Search...'),
@@ -19,7 +19,7 @@ const value = figma.selectedInstance.getEnum('State', {
   Filled: findTextContent('Search...'),
   Filled_Active: findTextContent('Search...')
 });
-// Search renders its own leading magnifying-glass icon — the Leading Icon
+// Search renders its own leading magnifying-glass icon, so the Leading Icon
 // boolean has no public prop, so it is intentionally not mapped.
 const size = figma.selectedInstance.getEnum('Size', {
   Small: 'small',

--- a/packages/raystack/figma/select.figma.ts
+++ b/packages/raystack/figma/select.figma.ts
@@ -22,7 +22,7 @@ const leadingIcon = instance.getBoolean('Icon', {
 });
 
 // Chevron / Avatar / Label BOOLEANs and Filled / Hover VARIANTs are visual-only
-// (the chevron is always rendered by Select.Trigger; Filled/Hover are states) —
+// (the chevron is always rendered by Select.Trigger; Filled/Hover are states),
 // no matching code props, intentionally not mapped.
 
 export default {

--- a/packages/raystack/figma/separator.figma.ts
+++ b/packages/raystack/figma/separator.figma.ts
@@ -5,7 +5,7 @@
 import figma from 'figma';
 
 // Figma "Divider" exposes only the `Outerspace` VARIANT (Small/None), which
-// controls the surrounding margin/spacing — there is no corresponding public
+// controls the surrounding margin/spacing, and there is no corresponding public
 // prop on the code Separator (its `size` controls line length, not spacing),
 // so no prop is emitted.
 

--- a/packages/raystack/figma/sidebar-group.figma.ts
+++ b/packages/raystack/figma/sidebar-group.figma.ts
@@ -18,9 +18,9 @@ const trailingIcon = instance.getBoolean('Trailing Icon', {
   false: undefined
 });
 
-// Label BOOLEAN — the code `label` prop is required; render placeholder text.
+// Label BOOLEAN. The code `label` prop is required; render placeholder text.
 // State (Default/Hover) and Type (Expanded/Collapsed) are visual / parent-driven
-// — no matching Sidebar.Group props, intentionally not mapped.
+// No matching Sidebar.Group props, so intentionally not mapped.
 
 export default {
   id: 'Sidebar.Group',

--- a/packages/raystack/figma/sidebar-item.figma.ts
+++ b/packages/raystack/figma/sidebar-item.figma.ts
@@ -19,11 +19,11 @@ const active = instance.getEnum('State', {
   Active_hover: true
 });
 
-// Label BOOLEAN — when false the cell shows no text; the code component always
+// Label BOOLEAN. When false the cell shows no text; the code component always
 // takes children, so we render placeholder label text below.
 // Trailing Icon BOOLEAN has no matching prop on Sidebar.Item, intentionally
 // not mapped. Type (Expanded/Collapsed) is driven by the parent Sidebar state,
-// not a Sidebar.Item prop — intentionally not mapped.
+// not a Sidebar.Item prop, so intentionally not mapped.
 
 export default {
   id: 'Sidebar.Item',

--- a/packages/raystack/figma/switch.figma.ts
+++ b/packages/raystack/figma/switch.figma.ts
@@ -4,7 +4,7 @@
 
 import figma from 'figma';
 
-// State is a VARIANT — Disabled maps to the `disabled` prop; Hover is
+// State is a VARIANT. Disabled maps to the `disabled` prop; Hover is
 // visual-only and intentionally unmapped (renderProp omits undefined).
 const disabled = figma.selectedInstance.getEnum('State', {
   Disabled: true

--- a/packages/raystack/figma/toast.figma.ts
+++ b/packages/raystack/figma/toast.figma.ts
@@ -4,7 +4,7 @@
 
 import figma from 'figma';
 
-// Toasts are created imperatively via toastManager.add(options) — there is no
+// Toasts are created imperatively via toastManager.add(options), so there is no
 // JSX toast element. We map the Figma properties onto the add() options shape.
 
 // Leading icon BOOLEAN gates the Icon INSTANCE_SWAP → `leadingIcon` option.

--- a/packages/raystack/figma/toolbar.figma.ts
+++ b/packages/raystack/figma/toolbar.figma.ts
@@ -14,7 +14,7 @@ const instance = figma.selectedInstance;
 //   forward the full button via the `render` prop.
 // - An uncoded instance whose layer name starts with "Line" → Toolbar.Separator.
 //   NOTE: raw Figma LINE/vector primitives are NOT exposed in `children` by the
-//   Code Connect API — only INSTANCE/TEXT children are. A divider only renders
+//   Code Connect API; only INSTANCE/TEXT children are. A divider only renders
 //   here if it is an instance (e.g. a Separator/Divider component).
 // - Any other child is passed through and rendered directly.
 const items = instance.children.flatMap(child => {
@@ -47,7 +47,7 @@ const items = instance.children.flatMap(child => {
     });
     const size = child.getEnum('Size', { Small: 'small', Normal: 'normal' });
     // "Plain" = the default Toolbar.Button render (text/neutral/small) with a
-    // label and no icons, disabled or loading state — i.e. nothing extra.
+    // label and no icons, disabled or loading state, meaning nothing extra.
     const isPlain =
       variant === 'text' &&
       color === 'neutral' &&

--- a/packages/raystack/icons/__tests__/bundle.test.ts
+++ b/packages/raystack/icons/__tests__/bundle.test.ts
@@ -9,9 +9,9 @@ import { describe, expect, it } from 'vitest';
  *
  * Per-key removal from a single module depends on the `/*#__PURE__*\/`
  * annotation on every `createIcon(…)` call, and on nothing in the module having
- * a side effect. It also fails on any aggregate icon map — a merged
+ * a side effect. It also fails on any aggregate icon map, whether a merged
  * `{ ...defaultIcons, ...overrides }` in `IconProvider`, or a runtime
- * `ICON_NAMES` array — because either puts all 31 icons in every bundle.
+ * `ICON_NAMES` array, because either puts all 31 icons in every bundle.
  */
 
 /** vitest runs with the package root as the cwd. */
@@ -27,7 +27,7 @@ const NOT_IMPORTED = [
   'ChevronDownIcon'
 ] as const;
 
-/** `createIcon('XIcon', X)` — quoted, so `XIcon` cannot match `ClearIcon`. */
+/** `createIcon('XIcon', X)`, quoted so `XIcon` cannot match `ClearIcon`. */
 const registration = (name: string) =>
   new RegExp(`createIcon\\(\\s*["']${name}["']`);
 

--- a/packages/raystack/icons/__tests__/create-icon.test.tsx
+++ b/packages/raystack/icons/__tests__/create-icon.test.tsx
@@ -78,9 +78,9 @@ describe('createIcon, for a key Apsara does not ship', () => {
 
     // `components` is typed to the keys Apsara ships, so naming a key it does
     // not ship is a type error, not a silent no-op. `tsc --noEmit` is what
-    // asserts this line — if the key ever became assignable, the unused
+    // asserts this line. If the key ever became assignable, the unused
     // `@ts-expect-error` would itself fail the type check.
-    // @ts-expect-error — RocketIcon is not one of Apsara's keys.
+    // @ts-expect-error RocketIcon is not one of Apsara's keys.
     const overrides: IconOverrides = { RocketIcon: Override };
 
     render(

--- a/packages/raystack/icons/create-icon.tsx
+++ b/packages/raystack/icons/create-icon.tsx
@@ -79,7 +79,7 @@ export function IconProvider({
   const stableProps = useStable(props);
 
   // Layer on the parent, so a nested provider changes only the keys it names
-  // and inherits the rest — the way `Scoped` layers theme tokens. Only supplied
+  // and inherits the rest, the way `Scoped` layers theme tokens. Only supplied
   // maps are merged, never the defaults, so an icon nobody overrides stays
   // absent from the context and removable by a bundler.
   const value = useMemo(
@@ -109,7 +109,7 @@ IconProvider.displayName = 'IconProvider';
  * ```
  *
  * `name` is any string. `IconName` covers the keys Apsara ships, so those are
- * the ones `<Theme icons>` can replace with types on your side — but every icon
+ * the ones `<Theme icons>` can replace with types on your side, but every icon
  * built here reads the same context, so its `props` reach yours too.
  *
  * Resolution: the override from the context, then `Default`.
@@ -125,7 +125,7 @@ export function createIcon(name: string, Default: IconComponent) {
     return (
       // `strokeWidth` counts units of the icon's own viewBox, and lucide draws
       // in a 24-unit box, so the rendered stroke is `strokeWidth * width / 24`.
-      // The design draws a 1px stroke in a 16px frame, which is 1.5 here — not
+      // The design draws a 1px stroke in a 16px frame, which is 1.5 here, not
       // 1, which would render a 0.67px stroke.
       <Resolved
         width={16}

--- a/packages/raystack/icons/icons.tsx
+++ b/packages/raystack/icons/icons.tsx
@@ -5,7 +5,7 @@
 // changing icon library is an edit to this file and nothing else.
 //
 // Keep the `/*#__PURE__*/` annotation on every call. It is what lets a bundler
-// drop an unused key — and its lucide import — out of this single module;
+// drop an unused key, and its lucide import, out of this single module;
 // `icons/__tests__/bundle.test.ts` checks that it still does.
 
 import {
@@ -67,7 +67,7 @@ export const ChevronRightIcon = /*#__PURE__*/ createIcon(
 );
 /** Clears an input. Shares a drawing with `ErrorIcon`, not a key. */
 export const ClearIcon = /*#__PURE__*/ createIcon('ClearIcon', CircleX);
-/** Marks an AI affordance — the ChatPanel trigger draws it. */
+/** Marks an AI affordance. The ChatPanel trigger draws it. */
 export const CoPilotIcon = /*#__PURE__*/ createIcon('CoPilotIcon', Sparkles);
 export const CopyIcon = /*#__PURE__*/ createIcon('CopyIcon', Copy);
 export const DisplayIcon = /*#__PURE__*/ createIcon(

--- a/packages/raystack/icons/index.tsx
+++ b/packages/raystack/icons/index.tsx
@@ -11,7 +11,7 @@
 // Both rollup configs write to dist/icons/, so both emit dist/icons/create-icon.js
 // and the later build (./icons) overwrites the earlier one (the root). Rollup
 // tree-shakes each build against its own entry point, so anything this barrel
-// does not reach is dropped from the shared output file — an export missing here
+// does not reach is dropped from the shared output file, so an export missing here
 // is missing from the published package, however the root barrel exports it.
 export {
   createIcon,

--- a/packages/raystack/icons/types.ts
+++ b/packages/raystack/icons/types.ts
@@ -2,8 +2,8 @@
 // nothing to any bundle. The union is read straight off the exports of
 // `icons.tsx`, so it cannot drift from them.
 //
-// The cycle with `icons.tsx` — which imports `create-icon.tsx`, which imports
-// this file — exists only in the type graph, where it is legal. At runtime the
+// The cycle with `icons.tsx`, which imports `create-icon.tsx`, which imports
+// this file, exists only in the type graph, where it is legal. At runtime the
 // graph is `icons.tsx -> create-icon.tsx` and stops there.
 import type * as icons from './icons';
 

--- a/packages/raystack/styles/effects.css
+++ b/packages/raystack/styles/effects.css
@@ -50,7 +50,7 @@
   --rs-focus-ring-shadow: 0 0 0 1px var(--rs-color-border-accent-emphasis);
 
   /* Ring offset: rings sit flush (0) by default. A control adds one of these
-       in its own :focus-visible rule when it needs to — accent-filled controls
+       in its own :focus-visible rule when it needs to, since accent-filled controls
        push the ring out so it clears the same-colour fill; controls in a
        clipped container pull it in so the ring isn't cut off. The -border
        variant pulls in just 1px so the ring hugs a bordered control instead

--- a/packages/raystack/styles/global.css
+++ b/packages/raystack/styles/global.css
@@ -1,4 +1,4 @@
-/* Global native scrollbar styling — uses the Baseline standard scrollbar
+/* Global native scrollbar styling. Uses the Baseline standard scrollbar
    properties (scrollbar-width / scrollbar-color), supported across Chrome,
    Safari and Firefox. Note: scrollbar-width is keyword-only (no exact px) and
    setting scrollbar-color opts out of the macOS overlay/auto-hide scrollbar.

--- a/packages/raystack/styles/primitives/appearance.css
+++ b/packages/raystack/styles/primitives/appearance.css
@@ -4,7 +4,7 @@
  * All variables must be used from colors.css file only.
  */
 
-/* Smooth theme switch transition — applies regardless of which theme is active */
+/* Smooth theme switch transition. Applies regardless of which theme is active */
 [data-theme="light"],
 [data-theme="dark"] {
   transition:

--- a/packages/raystack/styles/typography.css
+++ b/packages/raystack/styles/typography.css
@@ -35,7 +35,7 @@
   --rs-line-height-regular: 20px;
   --rs-line-height-large: 24px;
 
-  /* Body Letter spacing — tuned for Inter, which is spaced generously already.
+  /* Body letter spacing, tuned for Inter, which is spaced generously already.
      Near-zero at small sizes, slightly negative as size grows. em-based so it
      scales with font-size. */
   --rs-letter-spacing-micro: 0.01em;

--- a/packages/raystack/test-utils/data-slots.ts
+++ b/packages/raystack/test-utils/data-slots.ts
@@ -3,7 +3,7 @@ import { expect } from 'vitest';
 /**
  * Helpers for asserting the `data-slot` contract: every element a component
  * renders carries a stable, kebab-case, component-prefixed `data-slot`
- * identifier (e.g. `filter-chip-remove`). Slot names are public API — tests
+ * identifier (e.g. `filter-chip-remove`). Slot names are public API, so tests
  * use these helpers so a rename fails loudly.
  */
 


### PR DESCRIPTION
A punctuation and phrasing pass over the docs site and the library's source comments.

## What changed

886 em dashes across 228 files are replaced with plainer punctuation. Each one got the mark it was standing in for rather than a single blanket substitute:

- a colon for definition lists and list introductions
- a period where it joined two independent clauses
- commas, or parentheses, for a parenthetical aside
- a real conjunction where the two halves needed one

| Before | After |
|---|---|
| `` `--rs-space-5` — 16px spacing `` | `` `--rs-space-5`: 16px spacing `` |
| `**Accessibility first** — Every component…` | `**Accessibility first.** Every component…` |
| `a no-op pass-through — children render…` | `a no-op pass-through. Children render…` |
| `the Today button — wired through actionsRef — to jump back` | `the Today button, wired through actionsRef, to jump back` |

One phrase, `to own the state — needed when…`, appeared 12 times across the component docs and now reads `to own the state. Do this when…` everywhere.

Nine frontmatter descriptions are rephrased rather than re-punctuated. A `:` inside an unquoted YAML scalar reads as a nested mapping, so those took a period or a conjunction instead.

## Scope

Every occurrence inside `packages/raystack` was a comment or JSDoc block, so no string literal, prop, or rendered output changed. The only non-comment edits are two `console.warn` messages and two test names, and no test asserts on text spanning a dash.

Left in place on purpose:

- `CHANGELOG.md`, a historical record of shipped releases
- the root `README`, `CONTRIBUTING`, `DEVELOPMENT` and `agents.md`
- the eight "no value" placeholders in the timeline stress-test stats table, where an em dash is standard table typography

## Verification

- `pnpm test:apsara` — 2,707 passed, 1 skipped
- `npm run build:apsara` — succeeds
- `next build` in `apps/www` — all 187 pages generate, covering every docs route
- Biome — 4 errors and 61 warnings, identical to `main`; none in files this PR touches

Every changed file was checked to contain only punctuation edits: each removed line held a dash, and added and removed line counts match at 838 each.
